### PR TITLE
feat: message handling improvements (v0.5.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "IS908"
   }

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules/
 dist/
 docs/
 .env
+.DS_Store
 *.js.map
 *.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,9 @@ src/memory/
   distiller.ts      – Builds flush prompts to distill buffer into episodic memory
 ```
 
-**Data flow:** Feishu event → `LarkChannel.handleMessageEvent` → whitelist check → text extraction → enqueue per-chat → record in buffer → enrich with memory (profile + episodes + skills) → forward via MCP logging message → Claude calls `reply` tool → response sent back to Feishu.
+**Data flow:** Feishu event → `LarkChannel.handleMessageEvent` → whitelist check → ack reaction (MeMeMe) → text extraction → image auto-download → enqueue per-chat → record in buffer → enrich with memory (profile + episodes + skills) → forward via `notifications/claude/channel` → Claude calls `reply` tool → response sent back to Feishu → ack reaction revoked.
+
+**Reaction flow:** Feishu reaction event → `handleReactionEvent` → filter (bot self, bot messages only, whitelists) → forward to Claude via channel notification.
 
 ## Key Design Decisions
 
@@ -42,7 +44,10 @@ src/memory/
 - **Stdio transport**: MCP server communicates via stdin/stdout; all debug logging goes to `console.error`.
 - **Single-instance lock**: PID-based lock file in `/tmp/` prevents duplicate WebSocket connections.
 - **Config location**: All user config lives at `~/.claude/channels/lark/.env`, not in the repo.
-- **Memory is pluggable**: `MemoryProvider` interface with three backends; only `file` is fully implemented (openviking/mem0 are stubs).
+- **Memory is pluggable**: `MemoryProvider` interface with three backends; `file` and `openviking` are implemented (mem0 is a stub).
+- **Image auto-download**: Images are downloaded to `~/.claude/channels/lark/inbox/` on receive. Claude reads local paths via `image_path` in notification meta.
+- **Ack reaction**: Configurable emoji (`LARK_ACK_EMOJI`, default `MeMeMe`) sent on receive, auto-revoked after reply. Fire-and-forget, won't block message processing.
+- **Bot message tracking**: `BotMessageTracker` (capped 300, FIFO) tracks bot-sent message IDs. Used to filter reaction events — only reactions on bot messages are forwarded to Claude.
 
 ## Configuration
 
@@ -56,7 +61,8 @@ The `/lark:configure` skill (in `skills/configure/SKILL.md`) provides interactiv
 - **`.mcp.json` must use `--silent`**: Prevents npm script lifecycle output from corrupting MCP transport.
 - **Channel protocol**: Messages are forwarded to Claude via `notifications/claude/channel` (not `sendLoggingMessage`). Requires `experimental: { 'claude/channel': {} }` capability.
 - **User display names**: Resolved via contact API → cached. Falls back to stable aliases (`user_` + last 7 chars of open_id). Memory keys always use raw open_id/chat_id.
-- **Group chat filtering**: Only messages with @mentions are processed. P2P messages are always processed.
+- **Group chat filtering**: Only messages with @bot mentions are processed (precise match via bot open_id fetched at startup). P2P messages are always processed.
+- **Reaction events**: Subscribed to `im.message.reaction.created_v1`. Filtered: ignores bot's own reactions, non-bot messages, and respects whitelists.
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,15 @@ The plugin connects to Feishu via the Lark SDK WebSocket client, receives messag
 
 - Direct messages (P2P) and group chats (responds to @bot mentions)
 - Rich message types: text, post (rich text), image, file, audio, video, interactive cards
+- **Image auto-download**: images are downloaded to a local inbox so Claude can see them directly
 - Quoted reply support with automatic parent message fetching
-- Attachment extraction (image, file, audio, video)
+- Attachment extraction (image, file, audio, video) with type-aware download
+- **Reaction events**: user emoji reactions on bot messages are forwarded to Claude
 
 ### Responding
 
 - Text replies with automatic chunking for long messages (configurable limit)
+- **Ack reaction**: bot automatically reacts with an emoji (default: MeMeMe) on receive, removes it after replying
 - Image and file uploads (images up to 10 MB, files up to 30 MB)
 - Message editing (plain text and card markdown)
 - Emoji reactions on any message
@@ -67,8 +70,11 @@ Create a custom app at [Feishu Open Platform](https://open.feishu.cn/app) and en
 | `im:message:send_as_bot` | Send messages as the bot |
 | `im:resource` | Download attachments |
 | `im:message.reactions:write` | Add emoji reactions |
+| `im:message.reactions:read` | Receive reaction events |
 
-Enable the WebSocket mode under **Event Subscriptions** and subscribe to the `im.message.receive_v1` event.
+Enable the WebSocket mode under **Event Subscriptions** and subscribe to these events:
+- `im.message.receive_v1` -- receive messages
+- `im.message.reaction.created_v1` -- receive emoji reactions on bot messages
 
 ### 2. Install the Plugin
 
@@ -210,6 +216,7 @@ On every incoming message, the plugin injects relevant memory context in this or
 | `LARK_ALLOWED_USER_IDS` | (empty) | Comma-separated list of allowed user open_ids. Empty means all users allowed. |
 | `LARK_ALLOWED_CHAT_IDS` | (empty) | Comma-separated list of allowed chat IDs. Empty means all chats allowed. |
 | `LARK_TEXT_CHUNK_LIMIT` | `4000` | Maximum characters per message chunk |
+| `LARK_ACK_EMOJI` | `MeMeMe` | Emoji reaction on message receive. Set to empty string to disable. |
 | `LARK_ENABLED_SKILLS` | `lark-im,lark-contact,lark-doc,lark-calendar,lark-task` | Comma-separated skills to load alongside the plugin |
 
 ### Optional -- Memory

--- a/docs/superpowers/specs/2026-04-12-message-handling-improvements-design.md
+++ b/docs/superpowers/specs/2026-04-12-message-handling-improvements-design.md
@@ -1,0 +1,152 @@
+# Message Handling Improvements Design
+
+## Problem
+
+Three gaps in the current message handling pipeline:
+
+1. **Rich media not reaching Claude**: Images, files, audio, video sent from Feishu produce only placeholder text (`[Image]`, `[File: xxx]`). Claude cannot see image content or access file data.
+2. **Attachment download unclear**: The `download_attachment` tool exists but the pipeline doesn't guide Claude on when/how to use it. Image downloads may need `im.v1.image.get` instead of `im.v1.messageResource.get`.
+3. **No acknowledgement**: Users send a message and see nothing until Claude finishes thinking — no feedback that the message was received.
+
+## Design
+
+### 1. Image Auto-Download
+
+**When**: `messageType === 'image'` or a `post` (rich text) contains embedded image nodes.
+
+**How**: In `handleMessageEvent`, after parsing the message but before enqueuing:
+
+```
+if messageType is 'image':
+  download via im.v1.image.get(image_key) → save to inbox/{timestamp}-{image_key}.png
+  set imagePath on LarkMessage
+
+if messageType is 'post':
+  iterate content nodes, find tag === 'img'
+  download each image_key → save to inbox/
+  set imagePaths[] on LarkMessage
+```
+
+**Notification meta**: Add `image_path` (single image) or `image_paths` (multiple from rich text) to the channel notification. Claude reads the local file via the `Read` tool.
+
+**Inbox location**: `~/.claude/channels/lark/inbox/` (already defined in `appConfig.inboxDir`).
+
+**Cleanup**: No auto-cleanup in this iteration. Files accumulate in inbox. Future work can add TTL-based cleanup.
+
+### 2. Non-Image Attachment Meta
+
+**Current gap**: Only the first attachment is passed in notification meta.
+
+**Fix**: Pass all attachments. The notification meta changes from flat fields to an `attachments` array when there are multiple:
+
+Single attachment (backward compatible):
+```json
+{
+  "attachment_kind": "file",
+  "attachment_file_id": "xxx",
+  "attachment_name": "report.pdf",
+  "attachment_size": "1234"
+}
+```
+
+Multiple attachments:
+```json
+{
+  "attachments": [
+    { "kind": "file", "file_id": "xxx", "name": "report.pdf" },
+    { "kind": "audio", "file_id": "yyy" }
+  ]
+}
+```
+
+**Claude workflow**: See attachment meta in `<channel>` tag → call `download_attachment(message_id, file_key)` → `Read` the returned path.
+
+**`download_attachment` fix**: The current implementation uses `im.v1.messageResource.get` for all types. For images, this should use `im.v1.image.get` instead. Add type-aware download logic.
+
+### 3. Ack Reaction on Message Receive
+
+**When**: After the message event is validated (whitelist, mention checks pass), before enqueueing for processing.
+
+**How**: Fire-and-forget call to `im.v1.messageReaction.create` with emoji type `MeMeMe`.
+
+```typescript
+// Fire-and-forget — don't block message processing
+client.im.v1.messageReaction.create({
+  path: { message_id: messageId },
+  data: { reaction_type: { emoji_type: 'MeMeMe' } },
+}).catch(() => {});
+```
+
+**Why fire-and-forget**: The ack is cosmetic. If it fails (permission not granted, rate limit), message processing should continue unaffected.
+
+**Revoke on reply**: After the reply tool sends a response successfully, remove the ack reaction. Implementation:
+- Channel maintains a `Map<messageId, reactionId>` for pending acks
+- When `reply` tool is called with `reply_to`, look up the reaction and call `im.v1.messageReaction.delete` (fire-and-forget)
+- The Map is passed to `registerTools` alongside the conversation buffer
+
+**Configurable**: Add `LARK_ACK_EMOJI` env var (default: `MeMeMe`). Set to empty string to disable.
+
+### 4. Instructions Update
+
+Current instructions don't mention image handling or ack behavior. Update to:
+
+```
+Users see Feishu, not this transcript. Use reply to respond; edit_message to update; react for acknowledgements.
+Always pass reply_to=message_id so replies thread correctly in Feishu.
+If metadata has image_path, Read that file to see the image.
+If metadata has attachment_file_id, call download_attachment with message_id and file_key, then Read the path.
+Use save_memory for important facts; save_skill for reusable procedures.
+```
+
+### 5. Reaction Event Forwarding
+
+**Event**: `im.message.reaction.created_v1` (requires `im:message.reactions:read` permission).
+
+**When**: A user adds an emoji reaction to any message in a chat where the bot is present.
+
+**How**: Register a second event handler in `channel.start()`:
+
+```typescript
+eventDispatcher.register({
+  'im.message.reaction.created_v1': async (data: any) => {
+    // Extract reaction info and forward to Claude
+  },
+});
+```
+
+**Notification**: Forward to Claude via `notifications/claude/channel` with:
+- `content`: `(reacted with {emoji_type} to message {message_id})`
+- `meta`: `{ chat_id, message_id, user, user_id, reaction_emoji, ts }`
+
+Claude decides whether to respond (react back, reply, or ignore). No automatic behavior.
+
+**Filtering** (independent from message filtering — no @mention check):
+1. Ignore reactions from the bot itself (`operator_id === botOpenId`) to prevent loops from ack reactions
+2. Only process reactions on bot's own messages — maintain a capped `Set<messageId>` (max 300, FIFO eviction) of messages sent by the bot (populated in the `reply` tool); ignore reactions on messages not in this set
+3. Apply user whitelist (`allowedUserIds`) on operator
+4. Apply chat whitelist (`allowedChatIds`) on chat_id
+
+## Files to Change
+
+| File | Changes |
+|------|---------|
+| `src/channel.ts` | Image auto-download; ack reaction with revoke; reaction event handler; `LarkMessage` add `imagePath`/`imagePaths` |
+| `src/index.ts` | Pass `image_path`/`image_paths` and full attachments in notification meta; update instructions |
+| `src/tools.ts` | Fix `download_attachment` for image type; revoke ack reaction on reply |
+| `src/config.ts` | Add `LARK_ACK_EMOJI` config option |
+
+## Required Permissions
+
+| Permission | Purpose | Status |
+|---|---|---|
+| `im:message:send_as_bot` | Send messages | Already granted |
+| `im:message.reactions:write` | Add emoji reactions (ack) | Already granted |
+| `im:message.reactions:read` | Receive reaction events | **Needs to be granted** |
+| `im:resource` | Download attachments/images | Already granted |
+
+## Out of Scope
+
+- Streaming/progressive replies (not needed per user decision)
+- Inbox auto-cleanup (future work)
+- Audio/video transcription
+- Interactive card messages (read-only placeholder is sufficient)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with pluggable memory",
   "type": "module",
   "main": "src/index.ts",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,5 +1,5 @@
 import * as Lark from '@larksuiteoapi/node-sdk';
-import { appendFileSync } from 'node:fs';
+import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { appConfig } from './config.js';
@@ -29,9 +29,31 @@ export interface LarkMessage {
   mentions?: Array<{ id: string; name: string }>;
   attachments?: Array<{ fileKey: string; fileName: string; fileType: string }>;
   rawContent: string;
+  imagePath?: string;
+  imagePaths?: string[];
 }
 
 type MessageHandler = (message: LarkMessage) => Promise<void>;
+
+export class BotMessageTracker {
+  private ids: string[] = [];
+  private set = new Set<string>();
+  private readonly maxSize = 300;
+
+  add(messageId: string): void {
+    if (this.set.has(messageId)) return;
+    this.set.add(messageId);
+    this.ids.push(messageId);
+    while (this.ids.length > this.maxSize) {
+      const oldest = this.ids.shift()!;
+      this.set.delete(oldest);
+    }
+  }
+
+  has(messageId: string): boolean {
+    return this.set.has(messageId);
+  }
+}
 
 export class LarkChannel {
   private client: Lark.Client;
@@ -42,6 +64,8 @@ export class LarkChannel {
   private messageHandler: MessageHandler | null = null;
   private memoryProvider: MemoryProvider | null = null;
   private conversationBuffer: ConversationBuffer | null = null;
+  private ackReactions = new Map<string, string>(); // messageId → reactionId
+  private botMessageTracker = new BotMessageTracker();
 
   constructor() {
     // Custom logger to redirect all SDK output to stderr (stdout is reserved for MCP JSON-RPC)
@@ -77,6 +101,14 @@ export class LarkChannel {
     return this.client;
   }
 
+  getAckReactions(): Map<string, string> {
+    return this.ackReactions;
+  }
+
+  getBotMessageTracker(): BotMessageTracker {
+    return this.botMessageTracker;
+  }
+
   async start(): Promise<void> {
     // Fetch bot's own open_id for filtering group @mentions
     await this.fetchBotOpenId();
@@ -89,6 +121,15 @@ export class LarkChannel {
           await this.handleMessageEvent(data);
         } catch (err) {
           console.error('[channel] Error handling message event:', err);
+        }
+      },
+    }).register({
+      'im.message.reaction.created_v1': async (data: any) => {
+        debugLog(`[channel] Event received: im.message.reaction.created_v1`);
+        try {
+          await this.handleReactionEvent(data);
+        } catch (err) {
+          console.error('[channel] Error handling reaction event:', err);
         }
       },
     });
@@ -160,6 +201,17 @@ export class LarkChannel {
       debugLog(`[channel] Group message with @mention, processing`);
     }
 
+    // Fire-and-forget ack reaction
+    if (appConfig.ackEmoji) {
+      this.client.im.v1.messageReaction.create({
+        path: { message_id: messageId },
+        data: { reaction_type: { emoji_type: appConfig.ackEmoji } },
+      }).then((resp: any) => {
+        const reactionId = resp?.data?.reaction_id;
+        if (reactionId) this.ackReactions.set(messageId, reactionId);
+      }).catch(() => {});
+    }
+
     // Parse message text
     const text = this.extractText(rawContent, messageType);
 
@@ -171,6 +223,44 @@ export class LarkChannel {
 
     // Parse attachments
     const attachments = this.extractAttachments(message);
+
+    // Auto-download images
+    let imagePath: string | undefined;
+    let imagePaths: string[] | undefined;
+
+    if (messageType === 'image') {
+      try {
+        const parsed = JSON.parse(rawContent);
+        const imageKey = parsed.image_key;
+        if (imageKey) {
+          const downloaded = await this.downloadImage(imageKey, messageId);
+          if (downloaded) imagePath = downloaded;
+        }
+      } catch {
+        debugLog(`[channel] Failed to parse image content for auto-download`);
+      }
+    } else if (messageType === 'post') {
+      try {
+        const parsed = JSON.parse(rawContent);
+        const content = parsed.content ?? parsed.zh_cn?.content ?? parsed.en_us?.content ?? [];
+        const downloadedPaths: string[] = [];
+        for (const line of content) {
+          for (const node of line as any[]) {
+            if (node.tag === 'img' && node.image_key) {
+              const downloaded = await this.downloadImage(node.image_key, messageId);
+              if (downloaded) downloadedPaths.push(downloaded);
+            }
+          }
+        }
+        if (downloadedPaths.length === 1) {
+          imagePath = downloadedPaths[0];
+        } else if (downloadedPaths.length > 1) {
+          imagePaths = downloadedPaths;
+        }
+      } catch {
+        debugLog(`[channel] Failed to parse post content for image auto-download`);
+      }
+    }
 
     // Resolve chat name for group chats
     const chatName = chatType === 'group' ? await this.resolveChatName(chatId) : '';
@@ -190,6 +280,8 @@ export class LarkChannel {
       mentions: parsedMentions,
       attachments,
       rawContent,
+      imagePath,
+      imagePaths,
     };
 
     // Fetch parent message content if this is a quoted reply
@@ -306,6 +398,85 @@ export class LarkChannel {
       : '';
 
     return `[Memory Context]\n${memoryContext}\n${parentContext}\n[Current Message]\nFrom: ${msg.senderId} in ${msg.chatId}\n${msg.text}`;
+  }
+
+  /**
+   * Download an image by image_key and save to inboxDir.
+   * Returns the absolute path to the saved file, or undefined on failure.
+   */
+  private async downloadImage(imageKey: string, messageId: string): Promise<string | undefined> {
+    try {
+      mkdirSync(appConfig.inboxDir, { recursive: true });
+      const resp = await this.client.im.v1.image.get({
+        path: { image_key: imageKey },
+      } as any);
+      if (resp) {
+        const filename = `${Date.now()}-${imageKey}.png`;
+        const filePath = path.join(appConfig.inboxDir, filename);
+        // The SDK returns a readable stream or buffer
+        const data = resp as any;
+        if (Buffer.isBuffer(data)) {
+          writeFileSync(filePath, data);
+        } else if (data?.writeFile) {
+          await data.writeFile(filePath);
+        } else if (typeof data?.pipe === 'function') {
+          // Readable stream — collect into buffer
+          const chunks: Buffer[] = [];
+          for await (const chunk of data) {
+            chunks.push(Buffer.from(chunk));
+          }
+          writeFileSync(filePath, Buffer.concat(chunks));
+        } else {
+          debugLog(`[channel] Unexpected image response type for ${imageKey}`);
+          return undefined;
+        }
+        debugLog(`[channel] Downloaded image ${imageKey} → ${filePath}`);
+        return filePath;
+      }
+    } catch (err) {
+      debugLog(`[channel] Failed to download image ${imageKey}: ${err}`);
+    }
+    return undefined;
+  }
+
+  /**
+   * Handle reaction events on bot messages.
+   * Forwards emoji reactions to Claude as a special message type.
+   */
+  private async handleReactionEvent(data: any): Promise<void> {
+    const messageId = data?.message_id ?? data?.event?.message_id;
+    const operatorId = data?.operator_id?.open_id ?? data?.event?.operator_id?.open_id ?? data?.user_id?.open_id ?? '';
+    const emojiType = data?.reaction_type?.emoji_type ?? data?.event?.reaction_type?.emoji_type ?? '';
+    const chatId = data?.chat_id ?? data?.event?.chat_id ?? '';
+
+    debugLog(`[channel][debug] reaction event: messageId=${messageId} operatorId=${operatorId} emoji=${emojiType} chatId=${chatId}`);
+
+    // Ignore bot's own reactions
+    if (operatorId === this.botOpenId) return;
+
+    // Only process reactions on messages the bot sent
+    if (!this.botMessageTracker.has(messageId)) return;
+
+    // Whitelist filtering
+    if (appConfig.allowedUserIds.length > 0 && !appConfig.allowedUserIds.includes(operatorId)) return;
+    if (appConfig.allowedChatIds.length > 0 && chatId && !appConfig.allowedChatIds.includes(chatId)) return;
+
+    const senderName = await this.resolveUserName(operatorId);
+
+    const larkMessage: LarkMessage = {
+      messageId,
+      chatId,
+      chatType: 'reaction',
+      senderId: operatorId,
+      senderName: senderName || undefined,
+      text: `(reacted with ${emojiType} to message ${messageId})`,
+      messageType: 'reaction',
+      rawContent: JSON.stringify(data),
+    };
+
+    if (this.messageHandler) {
+      await this.messageHandler(larkMessage);
+    }
   }
 
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ export const appConfig = {
   allowedUserIds: optionalList('LARK_ALLOWED_USER_IDS'),
   allowedChatIds: optionalList('LARK_ALLOWED_CHAT_IDS'),
   textChunkLimit: optionalNumber('LARK_TEXT_CHUNK_LIMIT', 4000),
+  ackEmoji: optional('LARK_ACK_EMOJI', 'MeMeMe'),
 
   // Memory
   memoryProvider: optional('MEMORY_PROVIDER', 'file') as 'file' | 'openviking' | 'mem0',

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '0.4.0' },
+    { name: 'claude-lark-plugin', version: '0.5.0' },
     {
       capabilities: {
         logging: {},
@@ -59,7 +59,8 @@ async function main() {
       instructions: [
         'Users see Feishu, not this transcript. Use reply to respond; edit_message to update; react for acknowledgements.',
         'Always pass reply_to=message_id so replies thread correctly in Feishu.',
-        'If metadata has attachment_file_id, call download_attachment to fetch the file, then Read the path.',
+        'If metadata has image_path, Read that file to see the image.',
+        'If metadata has attachment_file_id, call download_attachment with message_id and file_key, then Read the path.',
         'Use save_memory for important facts; save_skill for reusable procedures.',
       ].join('\n'),
     }
@@ -92,7 +93,7 @@ async function main() {
   channel.setConversationBuffer(buffer);
 
   // 5. Register MCP tools (pass buffer so reply records assistant messages)
-  registerTools(server, channel.getClient(), memoryProvider, buffer);
+  registerTools(server, channel.getClient(), memoryProvider, buffer, channel.getAckReactions(), channel.getBotMessageTracker());
 
   // 6. Set message handler — forwards Feishu messages to Claude via MCP
   channel.setMessageHandler(async (message) => {
@@ -120,13 +121,17 @@ async function main() {
             ...(message.threadId ? { thread_id: message.threadId } : {}),
             ts: new Date().toISOString(),
             ...(message.parentContent ? { parent_content: message.parentContent } : {}),
-            ...(message.attachments?.length
+            ...(message.imagePath ? { image_path: message.imagePath } : {}),
+            ...(message.imagePaths?.length ? { image_paths: message.imagePaths.join(',') } : {}),
+            ...(message.attachments?.length === 1
               ? {
+                  attachment_kind: message.attachments[0].fileType,
                   attachment_file_id: message.attachments[0].fileKey,
                   attachment_name: message.attachments[0].fileName,
-                  attachment_kind: message.attachments[0].fileType,
                 }
-              : {}),
+              : message.attachments && message.attachments.length > 1
+                ? { attachments: JSON.stringify(message.attachments) }
+                : {}),
           },
         },
       });

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -6,6 +6,7 @@ import { appConfig } from './config.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { MemoryProvider } from './memory/interface.js';
 import type { ConversationBuffer } from './memory/buffer.js';
+import type { BotMessageTracker } from './channel.js';
 
 /**
  * Register all 6 MCP tools on the server.
@@ -14,7 +15,9 @@ export function registerTools(
   server: McpServer,
   client: Lark.Client,
   memoryProvider: MemoryProvider,
-  conversationBuffer?: ConversationBuffer
+  conversationBuffer?: ConversationBuffer,
+  ackReactions?: Map<string, string>,
+  botMessageTracker?: BotMessageTracker
 ): void {
   // ── 1. reply ──
   server.registerTool(
@@ -42,9 +45,10 @@ export function registerTools(
 
       for (let i = 0; i < chunks.length; i++) {
         try {
+          let resp: any;
           if (reply_to && i === 0) {
             // First chunk as a quoted reply
-            await client.im.v1.message.reply({
+            resp = await client.im.v1.message.reply({
               path: { message_id: reply_to },
               data: {
                 content: JSON.stringify({ text: chunks[i] }),
@@ -52,7 +56,7 @@ export function registerTools(
               },
             });
           } else {
-            await client.im.v1.message.create({
+            resp = await client.im.v1.message.create({
               params: { receive_id_type: 'chat_id' },
               data: {
                 receive_id: chat_id,
@@ -61,6 +65,8 @@ export function registerTools(
               },
             });
           }
+          const sentId = resp?.data?.message_id;
+          if (sentId && botMessageTracker) botMessageTracker.add(sentId);
         } catch (err: any) {
           const apiError = err?.response?.data ?? err?.data;
           if (apiError?.code && apiError?.msg) {
@@ -132,6 +138,17 @@ export function registerTools(
         text: text.slice(0, 500), // truncate for buffer efficiency
         timestamp: new Date().toISOString(),
       });
+
+      // Revoke ack reaction now that we've replied
+      if (reply_to && ackReactions) {
+        const reactionId = ackReactions.get(reply_to);
+        if (reactionId) {
+          ackReactions.delete(reply_to);
+          client.im.v1.messageReaction.delete({
+            path: { message_id: reply_to, reaction_id: reactionId },
+          }).catch(() => {});
+        }
+      }
 
       return {
         content: [{ type: 'text' as const, text: `Sent ${chunks.length} message(s)` }],
@@ -216,25 +233,32 @@ export function registerTools(
     async ({ message_id, file_key }) => {
       const inboxDir = appConfig.inboxDir;
       await fs.mkdir(inboxDir, { recursive: true });
-
-      const resp = await client.im.v1.messageResource.get({
-        path: { message_id, file_key },
-        params: { type: 'file' },
-      });
-
-      if (resp) {
-        const filePath = path.join(inboxDir, file_key);
-        // The SDK returns the file data; write it to disk
-        await fs.writeFile(filePath, resp as any);
-        return {
-          content: [{ type: 'text' as const, text: `Downloaded to ${filePath}` }],
-        };
+      try {
+        let data: any;
+        if (file_key.startsWith('img_')) {
+          data = await client.im.v1.image.get({
+            path: { image_key: file_key },
+          });
+        } else {
+          data = await client.im.v1.messageResource.get({
+            path: { message_id, file_key },
+            params: { type: 'file' },
+          });
+        }
+        if (data) {
+          const filePath = path.join(inboxDir, file_key);
+          await fs.writeFile(filePath, data as any);
+          return { content: [{ type: 'text' as const, text: `Downloaded to ${filePath}` }] };
+        }
+      } catch (err: any) {
+        const apiError = err?.response?.data ?? err?.data;
+        if (apiError?.code && apiError?.msg) {
+          console.error(`[tools] download failed [${apiError.code}]: ${apiError.msg}`);
+          return { content: [{ type: 'text' as const, text: `Feishu API [${apiError.code}]: ${apiError.msg}` }], isError: true };
+        }
+        console.error(`[tools] download failed:`, err?.message ?? String(err));
       }
-
-      return {
-        content: [{ type: 'text' as const, text: 'Failed to download attachment' }],
-        isError: true,
-      };
+      return { content: [{ type: 'text' as const, text: 'Failed to download attachment' }], isError: true };
     }
   );
 


### PR DESCRIPTION
## Summary
- Auto-download images to inbox → Claude can `Read` the local path directly
- Pass full attachment metadata in notifications (single flat / multi JSON)
- MeMeMe ack reaction on receive, auto-revoke after reply
- Forward user reaction events (`im.message.reaction.created_v1`) to Claude
- Bot message tracking (capped 300 FIFO) for reaction filtering
- Type-aware `download_attachment` — route `img_` keys through image API
- Updated MCP instructions for image/attachment handling
- New config: `LARK_ACK_EMOJI` (default: `MeMeMe`, set empty to disable)
- Bump version to 0.5.0

## New Permission Required
`im:message.reactions:read` — needed for receiving reaction events

## Test plan
- [ ] Send image in DM → image auto-downloaded, Claude can Read it
- [ ] Send image in rich text (post) → embedded images downloaded
- [ ] Send file/audio/video → attachment meta passed, Claude can download_attachment
- [ ] Send any message → MeMeMe reaction appears, disappears after reply
- [ ] Add reaction to bot's reply → Claude receives reaction event
- [ ] Add reaction to non-bot message → ignored
- [ ] `LARK_ACK_EMOJI=""` → no ack reaction
- [ ] `npm start -- --dry-run` passes, stdout empty

🤖 Generated with [Claude Code](https://claude.ai/claude-code)