### PR TITLE
fix: image auto-download (v0.8.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.8.4] - 2026-04-17
+
+### Fixed
+- **Image auto-download now works** (fixes #15): user-uploaded images are downloaded to `~/.claude/channels/lark/inbox/` as intended. Previously the plugin used `im.v1.image.get` which only works for images the bot itself uploaded — it silently failed for user-sent images. Switched to `im.v1.messageResource.get` with `type: 'image'` which is the correct API for downloading user-uploaded resources.
+- `download_attachment` tool: also switched all paths to `messageResource.get` (routing `type` by `img_` prefix: image → `'image'`, file/audio/video → `'file'` per Feishu API semantics). All resource types now download consistently through the same API.
+
 ## [0.8.3] - 2026-04-17
 
 ### Added
@@ -142,6 +148,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Score-based filtering (`LARK_MIN_SEARCH_SCORE`)
 - HealthCheck for memory provider connectivity
 
+[0.8.4]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.8.4
 [0.8.3]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.8.3
 [0.8.2]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.8.2
 [0.8.1]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.8.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with pluggable memory",
   "type": "module",
   "main": "src/index.ts",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -471,12 +471,16 @@ export class LarkChannel {
   /**
    * Download an image by image_key and save to inboxDir.
    * Returns the absolute path to the saved file, or undefined on failure.
+   *
+   * Uses messageResource.get because image.get can only download images that
+   * the bot itself uploaded — not images users send to the bot.
    */
   private async downloadImage(imageKey: string, messageId: string): Promise<string | undefined> {
     try {
       mkdirSync(appConfig.inboxDir, { recursive: true });
-      const resp = await this.client.im.v1.image.get({
-        path: { image_key: imageKey },
+      const resp = await this.client.im.v1.messageResource.get({
+        path: { message_id: messageId, file_key: imageKey },
+        params: { type: 'image' },
       } as any);
       if (resp) {
         const filename = `${Date.now()}-${imageKey}.png`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '0.8.3' },
+    { name: 'claude-lark-plugin', version: '0.8.4' },
     {
       capabilities: {
         logging: {},

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -398,17 +398,14 @@ export function registerTools(
       const inboxDir = appConfig.inboxDir;
       await fs.mkdir(inboxDir, { recursive: true });
       try {
-        let data: any;
-        if (file_key.startsWith('img_')) {
-          data = await client.im.v1.image.get({
-            path: { image_key: file_key },
-          });
-        } else {
-          data = await client.im.v1.messageResource.get({
-            path: { message_id, file_key },
-            params: { type: 'file' },
-          });
-        }
+        // Always use messageResource.get for user-uploaded resources.
+        // image.get only works for images the bot itself uploaded.
+        // Route type by key prefix: img_* → image, otherwise → file.
+        const resourceType = file_key.startsWith('img_') ? 'image' : 'file';
+        const data: any = await client.im.v1.messageResource.get({
+          path: { message_id, file_key },
+          params: { type: resourceType },
+        });
         if (data) {
           const filePath = path.join(inboxDir, file_key);
           await fs.writeFile(filePath, data as any);


### PR DESCRIPTION
Closes #15

## Problem

When a user sends an image to the bot, the plugin tried to auto-download it to \`~/.claude/channels/lark/inbox/\` but silently failed. Images never appeared in the inbox, and the \`download_attachment\` tool also couldn't retrieve user-sent images.

## Root Cause

Both code paths used \`im.v1.image.get\`, but per Feishu docs that API **only works for images the bot itself uploaded**. For images users send to the bot, the correct API is \`im.v1.messageResource.get\` with \`type: 'image'\`. The old API call returned a permission error which was swallowed by the catch block (only a debug log was written).

## Fix

- \`src/channel.ts\`: \`downloadImage()\` now uses \`messageResource.get\`
- \`src/tools.ts\`: \`download_attachment\` unified to \`messageResource.get\`, routing \`type\` by \`img_\` prefix (net -4 lines, clearer logic)
- Bump version to 0.8.4

## Test plan

- [x] \`npm test\` passes (6 test sections)
- [ ] Send an image to the bot → file appears in \`~/.claude/channels/lark/inbox/\`
- [ ] Claude receives \`image_path\` in notification meta and can \`Read\` it
- [ ] \`download_attachment\` works for both \`img_\`-prefixed keys (images) and other keys (files)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)