### PR TITLE
feat: marketplace metadata, smoke tests, and configurable tracker (v0.6.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,13 +3,17 @@
   "description": "Chat with Claude Code in real time through Feishu (Lark) with pluggable memory backends",
   "owner": {
     "name": "IS908",
-    "email": "kunchen@pku.edu.cn"
+    "email": "kevinchen0635@gmail.com"
   },
   "plugins": [
     {
       "name": "lark",
+      "version": "0.6.0",
       "source": "./",
-      "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory"
+      "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
+      "category": "productivity",
+      "homepage": "https://github.com/IS908/claude-lark-plugin",
+      "keywords": ["feishu", "lark", "im", "bot", "chat", "lite-memory"]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,12 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "author": {
     "name": "IS908"
-  }
+  },
+  "repository": "https://github.com/IS908/claude-lark-plugin",
+  "homepage": "https://github.com/IS908/claude-lark-plugin",
+  "license": "Apache-2.0",
+  "keywords": ["feishu", "lark", "im", "bot", "chat", "lite-memory"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+## [0.6.0] - 2026-04-14
+
+### Added
+- Marketplace metadata: version, homepage, category, keywords in marketplace.json and plugin.json
+- CHANGELOG.md following Keep a Changelog format
+- Smoke tests (`npm test`): typecheck, dry-run, stdout cleanliness
+- `LARK_BOT_MESSAGE_TRACKER_SIZE` config option (default: 500, was hardcoded 300)
+
+### Changed
+- BotMessageTracker size configurable via constructor and env var
+- Removed version badge from READMEs (maintained in package.json and releases only)
+
+## [0.5.3] - 2026-04-14
+
+### Added
+- Apache 2.0 LICENSE file
+- README badges (version, node, license, docs)
+
+### Changed
+- Updated README badge style for both EN and CN versions
+
+## [0.5.2] - 2026-04-12
+
+### Changed
+- Simplified `scripts/start.sh` — removed lark-cli skill symlink management
+- Removed `LARK_ENABLED_SKILLS` config option
+
+## [0.5.1] - 2026-04-12
+
+### Fixed
+- Use `Typing` emoji for P2P ack, `MeMeMe` for group @bot
+- Ack revoke fallback: clear all pending acks when `reply_to` not provided
+- Reaction event parsing: use `operator_type=app` to filter bot's own reactions
+- Removed verbose debug JSON dumps
+
+## [0.5.0] - 2026-04-12
+
+### Added
+- Image auto-download to local inbox; `image_path` in notification meta
+- Full attachment metadata in notifications (single + multi)
+- MeMeMe ack reaction on receive, auto-revoke on reply
+- Reaction event forwarding (`im.message.reaction.created_v1`)
+- Bot message tracking (capped 300, FIFO) for reaction filtering
+- Type-aware `download_attachment` (image API for `img_` keys)
+- `LARK_ACK_EMOJI` config option (default: `MeMeMe`)
+
+### Changed
+- Updated MCP instructions for image/attachment handling
+
+## [0.4.0] - 2026-04-12
+
+### Added
+- Memory injection pipeline: user profiles, episodic memory, skills
+- OpenViking adapter with dual-write architecture
+- Score-based filtering (`LARK_MIN_SEARCH_SCORE`)
+- HealthCheck for memory provider connectivity
+
+[0.6.0]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.6.0
+[0.5.3]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.5.3
+[0.5.2]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.5.2
+[0.5.1]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.5.1
+[0.5.0]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.5.0
+[0.4.0]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ src/tools.ts        – Registers 6 MCP tools: reply, edit_message, react, downl
 src/queue.ts        – Per-chat sequential message queue
 src/memory/
   interface.ts      – MemoryProvider interface (Episodes, Profiles, Skills)
-  factory.ts        – Provider factory (file | openviking | mem0)
+  factory.ts        – Provider factory (file | openviking | mem0 stub)
   file.ts           – File-based provider (default, stores in ~/.claude/channels/lark/memories/)
   openviking.ts     – OpenViking vector search provider (stub)
   mem0.ts           – mem0 managed memory provider (stub)
@@ -47,7 +47,7 @@ src/memory/
 - **Memory is pluggable**: `MemoryProvider` interface with three backends; `file` and `openviking` are implemented (mem0 is a stub).
 - **Image auto-download**: Images are downloaded to `~/.claude/channels/lark/inbox/` on receive. Claude reads local paths via `image_path` in notification meta.
 - **Ack reaction**: Configurable emoji (`LARK_ACK_EMOJI`, default `MeMeMe`) sent on receive, auto-revoked after reply. Fire-and-forget, won't block message processing.
-- **Bot message tracking**: `BotMessageTracker` (capped 300, FIFO) tracks bot-sent message IDs. Used to filter reaction events — only reactions on bot messages are forwarded to Claude.
+- **Bot message tracking**: `BotMessageTracker` (default 500, FIFO, configurable via `LARK_BOT_MESSAGE_TRACKER_SIZE`) tracks bot-sent message IDs. Used to filter reaction events — only reactions on bot messages are forwarded to Claude.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Claude Lark Plugin
 
 [![docs](https://img.shields.io/badge/docs-中文-blue)](README_CN.md)
-[![version](https://img.shields.io/badge/version-0.5.3-blue)](https://github.com/IS908/claude-lark-plugin/releases)
 [![node](https://img.shields.io/badge/node-%3E%3D20.0.0-339933?logo=node.js&logoColor=white)](package.json)
 [![license](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
-Chat with Claude Code in real time through Feishu (Lark). Pluggable memory with file-based, OpenViking, and mem0 backends.
+Chat with Claude Code in real time through Feishu (Lark). Pluggable memory with file-based and OpenViking backends.
 
 ---
 
@@ -44,7 +43,7 @@ The plugin connects to Feishu via the Lark SDK WebSocket client, receives messag
 
 - Three-layer architecture: Buffer, Episodic, and Semantic memory
 - Auto-flush distillation from conversation buffer to episodic memory
-- Pluggable backends: file-based (default), OpenViking (vector search), mem0
+- Pluggable backends: file-based (default), OpenViking (vector search), mem0 (planned)
 - User profiles, chat episodes, thread episodes, and global skills
 - Memory-enriched context injection on every incoming message
 
@@ -177,8 +176,8 @@ node -e "console.log(require('./package.json').version)"
 | Layer | Name | Scope | Injection | Storage |
 |---|---|---|---|---|
 | 1 | Buffer | Per-chat | N/A (in-process) | In-memory ring buffer |
-| 2 | Episodic | Per-chat / per-thread | Cold (search-based) | File / OpenViking / mem0 |
-| 3 | Semantic | Per-user (profile) or global (skills) | Hot (always loaded) | File / OpenViking / mem0 |
+| 2 | Episodic | Per-chat / per-thread | Cold (search-based) | File / OpenViking / mem0 (planned) |
+| 3 | Semantic | Per-user (profile) or global (skills) | Hot (always loaded) | File / OpenViking / mem0 (planned) |
 
 ### Memory Enrichment Pipeline
 
@@ -223,14 +222,14 @@ On every incoming message, the plugin injects relevant memory context in this or
 
 | Variable | Default | Description |
 |---|---|---|
-| `MEMORY_PROVIDER` | `file` | Memory backend: `file`, `openviking`, or `mem0` |
+| `MEMORY_PROVIDER` | `file` | Memory backend: `file`, `openviking`, or `mem0` (planned) |
 | `LARK_MIN_SEARCH_SCORE` | `0.3` | Minimum similarity score for memory search results |
 | `LARK_MAX_SEARCH_RESULTS` | `2` | Maximum number of memory search results to inject |
 | `LARK_INACTIVITY_HOURS` | `3` | Hours of inactivity before buffer flush to episodic memory |
 | `OPENVIKING_URL` | `http://localhost:1933` | OpenViking server URL |
 | `OPENVIKING_API_KEY` | (empty) | OpenViking API key |
-| `MEM0_URL` | (empty) | mem0 server URL |
-| `MEM0_API_KEY` | (empty) | mem0 API key |
+| `MEM0_URL` | (empty) | mem0 server URL (planned) |
+| `MEM0_API_KEY` | (empty) | mem0 API key (planned) |
 
 ---
 
@@ -254,11 +253,11 @@ Step 1: Credentials
   -> LARK_APP_ID and LARK_APP_SECRET (shows masked current values if already set)
 
 Step 2: Memory Provider
-  -> file (default, zero deps) / openviking (vector search) / mem0 (managed memory)
+  -> file (default, zero deps) / openviking (vector search) / mem0 (planned)
 
 Step 3: Backend Config (conditional)
   -> If openviking: OPENVIKING_URL, OPENVIKING_API_KEY
-  -> If mem0: MEM0_URL, MEM0_API_KEY
+  -> If mem0 (planned): MEM0_URL, MEM0_API_KEY
   -> If file: skipped
 
 Step 4: Filtering (optional)

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,11 +1,10 @@
 # Claude Lark Plugin
 
 [![docs](https://img.shields.io/badge/docs-English-blue)](README.md)
-[![version](https://img.shields.io/badge/version-0.5.3-blue)](https://github.com/IS908/claude-lark-plugin/releases)
 [![node](https://img.shields.io/badge/node-%3E%3D20.0.0-339933?logo=node.js&logoColor=white)](package.json)
 [![license](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
-通过飞书（Lark）与 Claude Code 实时聊天。支持可插拔记忆系统，内置文件存储后端，可扩展 OpenViking 和 mem0。
+通过飞书（Lark）与 Claude Code 实时聊天。支持可插拔记忆系统，内置文件存储和 OpenViking 后端。
 
 ---
 
@@ -40,7 +39,7 @@
 
 - 三层架构：Buffer（短期）/ 情景记忆（中期）/ 语义记忆（长期）
 - 自动蒸馏：对话静默超时后自动触发摘要
-- 可插拔后端：文件存储（内置）、OpenViking（向量搜索）、mem0（智能记忆管理）
+- 可插拔后端：文件存储（内置）、OpenViking（向量搜索）、mem0（计划中）
 
 ### 可靠性
 
@@ -207,14 +206,14 @@ node -e "console.log(require('./package.json').version)"
 
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
-| `MEMORY_PROVIDER` | `file` | 记忆后端：`file`、`openviking` 或 `mem0` |
+| `MEMORY_PROVIDER` | `file` | 记忆后端：`file`、`openviking` 或 `mem0`（计划中） |
 | `LARK_MIN_SEARCH_SCORE` | `0.3` | 最低相关度分数（仅向量后端生效） |
 | `LARK_MAX_SEARCH_RESULTS` | `2` | 每次查询返回的最大情景数 |
 | `LARK_INACTIVITY_HOURS` | `3` | 自动蒸馏触发的静默时长（小时） |
 | `OPENVIKING_URL` | `http://localhost:1933` | OpenViking 服务地址 |
 | `OPENVIKING_API_KEY` | （空） | OpenViking API 密钥 |
-| `MEM0_URL` | （空） | mem0 服务地址 |
-| `MEM0_API_KEY` | （空） | mem0 API 密钥 |
+| `MEM0_URL` | （空） | mem0 服务地址（计划中） |
+| `MEM0_API_KEY` | （空） | mem0 API 密钥（计划中） |
 
 ---
 
@@ -238,11 +237,11 @@ node -e "console.log(require('./package.json').version)"
   -> LARK_APP_ID 和 LARK_APP_SECRET（已有配置时显示脱敏值，可选保留/更新）
 
 第 2 步：记忆后端
-  -> file（默认，零依赖）/ openviking（向量语义搜索）/ mem0（智能记忆管理）
+  -> file（默认，零依赖）/ openviking（向量语义搜索）/ mem0（计划中）
 
 第 3 步：后端配置（按选择分支）
   -> openviking: OPENVIKING_URL、OPENVIKING_API_KEY
-  -> mem0: MEM0_URL、MEM0_API_KEY
+  -> mem0（计划中）: MEM0_URL、MEM0_API_KEY
   -> file: 跳过
 
 第 4 步：访问过滤（可选）

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "0.5.3",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with pluggable memory",
   "type": "module",
   "main": "src/index.ts",
@@ -8,7 +8,8 @@
     "prestart": "npm install --prefer-offline --silent",
     "start": "tsx src/index.ts",
     "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bash scripts/test.sh"
   },
   "dependencies": {
     "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== TypeScript typecheck ==="
+npx tsc --noEmit
+echo "PASS"
+
+echo ""
+echo "=== Dry-run (module loading) ==="
+npm run --silent start -- --dry-run 1>/tmp/lark-test-stdout.txt 2>/tmp/lark-test-stderr.txt
+echo "PASS"
+
+echo ""
+echo "=== MCP stdout clean ==="
+if [ -s /tmp/lark-test-stdout.txt ]; then
+  echo "FAIL: stdout is not empty"
+  cat /tmp/lark-test-stdout.txt
+  exit 1
+fi
+echo "PASS"
+
+echo ""
+echo "All tests passed."

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -38,7 +38,11 @@ type MessageHandler = (message: LarkMessage) => Promise<void>;
 export class BotMessageTracker {
   private ids: string[] = [];
   private set = new Set<string>();
-  private readonly maxSize = 300;
+  private readonly maxSize: number;
+
+  constructor(maxSize = 500) {
+    this.maxSize = maxSize;
+  }
 
   add(messageId: string): void {
     if (this.set.has(messageId)) return;
@@ -65,7 +69,7 @@ export class LarkChannel {
   private memoryProvider: MemoryProvider | null = null;
   private conversationBuffer: ConversationBuffer | null = null;
   private ackReactions = new Map<string, string>(); // messageId → reactionId
-  private botMessageTracker = new BotMessageTracker();
+  private botMessageTracker = new BotMessageTracker(appConfig.botMessageTrackerSize);
 
   constructor() {
     // Custom logger to redirect all SDK output to stderr (stdout is reserved for MCP JSON-RPC)

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,7 @@ export const appConfig = {
   allowedChatIds: optionalList('LARK_ALLOWED_CHAT_IDS'),
   textChunkLimit: optionalNumber('LARK_TEXT_CHUNK_LIMIT', 4000),
   ackEmoji: optional('LARK_ACK_EMOJI', 'MeMeMe'),
+  botMessageTrackerSize: optionalNumber('LARK_BOT_MESSAGE_TRACKER_SIZE', 500),
 
   // Memory
   memoryProvider: optional('MEMORY_PROVIDER', 'file') as 'file' | 'openviking' | 'mem0',

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '0.5.3' },
+    { name: 'claude-lark-plugin', version: '0.6.0' },
     {
       capabilities: {
         logging: {},


### PR DESCRIPTION
## Summary

Marketplace submission readiness improvements:

- **marketplace.json**: add version, homepage, category (`productivity`), keywords
- **plugin.json**: add repository, homepage, license (`Apache-2.0`), keywords
- **CHANGELOG.md**: full changelog from v0.4.0 to v0.6.0
- **Smoke tests**: `npm test` runs typecheck, dry-run, and stdout cleanliness check
- **BotMessageTracker**: configurable via `LARK_BOT_MESSAGE_TRACKER_SIZE` (default 500, was hardcoded 300)
- **mem0 marked as planned**: all docs now clearly indicate mem0 is not yet implemented
- **README badges**: removed version badge, kept docs/node/license
- Bump version to 0.6.0

## Test plan
- [x] `npm test` passes (typecheck + dry-run + stdout clean)
- [x] Version 0.6.0 consistent across all 6 locations
- [x] All mem0 references marked as planned/stub
- [x] No stale version references

🤖 Generated with [Claude Code](https://claude.ai/claude-code)