### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "author": {
     "name": "IS908"
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,20 @@ src/memory/
 Required env vars: `LARK_APP_ID`, `LARK_APP_SECRET` (in `~/.claude/channels/lark/.env`).
 
 The `/lark:configure` skill (in `skills/configure/SKILL.md`) provides interactive setup within Claude Code.
+
+## Important Conventions
+
+- **Stdout is sacred**: MCP uses stdio for JSON-RPC. All logging must go to `console.error`, never `console.log`. The Lark SDK uses custom loggers to redirect to stderr.
+- **`.mcp.json` must use `--silent`**: Prevents npm script lifecycle output from corrupting MCP transport.
+- **Channel protocol**: Messages are forwarded to Claude via `notifications/claude/channel` (not `sendLoggingMessage`). Requires `experimental: { 'claude/channel': {} }` capability.
+- **User display names**: Resolved via contact API → cached. Falls back to stable aliases (`user_` + last 7 chars of open_id). Memory keys always use raw open_id/chat_id.
+- **Group chat filtering**: Only messages with @mentions are processed. P2P messages are always processed.
+
+## Debugging
+
+Debug logs are written to `~/.claude/channels/lark/debug.log`. Contains raw event data (sender, mentions, chatType) for diagnosing message flow issues.
+
+Plugin code runs from three locations — all must stay in sync during development:
+- `workspace` (source of truth)
+- `~/.claude/plugins/marketplaces/claude-lark-plugin/` (marketplace clone)
+- `~/.claude/plugins/cache/claude-lark-plugin/lark/<version>/` (Claude Code runtime cache)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with pluggable memory",
   "type": "module",
   "main": "src/index.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '0.2.2' },
+    { name: 'claude-lark-plugin', version: '0.3.0' },
     {
       capabilities: {
         logging: {},
@@ -119,7 +119,6 @@ async function main() {
             chat_id: message.chatId,
             message_id: message.messageId,
             user: displayLabel,
-            user_id: message.senderId,
             user_id: message.senderId,
             chat_type: message.chatType,
             ...(message.chatName ? { chat_name: message.chatName } : {}),


### PR DESCRIPTION
## Summary
- Bump version from 0.2.2 to 0.3.0
- Fix duplicate `user_id` key in notification meta
- Update CLAUDE.md with conventions (stdout, channel protocol, display names) and debugging notes

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] No stale version references

🤖 Generated with [Claude Code](https://claude.ai/claude-code)