### PR TITLE
fix: update plugin.json version to 0.4.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "IS908"
   }


### PR DESCRIPTION
## Summary
- Fix missed version bump in `.claude-plugin/plugin.json` (0.3.0 → 0.4.0)
- This was missed during the v0.4.0 release in PR #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)