### PR TITLE
feat: simplify start.sh, remove lark-cli skill management (v0.5.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": {
     "name": "IS908"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with pluggable memory",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-
 # Load env
 ENV_FILE="${HOME}/.claude/channels/lark/.env"
 if [ -f "$ENV_FILE" ]; then
@@ -12,32 +9,8 @@ if [ -f "$ENV_FILE" ]; then
   set +a
 fi
 
-# Default skills to load alongside the plugin
-LARK_ENABLED_SKILLS="${LARK_ENABLED_SKILLS:-lark-im,lark-contact,lark-doc,lark-calendar,lark-task}"
-
-# ── Skill filtering: manage symlinks in ~/.claude/skills/ ──
-SKILLS_DIR="${HOME}/.claude/skills"
-mkdir -p "$SKILLS_DIR"
-
-# Remove existing lark-* symlinks (stale from previous runs)
-find "$SKILLS_DIR" -maxdepth 1 -name 'lark-*' -type l -delete 2>/dev/null || true
-
-# Create symlinks for enabled skills only
-IFS=',' read -ra SKILLS <<< "$LARK_ENABLED_SKILLS"
-for skill in "${SKILLS[@]}"; do
-  skill=$(echo "$skill" | xargs)  # trim whitespace
-  [ -z "$skill" ] && continue
-  # Search for the skill directory in known locations
-  src=$(find "${HOME}/.claude" -path "*/larksuite/cli/skills/${skill}" -type d 2>/dev/null | head -1)
-  if [ -n "$src" ]; then
-    ln -sf "$src" "$SKILLS_DIR/$skill"
-    echo >&2 "  Loaded skill: $skill"
-  fi
-done
-
 echo >&2 "Starting claude-lark-plugin..."
 echo >&2 "  App ID: ${LARK_APP_ID:-<not set>}"
 echo >&2 "  Memory: ${MEMORY_PROVIDER:-file}"
-echo >&2 "  Skills: ${LARK_ENABLED_SKILLS}"
 
 exec claude --dangerously-load-development-channels "plugin:lark@claude-lark-plugin" --dangerously-skip-permissions

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '0.5.1' },
+    { name: 'claude-lark-plugin', version: '0.5.2' },
     {
       capabilities: {
         logging: {},


### PR DESCRIPTION
## Summary
- Remove lark-cli skill symlink management from `scripts/start.sh`
- Remove `LARK_ENABLED_SKILLS` config and related logic
- lark-cli skills are installed independently, no need for the plugin to manage them
- Bump version to 0.5.2

🤖 Generated with [Claude Code](https://claude.ai/claude-code)