### PR TITLE
feat: raw card JSON support + centralized prompts (v0.8.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.8.3] - 2026-04-17
+
+### Added
+- Raw card JSON support: `reply` tool accepts a `card` param with Feishu Schema 2.0 JSON, sending pre-built cards directly without `buildCards` conversion
+- Centralized prompt templates: all hardcoded prompts extracted to `src/prompts.ts` (`flushPrompt`, `profileDistillationPrompt`, `cronJobPrompt`, `enrichmentPrompt`)
+- `scripts/reply-card-smoke.ts` — 8 smoke test assertions covering the raw card path (valid/invalid JSON, reply_to routing, buffer recording, ack revocation, fallback text)
+
+### Fixed
+- Raw card path now records assistant response in `ConversationBuffer` (previously skipped due to early return)
+- Raw card path now revokes ack reaction (previously skipped due to early return)
+- Removed unused `chat_id` destructuring in `save_skill` handler
+- Stale JSDoc comment ("Register all 6 MCP tools" → "Register all MCP tools")
+
+### Changed
+- Deduplicated buffer-record + ack-revoke logic into shared `recordAndRevokeAck()` helper in `reply` tool
+- `files` param description now notes it is ignored when `card` is provided
+
 ## [0.8.2] - 2026-04-17
 
 ### Fixed
@@ -125,6 +142,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Score-based filtering (`LARK_MIN_SEARCH_SCORE`)
 - HealthCheck for memory provider connectivity
 
+[0.8.3]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.8.3
 [0.8.2]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.8.2
 [0.8.1]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.8.1
 [0.8.0]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.8.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with pluggable memory",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/reply-card-smoke.ts
+++ b/scripts/reply-card-smoke.ts
@@ -1,0 +1,252 @@
+/**
+ * Reply tool raw-card path smoke test — runs as part of `npm test`.
+ * Uses a mock Lark client to verify the card param behavior without network.
+ * Exits non-zero if any assertion fails.
+ */
+import { registerTools } from '../src/tools.js';
+import type { MemoryProvider } from '../src/memory/interface.js';
+
+function fail(msg: string): never {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+// ── Mock helpers ──
+
+/** Capture calls to the mock Lark client */
+const apiCalls: { method: string; args: any }[] = [];
+
+function mockLarkClient() {
+  return {
+    im: {
+      v1: {
+        message: {
+          create: async (args: any) => {
+            apiCalls.push({ method: 'message.create', args });
+            return { data: { message_id: 'mock_msg_001' } };
+          },
+          reply: async (args: any) => {
+            apiCalls.push({ method: 'message.reply', args });
+            return { data: { message_id: 'mock_msg_002' } };
+          },
+        },
+        messageReaction: {
+          create: async (args: any) => {
+            apiCalls.push({ method: 'messageReaction.create', args });
+          },
+          delete: async (args: any) => {
+            apiCalls.push({ method: 'messageReaction.delete', args });
+          },
+        },
+        image: {
+          create: async () => ({ data: { image_key: 'img_mock' } }),
+          get: async () => Buffer.from('fake'),
+        },
+        file: {
+          create: async () => ({ data: { file_key: 'file_mock' } }),
+        },
+        messageResource: {
+          get: async () => Buffer.from('fake'),
+        },
+      },
+    },
+  };
+}
+
+/** Minimal no-op MemoryProvider */
+const noopMemory: MemoryProvider = {
+  getProfile: async () => null,
+  saveProfile: async () => {},
+  getEpisodes: async () => [],
+  saveEpisode: async () => {},
+  getSkills: async () => [],
+  saveSkill: async () => {},
+} as MemoryProvider;
+
+/** ConversationBuffer that records calls */
+function makeBuffer() {
+  const recorded: any[] = [];
+  return {
+    recorded,
+    record(chatId: string, entry: any) { recorded.push({ chatId, entry }); },
+    flush: async () => {},
+    startAutoFlush: () => {},
+    stopAutoFlush: () => {},
+  };
+}
+
+// ── Capture registered tool handlers via a fake McpServer ──
+
+const handlers = new Map<string, (args: any) => Promise<any>>();
+
+const fakeServer = {
+  registerTool(name: string, _config: any, handler: any) {
+    handlers.set(name, handler);
+  },
+};
+
+// ── Tests ──
+
+async function run() {
+  const client = mockLarkClient();
+  const botTrackerAdded: string[] = [];
+  const botTracker = {
+    ids: new Set<string>(),
+    maxSize: 500,
+    set: new Set<string>(),
+    add(id: string) { botTrackerAdded.push(id); this.ids.add(id); },
+    has(id: string) { return this.ids.has(id); },
+  };
+  const buffer = makeBuffer();
+  const ackReactions = new Map<string, string>();
+
+  // Register tools (captures handlers via fake server)
+  registerTools(
+    fakeServer as any,
+    client as any,
+    noopMemory,
+    buffer as any,
+    ackReactions,
+    botTracker as any,
+    undefined,
+  );
+
+  const replyHandler = handlers.get('reply');
+  if (!replyHandler) fail('replyHandler not captured');
+
+  const validCard = JSON.stringify({ type: 'template', data: { template_id: 't1' } });
+
+  // ── Test 1: valid card JSON → message.create with msg_type=interactive ──
+  apiCalls.length = 0;
+  botTrackerAdded.length = 0;
+  buffer.recorded.length = 0;
+
+  const r1 = await replyHandler({
+    chat_id: 'chat_001',
+    text: '',
+    card: validCard,
+  });
+
+  if (r1.isError) fail(`Test 1: unexpected error: ${r1.content[0].text}`);
+  if (r1.content[0].text !== 'Sent 1 card message') fail(`Test 1: wrong result: ${r1.content[0].text}`);
+
+  const createCall = apiCalls.find((c) => c.method === 'message.create');
+  if (!createCall) fail('Test 1: message.create not called');
+  if (createCall.args.data.msg_type !== 'interactive') fail('Test 1: msg_type should be interactive');
+
+  const sentContent = JSON.parse(createCall.args.data.content);
+  if (sentContent.type !== 'template') fail('Test 1: card content not passed through');
+
+  if (botTrackerAdded.length !== 1 || botTrackerAdded[0] !== 'mock_msg_001') {
+    fail(`Test 1: botTracker not updated: ${JSON.stringify(botTrackerAdded)}`);
+  }
+
+  // ── Test 2: invalid card JSON → isError ──
+  apiCalls.length = 0;
+  const r2 = await replyHandler({
+    chat_id: 'chat_001',
+    text: '',
+    card: 'not json{{{',
+  });
+
+  if (!r2.isError) fail('Test 2: should return isError for bad JSON');
+  if (!r2.content[0].text.includes('Invalid card JSON')) fail('Test 2: wrong error text');
+  if (apiCalls.length !== 0) fail('Test 2: should not call API on bad JSON');
+
+  // ── Test 3: card with reply_to → message.reply ──
+  apiCalls.length = 0;
+  botTrackerAdded.length = 0;
+
+  const r3 = await replyHandler({
+    chat_id: 'chat_001',
+    text: '',
+    card: validCard,
+    reply_to: 'om_reply_123',
+  });
+
+  if (r3.isError) fail('Test 3: unexpected error');
+  const replyCall = apiCalls.find((c) => c.method === 'message.reply');
+  if (!replyCall) fail('Test 3: message.reply not called');
+  if (replyCall.args.path.message_id !== 'om_reply_123') fail('Test 3: wrong reply_to');
+
+  // ── Test 4: card path records in conversationBuffer ──
+  apiCalls.length = 0;
+  buffer.recorded.length = 0;
+
+  await replyHandler({
+    chat_id: 'chat_buf',
+    text: 'some text',
+    card: validCard,
+  });
+
+  if (buffer.recorded.length !== 1) fail(`Test 4: buffer not recorded (got ${buffer.recorded.length})`);
+  if (buffer.recorded[0].chatId !== 'chat_buf') fail('Test 4: wrong chatId in buffer');
+  if (buffer.recorded[0].entry.role !== 'assistant') fail('Test 4: wrong role in buffer');
+
+  // ── Test 5: card path revokes ack reactions (exact match) ──
+  apiCalls.length = 0;
+  ackReactions.set('om_ack_msg', 'reaction_abc');
+
+  await replyHandler({
+    chat_id: 'chat_ack',
+    text: '',
+    card: validCard,
+    reply_to: 'om_ack_msg',
+  });
+
+  if (ackReactions.size !== 0) fail(`Test 5: ack reactions not cleared (size=${ackReactions.size})`);
+  const deleteCall = apiCalls.find((c) => c.method === 'messageReaction.delete');
+  if (!deleteCall) fail('Test 5: messageReaction.delete not called');
+  if (deleteCall.args.path.reaction_id !== 'reaction_abc') fail('Test 5: wrong reaction_id');
+
+  // ── Test 6: card path revokes all acks when no exact match ──
+  apiCalls.length = 0;
+  ackReactions.set('om_other1', 'r1');
+  ackReactions.set('om_other2', 'r2');
+
+  await replyHandler({
+    chat_id: 'chat_ack2',
+    text: '',
+    card: validCard,
+    // no reply_to — should revoke all pending acks
+  });
+
+  if (ackReactions.size !== 0) fail(`Test 6: ack reactions not fully cleared (size=${ackReactions.size})`);
+  const deleteCalls = apiCalls.filter((c) => c.method === 'messageReaction.delete');
+  if (deleteCalls.length !== 2) fail(`Test 6: expected 2 reaction deletes, got ${deleteCalls.length}`);
+
+  // ── Test 7: card with empty text uses '[card]' fallback in buffer ──
+  buffer.recorded.length = 0;
+
+  await replyHandler({
+    chat_id: 'chat_no_text',
+    text: '',
+    card: validCard,
+  });
+
+  if (buffer.recorded[0].entry.text !== '[card]') {
+    fail(`Test 7: expected '[card]' fallback, got '${buffer.recorded[0].entry.text}'`);
+  }
+
+  // ── Test 8: no card param → normal text path ──
+  apiCalls.length = 0;
+  buffer.recorded.length = 0;
+
+  const r8 = await replyHandler({
+    chat_id: 'chat_normal',
+    text: 'hello plain text',
+  });
+
+  if (r8.isError) fail('Test 8: unexpected error');
+  const normalCreate = apiCalls.find(
+    (c) => c.method === 'message.create' && c.args.data.msg_type === 'text'
+  );
+  if (!normalCreate) fail('Test 8: plain text path should use msg_type=text');
+
+  console.log('PASS');
+}
+
+run().catch((err) => {
+  console.error('FAIL:', err);
+  process.exit(1);
+});

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -28,4 +28,8 @@ echo "=== Job store unit checks ==="
 npx tsx scripts/job-smoke.ts
 
 echo ""
+echo "=== Reply raw-card unit checks ==="
+npx tsx scripts/reply-card-smoke.ts
+
+echo ""
 echo "All tests passed."

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -3,6 +3,7 @@ import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { appConfig } from './config.js';
+import { enrichmentPrompt } from './prompts.js';
 import { MessageQueue } from './queue.js';
 import type { MemoryProvider } from './memory/interface.js';
 import type { ConversationBuffer } from './memory/buffer.js';
@@ -458,12 +459,13 @@ export class LarkChannel {
     // Assemble
     if (parts.length === 0) return msg.text;
 
-    const memoryContext = parts.join('\n\n');
-    const parentContext = msg.parentContent
-      ? `\n[Quoted Message]\n${msg.parentContent}\n`
-      : '';
-
-    return `[Memory Context]\n${memoryContext}\n${parentContext}\n[Current Message]\nFrom: ${msg.senderId} in ${msg.chatId}\n${msg.text}`;
+    return enrichmentPrompt(
+      parts.join('\n\n'),
+      msg.parentContent,
+      msg.senderId,
+      msg.chatId,
+      msg.text
+    );
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '0.8.2' },
+    { name: 'claude-lark-plugin', version: '0.8.3' },
     {
       capabilities: {
         logging: {},

--- a/src/memory/distiller.ts
+++ b/src/memory/distiller.ts
@@ -1,46 +1,27 @@
 import type { BufferedMessage } from './buffer.js';
-import type { MemoryProvider } from './interface.js';
+import {
+  flushPrompt,
+  profileDistillationPrompt,
+} from '../prompts.js';
 
 /**
  * Distillation Stage 1: Buffer → Episode.
- * Builds a system prompt for Claude to summarize a conversation and save it to memory.
  */
 export function buildFlushPrompt(chatId: string, messages: BufferedMessage[]): string {
-  const messageLines = messages.map(
-    (m) => `[${m.timestamp}] ${m.role === 'user' ? m.senderId : 'bot'}: ${m.text}`
-  );
+  const conversation = messages
+    .map((m) => `[${m.timestamp}] ${m.role === 'user' ? m.senderId : 'bot'}: ${m.text}`)
+    .join('\n');
 
-  return `[Auto-memory-flush]
-The following is a conversation from chat ${chatId} (${messages.length} messages).
-Please:
-1. Write a 3-5 sentence summary focusing on: what was discussed, what was decided, what was resolved, and any open items.
-2. If you identified new user preferences or important facts, call save_memory(type="profile", open_id=<userId>, ...) for each user.
-3. Call save_memory(type="chat", chat_id="${chatId}", ...) with the conversation summary.
-
---- Conversation ---
-${messageLines.join('\n')}
---- End ---`;
+  return flushPrompt(chatId, conversation, messages.length);
 }
 
 /**
- * Distillation Stage 2: Episodes → Profile (for future use).
- * Builds a prompt for Claude to extract durable facts from episodes into a profile.
+ * Distillation Stage 2: Episodes → Profile.
  */
 export function buildProfileDistillationPrompt(
   userId: string,
   currentProfile: string | null,
   episodeSummaries: string[]
 ): string {
-  return `[Profile-distillation]
-Current user profile:
-${currentProfile || '(empty — no profile yet)'}
-
-Recent conversation summaries (${episodeSummaries.length}):
-${episodeSummaries.join('\n\n')}
-
-Please update the user profile:
-- ADD: new preferences, facts, expertise discovered in conversations
-- UPDATE: information that has changed (e.g., switched tech stack, new project)
-- REMOVE: outdated information no longer relevant
-Output the complete updated profile and call save_memory(type="profile", open_id="${userId}", ...).`;
+  return profileDistillationPrompt(userId, currentProfile, episodeSummaries);
 }

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,0 +1,76 @@
+/**
+ * Centralized prompt templates.
+ * All hardcoded prompts/instructions live here for easy tuning.
+ */
+
+/**
+ * Distillation Stage 1: Buffer → Episode.
+ * Instructs Claude to summarize a conversation and persist it as memory.
+ */
+export function flushPrompt(chatId: string, conversation: string, messageCount: number): string {
+  return `[Auto-memory-flush]
+The following is a conversation from chat ${chatId} (${messageCount} messages).
+Please:
+1. Write a 3-5 sentence summary focusing on: what was discussed, what was decided, what was resolved, and any open items.
+2. If you identified new user preferences or important facts, call save_memory(type="profile", open_id=<userId>, ...) for each user.
+3. Call save_memory(type="chat", chat_id="${chatId}", ...) with the conversation summary.
+
+--- Conversation ---
+${conversation}
+--- End ---`;
+}
+
+/**
+ * Distillation Stage 2: Episodes → Profile.
+ * Instructs Claude to extract durable facts from episode summaries into a user profile.
+ */
+export function profileDistillationPrompt(
+  userId: string,
+  currentProfile: string | null,
+  episodeSummaries: string[]
+): string {
+  return `[Profile-distillation]
+Current user profile:
+${currentProfile || '(empty — no profile yet)'}
+
+Recent conversation summaries (${episodeSummaries.length}):
+${episodeSummaries.join('\n\n')}
+
+Please update the user profile:
+- ADD: new preferences, facts, expertise discovered in conversations
+- UPDATE: information that has changed (e.g., switched tech stack, new project)
+- REMOVE: outdated information no longer relevant
+Output the complete updated profile and call save_memory(type="profile", open_id="${userId}", ...).`;
+}
+
+/**
+ * CronJob prompt injection.
+ * Wraps the user's prompt with execution instructions for Claude.
+ */
+export function cronJobPrompt(jobName: string, targetChatId: string, prompt: string): string {
+  return [
+    `[CronJob: ${jobName}]`,
+    `Execute this task and reply to chat_id=${targetChatId} with the result.`,
+    `Do NOT reply to any other chat. Use a subagent when possible so the main thread stays responsive.`,
+    ``,
+    prompt,
+  ].join('\n');
+}
+
+/**
+ * Memory enrichment assembly.
+ * Wraps the user's message with memory context before forwarding to Claude.
+ */
+export function enrichmentPrompt(
+  memoryContext: string,
+  parentContent: string | undefined,
+  senderId: string,
+  chatId: string,
+  text: string
+): string {
+  const parentContext = parentContent
+    ? `\n[Quoted Message]\n${parentContent}\n`
+    : '';
+
+  return `[Memory Context]\n${memoryContext}\n${parentContext}\n[Current Message]\nFrom: ${senderId} in ${chatId}\n${text}`;
+}

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -8,6 +8,7 @@
 import * as Lark from '@larksuiteoapi/node-sdk';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { appConfig } from './config.js';
+import { cronJobPrompt } from './prompts.js';
 import {
   listAllJobs,
   writeJob,
@@ -238,13 +239,11 @@ export class JobScheduler {
    * prompt type: inject prompt into Claude's channel via MCP notification.
    */
   private async executePromptJob(job: JobFile): Promise<void> {
-    const promptContent = [
-      `[CronJob: ${job.meta.name}]`,
-      `Execute this task and reply to chat_id=${job.meta.target_chat_id} with the result.`,
-      `Do NOT reply to any other chat. Use a subagent when possible so the main thread stays responsive.`,
-      ``,
-      job.meta.prompt ?? '',
-    ].join('\n');
+    const promptContent = cronJobPrompt(
+      job.meta.name,
+      job.meta.target_chat_id,
+      job.meta.prompt ?? ''
+    );
 
     await this.server.notification({
       method: 'notifications/claude/channel',

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -21,7 +21,7 @@ import {
 } from './job-store.js';
 
 /**
- * Register all 6 MCP tools on the server.
+ * Register all MCP tools on the server.
  */
 export function registerTools(
   server: McpServer,
@@ -37,10 +37,16 @@ export function registerTools(
     'reply',
     {
       description:
-        'Send a reply to a Feishu chat. Plain text by default; long or markdown-rich content auto-renders as a Feishu card. Supports optional images (≤10 MB) or files (≤30 MB).',
+        'Send a reply to a Feishu chat. Plain text by default; long or markdown-rich content auto-renders as a Feishu card. Pass "card" param with raw Schema 2.0 JSON to send a pre-built card directly.',
       inputSchema: z.object({
         chat_id: z.string().describe('The chat ID to reply in'),
-        text: z.string().describe('The text content to send'),
+        text: z.string().describe('The text content to send (ignored when card is provided)'),
+        card: z
+          .string()
+          .optional()
+          .describe(
+            'Raw Feishu Schema 2.0 card JSON string. When provided, sends the card directly without buildCards conversion. Use this for pre-built cards from scripts/skills.'
+          ),
         reply_to: z.string().optional().describe('Message ID to reply to (quoted reply)'),
         thread_id: z
           .string()
@@ -68,10 +74,10 @@ export function registerTools(
             })
           )
           .optional()
-          .describe('Optional attachments'),
+          .describe('Optional attachments (ignored when card is provided)'),
       }),
     },
-    async ({ chat_id, text, reply_to, thread_id, format, footer, files }) => {
+    async ({ chat_id, text, card, reply_to, thread_id, format, footer, files }) => {
       // Auto-correct reply_to from the plugin's per-thread tracker when Claude
       // omits it but passes thread_id. Explicit reply_to from Claude always wins.
       let effectiveReplyTo = reply_to;
@@ -83,6 +89,81 @@ export function registerTools(
             `[tools] Auto-filled reply_to=${latest.messageId} for thread ${thread_id}`
           );
         }
+      }
+
+      // Helper: record in buffer + revoke ack (shared by card & normal paths)
+      function recordAndRevokeAck(replyText: string) {
+        conversationBuffer?.record(chat_id, {
+          role: 'assistant',
+          senderId: 'bot',
+          text: replyText.slice(0, 500),
+          timestamp: new Date().toISOString(),
+        });
+
+        if (ackReactions && ackReactions.size > 0) {
+          const msgId = effectiveReplyTo || '';
+          const reactionId = msgId ? ackReactions.get(msgId) : undefined;
+          if (reactionId) {
+            ackReactions.delete(msgId);
+            client.im.v1.messageReaction.delete({
+              path: { message_id: msgId, reaction_id: reactionId },
+            }).catch(() => {});
+          } else {
+            for (const [mid, rid] of ackReactions.entries()) {
+              ackReactions.delete(mid);
+              client.im.v1.messageReaction.delete({
+                path: { message_id: mid, reaction_id: rid },
+              }).catch(() => {});
+            }
+          }
+        }
+      }
+
+      // Raw card JSON path — bypass buildCards entirely
+      if (card) {
+        let cardObj: object;
+        try {
+          cardObj = JSON.parse(card);
+        } catch {
+          return {
+            content: [{ type: 'text' as const, text: 'Invalid card JSON' }],
+            isError: true,
+          };
+        }
+        const content = JSON.stringify(cardObj);
+        try {
+          let resp: any;
+          if (effectiveReplyTo) {
+            resp = await client.im.v1.message.reply({
+              path: { message_id: effectiveReplyTo },
+              data: { content, msg_type: 'interactive' },
+            });
+          } else {
+            resp = await client.im.v1.message.create({
+              params: { receive_id_type: 'chat_id' },
+              data: {
+                receive_id: chat_id,
+                content,
+                msg_type: 'interactive',
+              },
+            });
+          }
+          const sentId = resp?.data?.message_id;
+          if (sentId && botMessageTracker) botMessageTracker.add(sentId);
+        } catch (err: any) {
+          const apiError = err?.response?.data ?? err?.data;
+          if (apiError?.code && apiError?.msg) {
+            console.error(`[tools] Feishu API error [${apiError.code}]: ${apiError.msg}`);
+            throw new Error(`Feishu API [${apiError.code}]: ${apiError.msg}`);
+          }
+          throw err;
+        }
+
+        recordAndRevokeAck((text || '[card]'));
+
+        return {
+          content: [{ type: 'text' as const, text: 'Sent 1 card message' }],
+        };
       }
 
       // Dispatch: card path vs plain-text path
@@ -231,34 +312,7 @@ export function registerTools(
         }
       }
 
-      // Record assistant response in buffer for distillation
-      conversationBuffer?.record(chat_id, {
-        role: 'assistant',
-        senderId: 'bot',
-        text: text.slice(0, 500), // truncate for buffer efficiency
-        timestamp: new Date().toISOString(),
-      });
-
-      // Revoke ack reaction — try effective reply_to first, then scan all pending acks
-      if (ackReactions && ackReactions.size > 0) {
-        const msgId = effectiveReplyTo || '';
-        const reactionId = msgId ? ackReactions.get(msgId) : undefined;
-        if (reactionId) {
-          // Exact match on reply_to
-          ackReactions.delete(msgId);
-          client.im.v1.messageReaction.delete({
-            path: { message_id: msgId, reaction_id: reactionId },
-          }).catch(() => {});
-        } else {
-          // Fallback: revoke all pending acks (handles case where Claude didn't pass reply_to)
-          for (const [mid, rid] of ackReactions.entries()) {
-            ackReactions.delete(mid);
-            client.im.v1.messageReaction.delete({
-              path: { message_id: mid, reaction_id: rid },
-            }).catch(() => {});
-          }
-        }
-      }
+      recordAndRevokeAck(text);
 
       return {
         content: [{ type: 'text' as const, text: `Sent ${sentCount} message(s)` }],
@@ -443,7 +497,7 @@ export function registerTools(
         chat_id: z.string().optional().describe('Chat ID where this skill was created (for context)'),
       }),
     },
-    async ({ name, description, content, chat_id }) => {
+    async ({ name, description, content }) => {
       await memoryProvider.saveSkill(name, description, content);
       return {
         content: [{ type: 'text' as const, text: `Saved skill "${name}": ${description}` }],


### PR DESCRIPTION
Closes #32

## Summary
- Add `card` param to `reply` tool for sending pre-built Schema 2.0 cards
- Fix card path skipping buffer recording and ack reaction revocation
- Extract all hardcoded prompts to `src/prompts.ts` for centralized management
- Deduplicate buffer+ack logic into shared `recordAndRevokeAck()` helper
- Add 8 smoke tests for the raw card path

## Test plan
- [x] `npm run typecheck`
- [x] `bash scripts/test.sh` (incl. new reply-card-smoke tests)
- [x] Manual: send a raw-card reply from Claude and verify buffer + ack revoke both fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)