### PR TITLE
fix: correct MCP channel protocol for message delivery

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "IS908"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@larksuiteoapi/node-sdk": "^1.39.0",
+        "@larksuiteoapi/node-sdk": "^1.60.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "dotenv": "^16.4.7",
         "zod": "^3.25.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with pluggable memory",
   "type": "module",
   "main": "src/index.ts",
@@ -11,15 +11,15 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@larksuiteoapi/node-sdk": "^1.39.0",
+    "@larksuiteoapi/node-sdk": "^1.60.0",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "dotenv": "^16.4.7",
     "zod": "^3.25.0"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0",
-    "@types/node": "^22.0.0"
+    "typescript": "^5.7.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,9 +48,14 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '0.2.0' },
+    { name: 'claude-lark-plugin', version: '0.2.1' },
     {
-      capabilities: { logging: {} },
+      capabilities: {
+        logging: {},
+        experimental: {
+          'claude/channel': {},
+        },
+      },
       instructions:
         'You are connected to Feishu (Lark) via this plugin. Users send messages through Feishu and you respond using the reply tool. You can also edit messages, add emoji reactions, download attachments, and save memories for cross-session recall.',
     }
@@ -97,22 +102,29 @@ async function main() {
     // In the channel plugin model, Claude Code reads messages from the MCP server
     // and calls tools to respond. The message is made available via server notification.
     try {
-      await server.server.sendLoggingMessage({
-        level: 'info',
-        logger: 'lark-channel',
-        data: {
-          type: 'incoming_message',
-          chatId: message.chatId,
-          senderId: message.senderId,
-          text: message.text,
-          messageId: message.messageId,
-          chatType: message.chatType,
-          parentContent: message.parentContent,
-          attachments: message.attachments,
+      await server.server.notification({
+        method: 'notifications/claude/channel',
+        params: {
+          content: message.text,
+          meta: {
+            chat_id: message.chatId,
+            message_id: message.messageId,
+            user: message.senderId,
+            chat_type: message.chatType,
+            ts: new Date().toISOString(),
+            ...(message.parentContent ? { parent_content: message.parentContent } : {}),
+            ...(message.attachments?.length
+              ? {
+                  attachment_file_id: message.attachments[0].fileKey,
+                  attachment_name: message.attachments[0].fileName,
+                  attachment_kind: message.attachments[0].fileType,
+                }
+              : {}),
+          },
         },
       });
     } catch (err) {
-      console.error('[channel] Failed to send logging message:', err);
+      console.error('[channel] Failed to deliver inbound to Claude:', err);
     }
   });
 


### PR DESCRIPTION
## Summary
- Replace `sendLoggingMessage()` with `notifications/claude/channel` — the actual protocol Claude Code uses for channel plugins
- Declare `claude/channel` experimental capability so Claude Code recognizes this as a channel plugin
- Bump version to 0.2.1
- Update `@larksuiteoapi/node-sdk` to ^1.60.0

## Root Cause
Messages from Feishu were being sent via `sendLoggingMessage()`, which is only for debug output. Claude Code ignores these for message display. The correct mechanism is `server.server.notification({ method: 'notifications/claude/channel' })` with `content` and `meta` params — matching the protocol used by the Telegram channel plugin.

## Test plan
- [ ] Send a DM to the Feishu bot → message appears in Claude Code terminal
- [ ] Claude calls `reply` tool → message delivered back to Feishu
- [ ] `npm start -- --dry-run` passes without errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)