### PR TITLE
feat: OpenViking memory adapter v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with pluggable memory",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -15,9 +15,29 @@ fi
 # Default skills to load alongside the plugin
 LARK_ENABLED_SKILLS="${LARK_ENABLED_SKILLS:-lark-im,lark-contact,lark-doc,lark-calendar,lark-task}"
 
-echo "Starting claude-lark-plugin..."
-echo "  App ID: ${LARK_APP_ID:-<not set>}"
-echo "  Memory: ${MEMORY_PROVIDER:-file}"
-echo "  Skills: ${LARK_ENABLED_SKILLS}"
+# ── Skill filtering: manage symlinks in ~/.claude/skills/ ──
+SKILLS_DIR="${HOME}/.claude/skills"
+mkdir -p "$SKILLS_DIR"
+
+# Remove existing lark-* symlinks (stale from previous runs)
+find "$SKILLS_DIR" -maxdepth 1 -name 'lark-*' -type l -delete 2>/dev/null || true
+
+# Create symlinks for enabled skills only
+IFS=',' read -ra SKILLS <<< "$LARK_ENABLED_SKILLS"
+for skill in "${SKILLS[@]}"; do
+  skill=$(echo "$skill" | xargs)  # trim whitespace
+  [ -z "$skill" ] && continue
+  # Search for the skill directory in known locations
+  src=$(find "${HOME}/.claude" -path "*/larksuite/cli/skills/${skill}" -type d 2>/dev/null | head -1)
+  if [ -n "$src" ]; then
+    ln -sf "$src" "$SKILLS_DIR/$skill"
+    echo >&2 "  Loaded skill: $skill"
+  fi
+done
+
+echo >&2 "Starting claude-lark-plugin..."
+echo >&2 "  App ID: ${LARK_APP_ID:-<not set>}"
+echo >&2 "  Memory: ${MEMORY_PROVIDER:-file}"
+echo >&2 "  Skills: ${LARK_ENABLED_SKILLS}"
 
 exec claude --dangerously-load-development-channels "plugin:lark@claude-lark-plugin"

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -236,13 +236,23 @@ export class LarkChannel {
 
     const parts: string[] = [];
 
-    // 1. User profile (hot injection)
+    // Build search query — enhance short messages with recent buffer context
+    let searchQuery = msg.text;
+    if (msg.text.length < 15 && this.conversationBuffer) {
+      const recent = this.conversationBuffer.getMessages(msg.chatId).slice(-3);
+      const context = recent.map(m => m.text).join(' ');
+      if (context.length > 0) {
+        searchQuery = `${context} ${msg.text}`;
+      }
+    }
+
+    // 1. User profile (hot injection — always loaded)
     const profile = await this.memoryProvider.getProfile(msg.senderId).catch(() => null);
     if (profile) {
       parts.push(`[User Profile]\n${profile}`);
     }
 
-    // 2. Mentioned user profiles
+    // 2. Mentioned user profiles (hot injection)
     if (msg.mentions?.length) {
       for (const mention of msg.mentions) {
         if (mention.id && mention.id !== msg.senderId) {
@@ -254,28 +264,37 @@ export class LarkChannel {
       }
     }
 
-    // 3. Thread episodes (if in a thread)
+    // 3. Thread episodes (cold injection — semantic search with score filtering)
     if (msg.threadId) {
       const threadEps = await this.memoryProvider
-        .searchEpisodes(msg.text, { chatId: msg.chatId, threadId: msg.threadId })
+        .searchEpisodes(searchQuery, { chatId: msg.chatId, threadId: msg.threadId })
         .catch(() => []);
-      for (const ep of threadEps) {
-        parts.push(`[Thread Context ${ep.timestamp}]\n${ep.content}`);
+      const filtered = threadEps.filter(ep => ep.score === undefined || ep.score >= appConfig.minSearchScore);
+      for (const ep of filtered) {
+        const scoreTag = ep.score !== undefined ? ` · score:${ep.score.toFixed(2)}` : '';
+        const dateTag = ep.timestamp.slice(0, 10);
+        parts.push(`[Thread Context${scoreTag} · ${dateTag}]\n${ep.content}`);
       }
     }
 
-    // 4. Chat episodes (cold injection)
+    // 4. Chat episodes (cold injection — semantic search with score filtering)
     const chatEps = await this.memoryProvider
-      .searchEpisodes(msg.text, { chatId: msg.chatId })
+      .searchEpisodes(searchQuery, { chatId: msg.chatId })
       .catch(() => []);
-    for (const ep of chatEps) {
-      parts.push(`[Past Context ${ep.timestamp}]\n${ep.content}`);
+    const filteredChat = chatEps.filter(ep => ep.score === undefined || ep.score >= appConfig.minSearchScore);
+    for (const ep of filteredChat) {
+      const scoreTag = ep.score !== undefined ? ` · score:${ep.score.toFixed(2)}` : '';
+      const dateTag = ep.timestamp.slice(0, 10);
+      parts.push(`[Chat Context${scoreTag} · ${dateTag}]\n${ep.content}`);
     }
 
-    // 5. Skills (cold injection, if relevant)
-    const skills = await this.memoryProvider.searchSkills(msg.text).catch(() => []);
-    for (const skill of skills) {
-      parts.push(`[Skill: ${skill.name}]\n${skill.content}`);
+    // 5. Skills (cold injection — inject name + description + path only, not full content)
+    const skills = await this.memoryProvider.searchSkills(searchQuery).catch(() => []);
+    const filteredSkills = skills.filter(s => s.score === undefined || s.score >= appConfig.minSearchScore);
+    for (const skill of filteredSkills) {
+      const scoreTag = skill.score !== undefined ? ` · score:${skill.score.toFixed(2)}` : '';
+      const skillPath = `${appConfig.memoriesDir}/skills/${skill.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}.md`;
+      parts.push(`[Skill: ${skill.name}${scoreTag}]\n${skill.description}\n→ ${skillPath}`);
     }
 
     // Assemble

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,11 +44,11 @@ async function main() {
   const isDryRun = process.argv.includes('--dry-run');
 
   // 1. Create memory provider
-  const memoryProvider = createMemoryProvider();
+  const memoryProvider = await createMemoryProvider();
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '0.3.0' },
+    { name: 'claude-lark-plugin', version: '0.4.0' },
     {
       capabilities: {
         logging: {},
@@ -57,15 +57,10 @@ async function main() {
         },
       },
       instructions: [
-        'Users read Feishu, not this transcript — your transcript output never reaches their chat. Use reply to respond; edit_message for updating bot\'s own messages; react for lightweight acknowledgements.',
-        '',
-        'Messages arrive as <channel source="lark" chat_id="..." message_id="..." user="..." ts="...">. P2P and @bot group messages share the same Claude transcript. Use chat_id and chat_type in metadata to distinguish chats and avoid mixing contexts.',
-        '',
-        'Always pass reply_to=message_id when calling the reply tool so your response is threaded under the original message in Feishu.',
-        '',
-        'If metadata has attachment_kind and attachment_file_id, call download_attachment with message_id and file_key to fetch the file, then Read the returned path.',
-        '',
-        'Use save_memory to persist important user preferences, decisions, or facts for cross-session recall.',
+        'Users see Feishu, not this transcript. Use reply to respond; edit_message to update; react for acknowledgements.',
+        'Always pass reply_to=message_id so replies thread correctly in Feishu.',
+        'If metadata has attachment_file_id, call download_attachment to fetch the file, then Read the path.',
+        'Use save_memory for important facts; save_skill for reusable procedures.',
       ].join('\n'),
     }
   );

--- a/src/memory/buffer.ts
+++ b/src/memory/buffer.ts
@@ -18,6 +18,7 @@ type FlushHandler = (chatId: string, messages: BufferedMessage[]) => Promise<voi
 export class ConversationBuffer {
   private buffers = new Map<string, BufferedMessage[]>();
   private timers = new Map<string, NodeJS.Timeout>();
+  private flushing = new Set<string>(); // guard against re-entry during flush
   private flushHandler: FlushHandler | null = null;
 
   setFlushHandler(handler: FlushHandler): void {
@@ -25,6 +26,9 @@ export class ConversationBuffer {
   }
 
   record(chatId: string, message: BufferedMessage): void {
+    // Don't record or reset timer during an active flush (prevents re-entry loops)
+    if (this.flushing.has(chatId)) return;
+
     if (!this.buffers.has(chatId)) {
       this.buffers.set(chatId, []);
     }
@@ -106,15 +110,19 @@ export class ConversationBuffer {
   private async triggerFlush(chatId: string): Promise<void> {
     const messages = this.buffers.get(chatId);
     if (!messages || messages.length === 0) return;
+    if (this.flushing.has(chatId)) return; // already flushing
 
     console.error(`[buffer] Auto-flush triggered for chat ${chatId} (${messages.length} messages)`);
 
-    if (this.flushHandler) {
-      try {
+    this.flushing.add(chatId);
+    try {
+      if (this.flushHandler) {
         await this.flushHandler(chatId, [...messages]);
-      } catch (err) {
-        console.error(`[buffer] Flush failed for chat ${chatId}:`, err);
       }
+    } catch (err) {
+      console.error(`[buffer] Flush failed for chat ${chatId}:`, err);
+    } finally {
+      this.flushing.delete(chatId);
     }
 
     this.buffers.delete(chatId);

--- a/src/memory/factory.ts
+++ b/src/memory/factory.ts
@@ -6,18 +6,25 @@ import { Mem0MemoryProvider } from './mem0.js';
 
 /**
  * Create a MemoryProvider based on MEMORY_PROVIDER config.
- * Falls back to file adapter if the selected adapter is not implemented.
+ * Calls healthCheck on startup and logs connectivity status.
  */
-export function createMemoryProvider(): MemoryProvider {
+export async function createMemoryProvider(): Promise<MemoryProvider> {
   const provider = appConfig.memoryProvider;
 
   switch (provider) {
-    case 'openviking':
-      console.error('[memory] OpenViking adapter selected but not yet implemented. Falling back to file adapter.');
-      return new FileMemoryProvider();
+    case 'openviking': {
+      const ov = new OpenVikingMemoryProvider(appConfig.openVikingUrl, appConfig.openVikingApiKey);
+      const healthy = await ov.healthCheck();
+      if (healthy) {
+        console.error(`[memory] OpenViking connected at ${appConfig.openVikingUrl}`);
+      } else {
+        console.error(`[memory] WARNING: OpenViking unreachable at ${appConfig.openVikingUrl} — memory features may be degraded`);
+      }
+      return ov;
+    }
 
     case 'mem0':
-      console.error('[memory] mem0 adapter selected but not yet implemented. Falling back to file adapter.');
+      console.error('[memory] mem0 adapter not yet implemented. Falling back to file adapter.');
       return new FileMemoryProvider();
 
     case 'file':

--- a/src/memory/file.ts
+++ b/src/memory/file.ts
@@ -14,6 +14,8 @@ export class FileMemoryProvider implements MemoryProvider {
     this.baseDir = baseDir ?? appConfig.memoriesDir;
   }
 
+  async healthCheck(): Promise<boolean> { return true; }
+
   // ── User Profile ──
 
   async getProfile(userId: string): Promise<string | null> {
@@ -87,7 +89,10 @@ export class FileMemoryProvider implements MemoryProvider {
 
       // Sort by score descending, return top N
       scored.sort((a, b) => b.score - a.score);
-      return scored.slice(0, appConfig.maxSearchResults).map(s => s.episode);
+      return scored.slice(0, appConfig.maxSearchResults).map(s => ({
+        ...s.episode,
+        score: s.score,
+      }));
     } catch {
       return [];
     }
@@ -176,7 +181,10 @@ export class FileMemoryProvider implements MemoryProvider {
       }
 
       results.sort((a, b) => b.score - a.score);
-      return results.slice(0, appConfig.maxSearchResults).map(r => r.skill);
+      return results.slice(0, appConfig.maxSearchResults).map(r => ({
+        ...r.skill,
+        score: r.score,
+      }));
     } catch {
       return [];
     }

--- a/src/memory/interface.ts
+++ b/src/memory/interface.ts
@@ -1,12 +1,13 @@
 /**
  * Memory provider interface — the pluggable abstraction layer.
- * Implementations: FileMemoryProvider (complete), OpenVikingMemoryProvider (stub), Mem0MemoryProvider (stub)
+ * Implementations: FileMemoryProvider (complete), OpenVikingMemoryProvider (complete), Mem0MemoryProvider (stub)
  */
 
 export interface Episode {
   id: string;
   content: string;
   timestamp: string;
+  score?: number;
   chatId?: string;
   threadId?: string;
 }
@@ -21,9 +22,13 @@ export interface Skill {
   name: string;
   description: string;
   content: string;
+  score?: number;
 }
 
 export interface MemoryProvider {
+  /** Check if the backend is reachable. File adapter always returns true. */
+  healthCheck(): Promise<boolean>;
+
   // Layer 3 — Semantic Memory (user-isolated)
   getProfile(userId: string): Promise<string | null>;
   saveProfile(userId: string, content: string): Promise<void>;

--- a/src/memory/mem0.ts
+++ b/src/memory/mem0.ts
@@ -18,6 +18,8 @@ export class Mem0MemoryProvider implements MemoryProvider {
     console.error(`[mem0] mem0 adapter initialized — NOT YET IMPLEMENTED`);
   }
 
+  async healthCheck(): Promise<boolean> { return false; }
+
   async getProfile(userId: string): Promise<string | null> {
     throw new Error('mem0 adapter not yet implemented — use MEMORY_PROVIDER=file');
   }

--- a/src/memory/openviking.ts
+++ b/src/memory/openviking.ts
@@ -1,52 +1,362 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { appConfig } from '../config.js';
 import type { MemoryProvider, Episode, EpisodeMeta, Skill } from './interface.js';
 
-/**
- * OpenViking memory adapter — STUB.
- *
- * TODO: implement using OpenViking REST API
- * Reference: https://github.com/volcengine/OpenViking
- * Endpoint: OPENVIKING_URL (default http://localhost:1933)
- * Auth: OPENVIKING_API_KEY (optional for local dev)
- *
- * Advantages over file adapter:
- * - Vector-based semantic search for episodes and skills
- * - Better relevance scoring
- * - Scalable storage
- */
-export class OpenVikingMemoryProvider implements MemoryProvider {
-  constructor(url: string, apiKey?: string) {
-    console.error(`[openviking] OpenViking adapter initialized (url: ${url}) — NOT YET IMPLEMENTED`);
+// ── Low-level OpenViking HTTP client ──
+
+class OpenVikingClient {
+  private baseUrl: string;
+  private headers: Record<string, string>;
+
+  constructor(baseUrl: string, apiKey?: string) {
+    this.baseUrl = baseUrl.replace(/\/+$/, '');
+    this.headers = {
+      ...(apiKey ? { 'x-api-key': apiKey } : {}),
+    };
   }
 
+  async health(): Promise<boolean> {
+    try {
+      const resp = await fetch(`${this.baseUrl}/health`, {
+        headers: this.headers,
+        signal: AbortSignal.timeout(3000),
+      });
+      return resp.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Index a text resource into OpenViking via temp_upload + add-resource */
+  async indexResource(targetPath: string, content: string): Promise<void> {
+    try {
+      // Step 1: Create a temp file from the content
+      const blob = new Blob([content], { type: 'text/markdown' });
+      const formData = new FormData();
+      formData.append('file', blob, 'content.md');
+
+      const uploadResp = await fetch(`${this.baseUrl}/api/v1/resources/temp_upload`, {
+        method: 'POST',
+        headers: this.headers,
+        body: formData,
+        signal: AbortSignal.timeout(10000),
+      });
+      if (!uploadResp.ok) {
+        console.error(`[openviking] temp_upload failed: ${uploadResp.status}`);
+        return;
+      }
+      const uploadData = (await uploadResp.json()) as any;
+      const tempFileId = uploadData?.result?.temp_file_id;
+      if (!tempFileId) {
+        console.error('[openviking] temp_upload returned no temp_file_id');
+        return;
+      }
+
+      // Step 2: Add the resource at the target path
+      const addResp = await fetch(`${this.baseUrl}/api/v1/resources`, {
+        method: 'POST',
+        headers: { ...this.headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          temp_file_id: tempFileId,
+          to: targetPath,
+          wait: true,
+          timeout: 10,
+        }),
+        signal: AbortSignal.timeout(15000),
+      });
+      if (!addResp.ok) {
+        const errData = await addResp.json().catch(() => ({}));
+        console.error(`[openviking] add-resource failed for ${targetPath}:`, (errData as any)?.error?.message ?? addResp.status);
+      }
+    } catch (err) {
+      console.error(`[openviking] indexResource failed for ${targetPath}:`, (err as Error).message);
+    }
+  }
+
+  /** Semantic search using the find API */
+  async find(
+    query: string,
+    targetUri?: string,
+    limit?: number,
+    scoreThreshold?: number
+  ): Promise<Array<{ uri: string; score: number; abstract: string }>> {
+    try {
+      const resp = await fetch(`${this.baseUrl}/api/v1/search/find`, {
+        method: 'POST',
+        headers: { ...this.headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query,
+          target_uri: targetUri ?? '',
+          limit: limit ?? appConfig.maxSearchResults * 3, // fetch more, filter later
+          score_threshold: scoreThreshold ?? appConfig.minSearchScore,
+        }),
+        signal: AbortSignal.timeout(5000),
+      });
+      if (!resp.ok) return [];
+      const data = (await resp.json()) as any;
+      const result = data?.result ?? {};
+      // Combine memories, resources, skills into a flat list
+      const all: Array<{ uri: string; score: number; abstract: string }> = [];
+      for (const key of ['memories', 'resources', 'skills']) {
+        for (const item of result[key] ?? []) {
+          all.push({
+            uri: item.uri ?? '',
+            score: item.score ?? 0,
+            abstract: item.abstract ?? '',
+          });
+        }
+      }
+      return all.sort((a, b) => b.score - a.score);
+    } catch (err) {
+      console.error(`[openviking] find failed:`, (err as Error).message);
+      return [];
+    }
+  }
+
+  /** Create a directory in the viking filesystem */
+  async mkdir(uri: string): Promise<void> {
+    try {
+      await fetch(`${this.baseUrl}/api/v1/fs/mkdir`, {
+        method: 'POST',
+        headers: { ...this.headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uri }),
+        signal: AbortSignal.timeout(5000),
+      });
+    } catch (err) {
+      console.error(`[openviking] mkdir failed for ${uri}:`, (err as Error).message);
+    }
+  }
+
+  /** Delete a resource from the viking filesystem */
+  async rm(uri: string): Promise<void> {
+    try {
+      await fetch(`${this.baseUrl}/api/v1/fs?uri=${encodeURIComponent(uri)}`, {
+        method: 'DELETE',
+        headers: this.headers,
+        signal: AbortSignal.timeout(5000),
+      });
+    } catch (err) {
+      console.error(`[openviking] rm failed for ${uri}:`, (err as Error).message);
+    }
+  }
+}
+
+// ── MemoryProvider implementation with dual-write ──
+
+export class OpenVikingMemoryProvider implements MemoryProvider {
+  private client: OpenVikingClient;
+  private memoriesDir: string;
+
+  constructor(url: string, apiKey?: string) {
+    this.client = new OpenVikingClient(url, apiKey);
+    this.memoriesDir = appConfig.memoriesDir;
+  }
+
+  async healthCheck(): Promise<boolean> {
+    return this.client.health();
+  }
+
+  // ── Profiles (hot path — read from local file, not OpenViking) ──
+
   async getProfile(userId: string): Promise<string | null> {
-    throw new Error('OpenViking adapter not yet implemented — use MEMORY_PROVIDER=file');
+    // Hot path: read from local file (faster than API, always available)
+    const filePath = path.join(this.memoriesDir, 'profiles', `${userId}.md`);
+    try {
+      return await fs.readFile(filePath, 'utf-8');
+    } catch {
+      return null;
+    }
   }
 
   async saveProfile(userId: string, content: string): Promise<void> {
-    throw new Error('OpenViking adapter not yet implemented — use MEMORY_PROVIDER=file');
+    // Write local file (primary storage)
+    const dir = path.join(this.memoriesDir, 'profiles');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, `${userId}.md`), content, 'utf-8');
+    // Index in OpenViking (for potential future search)
+    await this.client.indexResource(`viking://resources/profiles/${userId}.md`, content);
   }
 
-  async searchEpisodes(query: string, scope?: { chatId?: string; threadId?: string }): Promise<Episode[]> {
-    throw new Error('OpenViking adapter not yet implemented — use MEMORY_PROVIDER=file');
+  // ── Episodes (cold path — vector search) ──
+
+  async searchEpisodes(
+    query: string,
+    scope?: { chatId?: string; threadId?: string }
+  ): Promise<Episode[]> {
+    if (!scope?.chatId) return [];
+
+    const targetUri = scope.threadId
+      ? `viking://resources/episodes/${scope.chatId}/threads/${scope.threadId}`
+      : `viking://resources/episodes/${scope.chatId}`;
+
+    // Fetch extra results to account for .overview.md entries that will be filtered out
+    const results = await this.client.find(query, targetUri, appConfig.maxSearchResults * 2);
+
+    // Filter out .overview.md entries (they are directory metadata, not user content)
+    const filtered = results
+      .filter(r => !r.uri.endsWith('.overview.md'))
+      .slice(0, appConfig.maxSearchResults);
+
+    // For results with empty abstract, try to read content from local file
+    const episodes: Episode[] = [];
+    for (const r of filtered) {
+      let content = r.abstract;
+      if (!content) {
+        // Try local file fallback
+        const ts = this.extractTimestamp(r.uri);
+        if (ts) {
+          const localPath = scope.threadId
+            ? path.join(this.memoriesDir, 'episodes', scope.chatId!, 'threads', scope.threadId, `${ts}.md`)
+            : path.join(this.memoriesDir, 'episodes', scope.chatId!, `${ts}.md`);
+          try {
+            content = await fs.readFile(localPath, 'utf-8');
+          } catch { /* not found locally */ }
+        }
+      }
+      episodes.push({
+        id: r.uri,
+        content: content || '[content unavailable]',
+        timestamp: this.extractTimestamp(r.uri),
+        score: r.score,
+        chatId: scope.chatId,
+        threadId: scope.threadId,
+      });
+    }
+    return episodes;
   }
 
-  async saveEpisode(type: 'chat' | 'thread', content: string, meta: EpisodeMeta): Promise<void> {
-    throw new Error('OpenViking adapter not yet implemented — use MEMORY_PROVIDER=file');
+  async saveEpisode(
+    type: 'chat' | 'thread',
+    content: string,
+    meta: EpisodeMeta
+  ): Promise<void> {
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+
+    const fileDir =
+      type === 'thread' && meta.threadId
+        ? path.join(this.memoriesDir, 'episodes', meta.chatId, 'threads', meta.threadId)
+        : path.join(this.memoriesDir, 'episodes', meta.chatId);
+
+    // Write local file (primary storage)
+    await fs.mkdir(fileDir, { recursive: true });
+    const filePath = path.join(fileDir, `${ts}.md`);
+    await fs.writeFile(filePath, content, 'utf-8');
+
+    // Index in OpenViking
+    const ovPath =
+      type === 'thread' && meta.threadId
+        ? `viking://resources/episodes/${meta.chatId}/threads/${meta.threadId}/${ts}.md`
+        : `viking://resources/episodes/${meta.chatId}/${ts}.md`;
+    await this.client.indexResource(ovPath, content);
   }
 
   async listEpisodes(chatId: string): Promise<Episode[]> {
-    throw new Error('OpenViking adapter not yet implemented — use MEMORY_PROVIDER=file');
+    const dir = path.join(this.memoriesDir, 'episodes', chatId);
+    try {
+      const files = await fs.readdir(dir);
+      const episodes: Episode[] = [];
+      for (const file of files.filter(f => f.endsWith('.md'))) {
+        const content = await fs.readFile(path.join(dir, file), 'utf-8');
+        const stat = await fs.stat(path.join(dir, file));
+        episodes.push({
+          id: file,
+          content,
+          timestamp: stat.mtime.toISOString(),
+          chatId,
+        });
+      }
+      episodes.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+      return episodes;
+    } catch {
+      return [];
+    }
   }
 
   async deleteEpisodes(chatId: string, ids: string[]): Promise<void> {
-    throw new Error('OpenViking adapter not yet implemented — use MEMORY_PROVIDER=file');
+    for (const id of ids) {
+      // id may be a full URI (from searchEpisodes) or a filename (from listEpisodes)
+      if (id.startsWith('viking://')) {
+        // Full URI — extract the resource path for deletion
+        // URI: viking://resources/episodes/{chatId}/{ts}.md/upload_xxx.md → delete the {ts}.md dir
+        const tsMatch = id.match(/\/(\d{4}-\d{2}-\d{2}T[^/]+\.md)\//);
+        if (tsMatch) {
+          const dirUri = id.substring(0, id.indexOf(tsMatch[1]) + tsMatch[1].length);
+          await this.client.rm(dirUri);
+        }
+      } else {
+        // Filename — construct the Viking URI (keep .md, it's a directory in Viking)
+        await this.client.rm(`viking://resources/episodes/${chatId}/${id}`);
+      }
+      // Delete local file — derive filename from id
+      const filename = id.startsWith('viking://')
+        ? (() => { const ts = this.extractTimestamp(id); return ts ? `${ts}.md` : ''; })()
+        : id;
+      if (filename) {
+        try {
+          await fs.unlink(path.join(this.memoriesDir, 'episodes', chatId, filename));
+        } catch { /* ignore — may already be deleted */ }
+      }
+    }
   }
 
+  // ── Skills (cold path — vector search) ──
+
   async searchSkills(query: string): Promise<Skill[]> {
-    throw new Error('OpenViking adapter not yet implemented — use MEMORY_PROVIDER=file');
+    // Search without target_uri restriction (Viking's target_uri doesn't reliably match
+    // shallow paths like skills/). Fetch generously and filter client-side by URI prefix.
+    const results = await this.client.find(query, undefined, appConfig.maxSearchResults * 5);
+
+    const skillPrefix = 'viking://resources/skills/';
+    const filtered = results
+      .filter(r => r.uri.startsWith(skillPrefix) && !r.uri.endsWith('.overview.md'))
+      .slice(0, appConfig.maxSearchResults);
+
+    const skills: Skill[] = [];
+    for (const r of filtered) {
+      // URI: viking://resources/skills/{name}.md/upload_xxx.md → extract {name}
+      const afterPrefix = r.uri.slice(skillPrefix.length);
+      const name = afterPrefix.split('/')[0]?.replace('.md', '') ?? '';
+
+      // Try to read full content from local file
+      let content = r.abstract;
+      if (!content) {
+        try {
+          content = await fs.readFile(path.join(this.memoriesDir, 'skills', `${name}.md`), 'utf-8');
+        } catch { /* fallback */ }
+      }
+
+      const lines = (content || '').split('\n');
+      const description = (lines[1] ?? '').trim();
+      skills.push({ name, description, content: content || '[content unavailable]', score: r.score });
+    }
+    return skills;
   }
 
   async saveSkill(name: string, description: string, content: string): Promise<void> {
-    throw new Error('OpenViking adapter not yet implemented — use MEMORY_PROVIDER=file');
+    const normalizedName = name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    const fileContent = `# ${name}\n${description}\n\n${content}`;
+
+    // Write local file
+    const dir = path.join(this.memoriesDir, 'skills');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, `${normalizedName}.md`), fileContent, 'utf-8');
+
+    // Index in OpenViking
+    await this.client.indexResource(`viking://resources/skills/${normalizedName}.md`, fileContent);
+  }
+
+  // ── Helpers ──
+
+  private extractTimestamp(uri: string): string {
+    // URI format: viking://resources/episodes/{chatId}/{ts}.md/upload_xxx.md
+    // We need the {ts}.md segment (parent of the upload file)
+    const parts = uri.split('/');
+    // Find the segment that looks like a timestamp (ISO-ish format)
+    for (let i = parts.length - 1; i >= 0; i--) {
+      const seg = parts[i].replace('.md', '');
+      if (/^\d{4}-\d{2}-\d{2}T/.test(seg)) return seg;
+    }
+    return '';
   }
 }

--- a/test/test-openviking.ts
+++ b/test/test-openviking.ts
@@ -1,0 +1,50 @@
+import { OpenVikingMemoryProvider } from '../src/memory/openviking.js';
+
+async function test() {
+  const ov = new OpenVikingMemoryProvider('http://localhost:1933');
+
+  const healthy = await ov.healthCheck();
+  console.error('Health check:', healthy ? 'OK' : 'UNREACHABLE');
+  if (!healthy) { console.error('OpenViking not running — skip'); return; }
+
+  const testChat = `test-chat-${Date.now()}`;
+
+  // Test profile
+  await ov.saveProfile('test-user', '# Test User\nPrefers concise answers.');
+  const profile = await ov.getProfile('test-user');
+  console.error('Profile save/load:', profile?.includes('concise') ? 'OK' : 'FAIL');
+
+  // Test episode save + search
+  await ov.saveEpisode('chat', '# Deployment Discussion\nWe discussed the new CI/CD pipeline for production. The team agreed to use blue-green deployment strategy with automated rollback. Canary at 5%, full rollout after 30min.', { chatId: testChat });
+  console.error('Episode saved, waiting for indexing...');
+
+  // Wait for OpenViking to index (embedding takes a few seconds)
+  await new Promise(r => setTimeout(r, 4000));
+
+  // Search for the episode
+  const episodes = await ov.searchEpisodes('deployment pipeline rollback', { chatId: testChat });
+  console.error('Episode search:', episodes.length > 0 ? `OK (${episodes.length} results, score: ${episodes[0]?.score?.toFixed(3)})` : 'EMPTY');
+  if (episodes.length > 0) {
+    const preview = episodes[0].content.substring(0, 80);
+    console.error('  Content:', preview + (episodes[0].content.length > 80 ? '...' : ''));
+  }
+
+  // Test cross-chat isolation
+  const otherChat = await ov.searchEpisodes('deployment', { chatId: 'nonexistent-chat-xyz' });
+  console.error('Cross-chat isolation:', otherChat.length === 0 ? 'OK (no leakage)' : `FAIL (leaked ${otherChat.length} results)`);
+
+  // Test skill save + search
+  await ov.saveSkill('deploy-prod', 'Production deployment procedure', '1. Build image\n2. Push to registry\n3. Canary 5%\n4. Full rollout');
+  console.error('Skill saved, waiting for indexing...');
+  await new Promise(r => setTimeout(r, 4000));
+
+  const skills = await ov.searchSkills('how to deploy production');
+  console.error('Skill search:', skills.length > 0 ? `OK (${skills.length} results, score: ${skills[0]?.score?.toFixed(3)})` : 'EMPTY');
+  if (skills.length > 0) {
+    console.error('  Name:', skills[0].name);
+  }
+
+  console.error('\n✅ All OpenViking integration tests complete!');
+}
+
+test().catch(console.error);


### PR DESCRIPTION
## Summary
- Implement OpenViking vector search adapter with real API integration (`temp_upload` + `add-resource`, `find`, `mkdir`, `rm`)
- Dual-write architecture: local files as primary storage, OpenViking as semantic search index
- Add `healthCheck()` to MemoryProvider interface with implementations for all backends
- Add `score` field to search results for relevance filtering
- Improve memory injection pipeline: score-based filtering, short-message enhancement, skills-as-reference
- Condense MCP instructions to save ~200 tokens per session
- Add lark-cli skill symlink management to `start.sh`

## Key design decisions
- **Local-first**: profiles read from local files (hot path), episodes/skills indexed in OpenViking for semantic search with local file fallback when abstract is empty
- **URI scheme**: OpenViking requires `viking://resources/` prefix for all resource paths
- **Directory-style storage**: OpenViking stores each uploaded file as a directory (`{name}.md/upload_xxx.md`), timestamp extraction adjusted accordingly

## Test plan
- [x] `npm run typecheck` passes
- [x] Integration test (`src/test-openviking.ts`) validates: health check, profile save/load, episode save + semantic search (score 0.700), cross-chat isolation, skill save + search (score 0.622)

🤖 Generated with [Claude Code](https://claude.com/claude-code)