### PR TITLE
fix: ack reaction improvements and debug log cleanup (v0.5.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "IS908"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with pluggable memory",
   "type": "module",
   "main": "src/index.ts",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -166,11 +166,6 @@ export class LarkChannel {
 
     const senderId = sender?.sender_id?.open_id ?? '';
 
-    // Debug: log raw event structure to understand sender/mentions shape
-    debugLog(`[channel][debug] sender: ${JSON.stringify(sender)}`);
-    debugLog(`[channel][debug] chatType=${chatType} chatId=${chatId} messageType=${messageType}`);
-    if (mentions) debugLog(`[channel][debug] mentions: ${JSON.stringify(mentions)}`);
-
     // Resolve sender display name (from event data or cache)
     const senderName = await this.resolveUserName(senderId, sender);
 
@@ -201,11 +196,12 @@ export class LarkChannel {
       debugLog(`[channel] Group message with @mention, processing`);
     }
 
-    // Fire-and-forget ack reaction
-    if (appConfig.ackEmoji) {
+    // Fire-and-forget ack reaction (Typing for P2P, MeMeMe for group @bot)
+    const ackEmoji = chatType === 'p2p' ? 'Typing' : appConfig.ackEmoji;
+    if (ackEmoji) {
       this.client.im.v1.messageReaction.create({
         path: { message_id: messageId },
-        data: { reaction_type: { emoji_type: appConfig.ackEmoji } },
+        data: { reaction_type: { emoji_type: ackEmoji } },
       }).then((resp: any) => {
         const reactionId = resp?.data?.reaction_id;
         if (reactionId) this.ackReactions.set(messageId, reactionId);
@@ -444,28 +440,26 @@ export class LarkChannel {
    * Forwards emoji reactions to Claude as a special message type.
    */
   private async handleReactionEvent(data: any): Promise<void> {
-    const messageId = data?.message_id ?? data?.event?.message_id;
-    const operatorId = data?.operator_id?.open_id ?? data?.event?.operator_id?.open_id ?? data?.user_id?.open_id ?? '';
-    const emojiType = data?.reaction_type?.emoji_type ?? data?.event?.reaction_type?.emoji_type ?? '';
-    const chatId = data?.chat_id ?? data?.event?.chat_id ?? '';
+    const messageId = data?.message_id ?? '';
+    const emojiType = data?.reaction_type?.emoji_type ?? '';
+    const operatorType = data?.operator_type ?? '';
+    // app reactions: operator_type=app; user reactions: operator_type=user, user_id.open_id=ou_xxx
+    const operatorId = data?.user_id?.open_id ?? '';
 
-    debugLog(`[channel][debug] reaction event: messageId=${messageId} operatorId=${operatorId} emoji=${emojiType} chatId=${chatId}`);
-
-    // Ignore bot's own reactions
-    if (operatorId === this.botOpenId) return;
+    // Ignore bot's own reactions (operator_type=app means the bot itself)
+    if (operatorType === 'app') return;
 
     // Only process reactions on messages the bot sent
     if (!this.botMessageTracker.has(messageId)) return;
 
-    // Whitelist filtering
+    // Whitelist filtering (no chat_id in reaction events)
     if (appConfig.allowedUserIds.length > 0 && !appConfig.allowedUserIds.includes(operatorId)) return;
-    if (appConfig.allowedChatIds.length > 0 && chatId && !appConfig.allowedChatIds.includes(chatId)) return;
 
     const senderName = await this.resolveUserName(operatorId);
 
     const larkMessage: LarkMessage = {
       messageId,
-      chatId,
+      chatId: '',
       chatType: 'reaction',
       senderId: operatorId,
       senderName: senderName || undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '0.5.0' },
+    { name: 'claude-lark-plugin', version: '0.5.1' },
     {
       capabilities: {
         logging: {},

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -139,14 +139,24 @@ export function registerTools(
         timestamp: new Date().toISOString(),
       });
 
-      // Revoke ack reaction now that we've replied
-      if (reply_to && ackReactions) {
-        const reactionId = ackReactions.get(reply_to);
+      // Revoke ack reaction — try reply_to first, then scan all pending acks
+      if (ackReactions && ackReactions.size > 0) {
+        const msgId = reply_to || '';
+        const reactionId = msgId ? ackReactions.get(msgId) : undefined;
         if (reactionId) {
-          ackReactions.delete(reply_to);
+          // Exact match on reply_to
+          ackReactions.delete(msgId);
           client.im.v1.messageReaction.delete({
-            path: { message_id: reply_to, reaction_id: reactionId },
+            path: { message_id: msgId, reaction_id: reactionId },
           }).catch(() => {});
+        } else {
+          // Fallback: revoke all pending acks (handles case where Claude didn't pass reply_to)
+          for (const [mid, rid] of ackReactions.entries()) {
+            ackReactions.delete(mid);
+            client.im.v1.messageReaction.delete({
+              path: { message_id: mid, reaction_id: rid },
+            }).catch(() => {});
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- Use `Typing` emoji for P2P chats, `MeMeMe` for group @bot
- Fix ack revoke: fallback to clear all pending acks when `reply_to` is not provided
- Fix reaction event parsing: use `operator_type=app` to filter bot's own reactions
- Remove verbose debug JSON dumps, keep operational logs
- Bump version to 0.5.1

## Test plan
- [x] P2P message → Typing reaction appears, revoked after reply
- [x] Group @bot message → MeMeMe reaction appears, revoked after reply
- [x] Reply without reply_to → ack still revoked (fallback)
- [x] `npm start -- --dry-run` passes, stdout empty

🤖 Generated with [Claude Code](https://claude.ai/claude-code)