### PR TITLE
feat: improve reply threading, error messages, and display names

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "IS908"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with pluggable memory",
   "type": "module",
   "main": "src/index.ts",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -9,6 +9,8 @@ export interface LarkMessage {
   chatId: string;
   chatType: string; // 'p2p' | 'group'
   senderId: string;
+  senderName?: string;
+  chatName?: string;
   text: string;
   messageType: string;
   parentId?: string;
@@ -23,6 +25,7 @@ type MessageHandler = (message: LarkMessage) => Promise<void>;
 
 export class LarkChannel {
   private client: Lark.Client;
+  private nameCache = new Map<string, string>(); // open_id/chat_id → display name
   private wsClient: Lark.WSClient | null = null;
   private queue = new MessageQueue();
   private messageHandler: MessageHandler | null = null;
@@ -30,11 +33,20 @@ export class LarkChannel {
   private conversationBuffer: ConversationBuffer | null = null;
 
   constructor() {
+    // Custom logger to redirect all SDK output to stderr (stdout is reserved for MCP JSON-RPC)
+    const sdkLogger = {
+      info: (...args: any[]) => console.error('[lark-sdk]', ...args),
+      warn: (...args: any[]) => console.error('[lark-sdk][warn]', ...args),
+      error: (...args: any[]) => console.error('[lark-sdk][error]', ...args),
+      debug: (...args: any[]) => console.error('[lark-sdk][debug]', ...args),
+      trace: (...args: any[]) => console.error('[lark-sdk][trace]', ...args),
+    };
     this.client = new Lark.Client({
       appId: appConfig.appId,
       appSecret: appConfig.appSecret,
       appType: Lark.AppType.SelfBuild,
       domain: Lark.Domain.Feishu,
+      logger: sdkLogger,
     });
   }
 
@@ -69,6 +81,13 @@ export class LarkChannel {
       appId: appConfig.appId,
       appSecret: appConfig.appSecret,
       loggerLevel: Lark.LoggerLevel.info,
+      logger: {
+        info: (...args: any[]) => console.error('[lark-ws]', ...args),
+        warn: (...args: any[]) => console.error('[lark-ws][warn]', ...args),
+        error: (...args: any[]) => console.error('[lark-ws][error]', ...args),
+        debug: (...args: any[]) => console.error('[lark-ws][debug]', ...args),
+        trace: (...args: any[]) => console.error('[lark-ws][trace]', ...args),
+      },
     });
 
     this.wsClient.start({ eventDispatcher });
@@ -89,6 +108,9 @@ export class LarkChannel {
     } = message;
 
     const senderId = sender?.sender_id?.open_id ?? '';
+
+    // Resolve sender display name (from event data or cache)
+    const senderName = await this.resolveUserName(senderId, sender);
 
     // Whitelist filtering
     if (appConfig.allowedUserIds.length > 0 && !appConfig.allowedUserIds.includes(senderId)) {
@@ -124,12 +146,17 @@ export class LarkChannel {
     // Parse attachments
     const attachments = this.extractAttachments(message);
 
+    // Resolve chat name for group chats
+    const chatName = chatType === 'group' ? await this.resolveChatName(chatId) : '';
+
     // Build message object
     const larkMessage: LarkMessage = {
       messageId,
       chatId,
       chatType,
       senderId,
+      senderName: senderName || undefined,
+      chatName: chatName || undefined,
       text,
       messageType,
       parentId,
@@ -234,6 +261,70 @@ export class LarkChannel {
       : '';
 
     return `[Memory Context]\n${memoryContext}\n${parentContext}\n[Current Message]\nFrom: ${msg.senderId} in ${msg.chatId}\n${msg.text}`;
+  }
+
+  /**
+   * Resolve a user's display name. Tries event data first, then API, then cache.
+   * Falls back to a truncated open_id if all else fails.
+   */
+  private async resolveUserName(openId: string, sender?: any): Promise<string> {
+    if (!openId) return '';
+
+    // Check cache
+    const cached = this.nameCache.get(openId);
+    if (cached) return cached;
+
+    // Try event sender data (some SDK versions include name)
+    const eventName = sender?.sender_id?.name || sender?.tenant_key;
+    if (eventName) {
+      this.nameCache.set(openId, eventName);
+      return eventName;
+    }
+
+    // Try contact API (requires contact:contact.base:readonly permission)
+    try {
+      const resp = await this.client.contact.v3.user.get({
+        path: { user_id: openId },
+        params: { user_id_type: 'open_id' },
+      });
+      const name = (resp?.data as any)?.user?.name;
+      if (name) {
+        this.nameCache.set(openId, name);
+        return name;
+      }
+    } catch {
+      // Permission not granted or API failed; fall through
+    }
+
+    // Fallback: truncated open_id
+    const short = openId.length > 12 ? openId.slice(0, 6) + '..' + openId.slice(-4) : openId;
+    this.nameCache.set(openId, short);
+    return short;
+  }
+
+  /**
+   * Resolve a chat's display name. Caches the result.
+   */
+  private async resolveChatName(chatId: string): Promise<string> {
+    if (!chatId) return '';
+
+    const cached = this.nameCache.get(chatId);
+    if (cached) return cached;
+
+    try {
+      const resp = await this.client.im.v1.chat.get({
+        path: { chat_id: chatId },
+      });
+      const name = (resp?.data as any)?.name;
+      if (name) {
+        this.nameCache.set(chatId, name);
+        return name;
+      }
+    } catch {
+      // Chat name fetch failed; continue without it
+    }
+
+    return '';
   }
 
   private extractText(rawContent: string, messageType: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '0.2.1' },
+    { name: 'claude-lark-plugin', version: '0.2.2' },
     {
       capabilities: {
         logging: {},
@@ -56,8 +56,13 @@ async function main() {
           'claude/channel': {},
         },
       },
-      instructions:
-        'You are connected to Feishu (Lark) via this plugin. Users send messages through Feishu and you respond using the reply tool. You can also edit messages, add emoji reactions, download attachments, and save memories for cross-session recall.',
+      instructions: [
+        'You are connected to Feishu (Lark) via this plugin. Users send messages through Feishu and you respond using the reply tool.',
+        '',
+        'Messages from Feishu arrive as <channel source="lark" chat_id="..." message_id="..." user="..." ts="...">. Always pass reply_to=message_id when calling the reply tool so your response is threaded under the original message in Feishu.',
+        '',
+        'You can also edit messages, add emoji reactions, download attachments, and save memories for cross-session recall.',
+      ].join('\n'),
     }
   );
 
@@ -92,15 +97,15 @@ async function main() {
 
   // 6. Set message handler — forwards Feishu messages to Claude via MCP
   channel.setMessageHandler(async (message) => {
-    // Log the incoming message for debugging
-    console.error(
-      `[channel] Message from ${message.senderId} in ${message.chatId}: ${message.text.slice(0, 100)}...`
-    );
+    // Build friendly display name: {chat_type}:{user_name}:{chat_name}:{thread_id}
+    const displayUser = message.senderName || message.senderId;
+    const displayParts = [message.chatType, displayUser];
+    if (message.chatName) displayParts.push(message.chatName);
+    if (message.threadId) displayParts.push(message.threadId);
+    const displayLabel = displayParts.join(':');
 
-    // Record assistant responses in buffer when Claude replies
-    // (The actual forwarding to Claude happens via the MCP server's tool calls)
-    // In the channel plugin model, Claude Code reads messages from the MCP server
-    // and calls tools to respond. The message is made available via server notification.
+    console.error(`[channel] ${displayLabel}: ${message.text.slice(0, 100)}...`);
+
     try {
       await server.server.notification({
         method: 'notifications/claude/channel',
@@ -109,8 +114,11 @@ async function main() {
           meta: {
             chat_id: message.chatId,
             message_id: message.messageId,
-            user: message.senderId,
+            user: displayUser,
+            user_id: message.senderId,
             chat_type: message.chatType,
+            ...(message.chatName ? { chat_name: message.chatName } : {}),
+            ...(message.threadId ? { thread_id: message.threadId } : {}),
             ts: new Date().toISOString(),
             ...(message.parentContent ? { parent_content: message.parentContent } : {}),
             ...(message.attachments?.length

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -41,24 +41,34 @@ export function registerTools(
       const chunks = chunkText(text, appConfig.textChunkLimit);
 
       for (let i = 0; i < chunks.length; i++) {
-        if (reply_to && i === 0) {
-          // First chunk as a quoted reply
-          await client.im.v1.message.reply({
-            path: { message_id: reply_to },
-            data: {
-              content: JSON.stringify({ text: chunks[i] }),
-              msg_type: 'text',
-            },
-          });
-        } else {
-          await client.im.v1.message.create({
-            params: { receive_id_type: 'chat_id' },
-            data: {
-              receive_id: chat_id,
-              content: JSON.stringify({ text: chunks[i] }),
-              msg_type: 'text',
-            },
-          });
+        try {
+          if (reply_to && i === 0) {
+            // First chunk as a quoted reply
+            await client.im.v1.message.reply({
+              path: { message_id: reply_to },
+              data: {
+                content: JSON.stringify({ text: chunks[i] }),
+                msg_type: 'text',
+              },
+            });
+          } else {
+            await client.im.v1.message.create({
+              params: { receive_id_type: 'chat_id' },
+              data: {
+                receive_id: chat_id,
+                content: JSON.stringify({ text: chunks[i] }),
+                msg_type: 'text',
+              },
+            });
+          }
+        } catch (err: any) {
+          const apiError = err?.response?.data ?? err?.data;
+          if (apiError?.code && apiError?.msg) {
+            console.error(`[tools] Feishu API error [${apiError.code}]: ${apiError.msg}`);
+            throw new Error(`Feishu API [${apiError.code}]: ${apiError.msg}`);
+          }
+          console.error(`[tools] send message failed:`, err?.message ?? String(err));
+          throw err;
         }
       }
 
@@ -124,7 +134,7 @@ export function registerTools(
       });
 
       return {
-        content: [{ type: 'text' as const, text: `Sent ${chunks.length} message(s) to ${chat_id}` }],
+        content: [{ type: 'text' as const, text: `Sent ${chunks.length} message(s)` }],
       };
     }
   );


### PR DESCRIPTION
## Summary
- Instruct Claude to always use `reply_to=message_id` so responses are threaded under the original Feishu message
- Surface actual Feishu API error codes (e.g. permission denied) instead of generic "status code 400"
- Resolve sender and chat names for friendly terminal display (`p2p:张三` / `group:张三:项目群`)
- Redirect Lark SDK logger to stderr to prevent MCP stdio corruption
- Bump version to 0.2.2

## Before / After
```
# Before
plugin:lark:lark · ou_b57ec84de95916331e32a7490e4338bc: hi
⎿ Sent 1 message(s) to oc_b0fab7ae2c0be4b71bebe2a8a2fbf208

# After
plugin:lark:lark · p2p:张三: hi
⎿ Sent 1 message(s)
```

## Test plan
- [x] Send a DM → reply is threaded under original message in Feishu
- [ ] Send in a group chat → display shows `group:username:groupname`
- [ ] Revoke `im:message:send_as_bot` → error shows Feishu error code instead of generic 400
- [ ] `npm start -- --dry-run` → stdout is empty, no SDK log pollution

🤖 Generated with [Claude Code](https://claude.ai/claude-code)