### PR TITLE
feat: add Claude plugin marketplace manifest and docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "claude-lark-plugin",
+  "description": "Chat with Claude Code in real time through Feishu (Lark) with pluggable memory backends",
+  "owner": {
+    "name": "IS908",
+    "email": "kunchen@pku.edu.cn"
+  },
+  "plugins": [
+    {
+      "name": "lark",
+      "source": "./",
+      "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "lark",
+  "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
+  "version": "0.1.0",
+  "author": {
+    "name": "IS908"
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Claude Lark Plugin is an MCP (Model Context Protocol) channel plugin that connects Claude Code to Feishu/Lark via WebSocket. It receives messages from Feishu users, enriches them with memory context, and forwards them to Claude Code. Responses flow back through the Feishu IM API.
+
+## Commands
+
+```bash
+npm start              # Run with tsx (development)
+npm run build          # Compile TypeScript to dist/
+npm run typecheck      # Type-check without emitting
+bash scripts/start.sh  # Production launcher (loads lark-cli skills)
+npm start -- --dry-run # Validate config and module loading without connecting
+```
+
+## Architecture
+
+```
+src/index.ts        – Entry point: wires MCP server, LarkChannel, memory, and buffer together
+src/config.ts       – Loads config from ~/.claude/channels/lark/.env (dotenv)
+src/channel.ts      – LarkChannel: Feishu WebSocket client, message parsing, memory enrichment pipeline
+src/tools.ts        – Registers 6 MCP tools: reply, edit_message, react, download_attachment, save_memory, save_skill
+src/queue.ts        – Per-chat sequential message queue
+src/memory/
+  interface.ts      – MemoryProvider interface (Episodes, Profiles, Skills)
+  factory.ts        – Provider factory (file | openviking | mem0)
+  file.ts           – File-based provider (default, stores in ~/.claude/channels/lark/memories/)
+  openviking.ts     – OpenViking vector search provider (stub)
+  mem0.ts           – mem0 managed memory provider (stub)
+  buffer.ts         – In-memory ring buffer with auto-flush on inactivity
+  distiller.ts      – Builds flush prompts to distill buffer into episodic memory
+```
+
+**Data flow:** Feishu event → `LarkChannel.handleMessageEvent` → whitelist check → text extraction → enqueue per-chat → record in buffer → enrich with memory (profile + episodes + skills) → forward via MCP logging message → Claude calls `reply` tool → response sent back to Feishu.
+
+## Key Design Decisions
+
+- **ESM-only**: `"type": "module"` in package.json; all imports use `.js` extensions.
+- **Stdio transport**: MCP server communicates via stdin/stdout; all debug logging goes to `console.error`.
+- **Single-instance lock**: PID-based lock file in `/tmp/` prevents duplicate WebSocket connections.
+- **Config location**: All user config lives at `~/.claude/channels/lark/.env`, not in the repo.
+- **Memory is pluggable**: `MemoryProvider` interface with three backends; only `file` is fully implemented (openviking/mem0 are stubs).
+
+## Configuration
+
+Required env vars: `LARK_APP_ID`, `LARK_APP_SECRET` (in `~/.claude/channels/lark/.env`).
+
+The `/lark:configure` skill (in `skills/configure/SKILL.md`) provides interactive setup within Claude Code.


### PR DESCRIPTION
## Changes

- **`.claude-plugin/marketplace.json`**: Add plugin marketplace manifest for Claude Lark Plugin, listing metadata and plugin configuration
- **`.claude-plugin/plugin.json`**: Add plugin definition with version 0.1.0 and description for Feishu/Lark channel integration
- **`CLAUDE.md`**: Add comprehensive guidance for Claude Code, including:
  - Project overview of the MCP channel plugin architecture
  - npm commands for development and production
  - Detailed architecture diagram with module descriptions
  - Data flow explanation from Feishu events to Claude responses
  - Key design decisions (ESM-only, stdio transport, config location)
  - Configuration requirements and setup instructions

These files enable the plugin to be discoverable and provide context for Claude Code when working with the repository.