### PR TITLE
feat: add --dangerously-skip-permissions to start.sh

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -40,4 +40,4 @@ echo >&2 "  App ID: ${LARK_APP_ID:-<not set>}"
 echo >&2 "  Memory: ${MEMORY_PROVIDER:-file}"
 echo >&2 "  Skills: ${LARK_ENABLED_SKILLS}"
 
-exec claude --dangerously-load-development-channels "plugin:lark@claude-lark-plugin"
+exec claude --dangerously-load-development-channels "plugin:lark@claude-lark-plugin" --dangerously-skip-permissions


### PR DESCRIPTION
## Summary
- Add `--dangerously-skip-permissions` flag to the `exec claude` command in `start.sh`, enabling unattended operation without permission prompts.

## Test plan
- [x] Run `bash scripts/start.sh` and verify Claude starts with permissions skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)