### PR TITLE
feat: IdentitySession + CronJob visibility (v0.9.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "0.8.5",
+      "version": "0.9.0",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "author": {
     "name": "IS908"
   },

--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,7 @@ LARK_APP_SECRET=
 # LARK_MIN_SEARCH_SCORE=0.3     # Minimum relevance score for episode search
 # LARK_MAX_SEARCH_RESULTS=2     # Max episodes per query
 # LARK_INACTIVITY_HOURS=3       # Auto-flush trigger threshold
+
+# === Optional — Identity / privacy (v0.9.0+) ===
+# LARK_OWNER_OPEN_ID=            # Operator open_id — enables terminal skills like /lark:jobs
+# LARK_IDENTITY_SESSION_TTL_MS=  # Session entry TTL in ms (default: max(2h, inactivity × 2))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.9.0] - 2026-04-19
+
+### Added
+- **`IdentitySession`** (`src/identity-session.ts`) — server-side `(chat_id, thread_id?) → open_id` mapping populated from Feishu events. Sensitive MCP tools now consult the session instead of trusting Claude-declared identity parameters. Closes a privacy hole where a socially-engineered prompt could make tools act on behalf of another user.
+- **`send_chat_id` and `origin_chat_id` on `JobMeta`** — enables visibility filtering based on where a job delivers output vs where it was created. Legacy jobs are backfilled from `target_chat_id` on read.
+- **`LARK_OWNER_OPEN_ID` config key** — identity fallback for terminal skill invocations. Terminal skills pass the reserved `__terminal__` chat id; the session resolves it to this owner. Without this set, terminal-side sensitive operations are denied.
+- **`LARK_IDENTITY_SESSION_TTL_MS` config key** — optional override for session entry staleness. Default is `max(2h, LARK_INACTIVITY_HOURS × 2h)` so session entries always outlive the auto-flush window — otherwise flush-triggered `save_memory` calls would fail to resolve the caller.
+- `scripts/identity-smoke.ts` — 8 smoke assertions covering chat/thread precedence, fallback, terminal sentinel, unknown chat, staleness, cleanup, and overwrite.
+
+### Changed
+- **`list_jobs` now filters by rendering visibility.** In a private chat, the caller sees jobs they created. In a group chat, everyone sees jobs whose `send_chat_id` matches that group — with prompt/content/meta redacted for non-owners (owner identity and schedule remain visible for accountability). Closes the hole where group members could inspect each other's full job prompts.
+- **`update_job` / `delete_job` restricted to job owner.** Visibility ≠ mutation rights.
+- **`save_memory` no longer accepts a client-supplied `open_id`.** Profile writes always target the resolved caller — you cannot write facts "on behalf of" another user.
+- **`create_job` now requires `chat_id`** (used to resolve caller identity and populate `origin_chat_id`). The `created_by` parameter is removed; creator is derived from the session.
+- **Scheduler attaches a unique `thread_id`** (`job-<id>-<timestamp>`) to each cronjob execution so cronjob session entries don't clobber concurrent inbound human messages in the same chat.
+- Cronjob deliveries use `send_chat_id` (same value as `target_chat_id` for freshly created jobs).
+
+### Security
+- Group members can no longer list or inspect other users' jobs in a group — `list_jobs` returns only the jobs delivering output to that group, with free-form content redacted for non-owners.
+- Socially-engineered prompts ("act as kk and list their jobs") can no longer direct tools to act on behalf of a different user — the caller is derived server-side from the Feishu event, not from tool arguments.
+- Terminal skill invocations now require `LARK_OWNER_OPEN_ID` to be configured; missing or mismatched identity results in tool rejection.
+- **Defensive posture for the `__terminal__` sentinel.** The MCP server instructions explicitly warn Claude never to substitute `__terminal__` for a real `chat_id`, and `src/identity-session.ts` carries a SECURITY NOTE documenting the trust-but-verify model. A stronger server-side heuristic (e.g. reject `__terminal__` when a fresh real-chat session entry exists) is deferred to Phase 3. Practical risk is low — the sentinel is not surfaced in any notification metadata, so Claude would need to invent the string on its own.
+- Thread-id handling strengthened at the parameter-description level on all sensitive tools (`save_memory`, `create_job`, `list_jobs`, `update_job`, `delete_job`): Claude is told explicitly that omitting `thread_id` in a cronjob turn silently attributes the action to the wrong user. Prevents a subtle cross-turn leak where a cronjob-owned action would be recorded against the last human speaker's identity.
+
+### Migration
+- **Legacy jobs with empty `created_by`** (created before the field was enforced) are backfilled to `LARK_OWNER_OPEN_ID` on read. This keeps the operator's existing jobs mutable via `update_job` / `delete_job` after upgrade. If `LARK_OWNER_OPEN_ID` is unset, legacy jobs with empty `created_by` remain un-mutable — set the env var and restart to recover them.
+- **Legacy jobs missing `send_chat_id` / `origin_chat_id`** are backfilled from `target_chat_id` on read. No operator action required.
+- **`MEMORY_PROVIDER=openviking` or `mem0`** users: already migrated in v0.8.5 (those backends were dropped). No v0.9.0-specific migration.
+
 ## [0.8.5] - 2026-04-19
 
 ### Removed
@@ -168,6 +197,7 @@ Precondition for the privacy redesign (#35). A pluggable abstraction made every 
 - Score-based filtering (`LARK_MIN_SEARCH_SCORE`)
 - HealthCheck for memory provider connectivity
 
+[0.9.0]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.9.0
 [0.8.5]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.8.5
 [0.8.4]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.8.4
 [0.8.3]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.8.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,9 @@ src/memory/
 
 **Reaction flow:** Feishu reaction event → `handleReactionEvent` → filter (bot self, bot messages only, whitelists) → forward to Claude via channel notification.
 
-**CronJob flow:** `JobScheduler.tick()` every 60s → read all job files → for each active job where `next_run_at <= now` → execute (message: direct Feishu API / prompt: inject via `notifications/claude/channel`) → update `runtime` in job file. On startup, `recoverMissedJobs()` runs the same check once for crash recovery.
+**CronJob flow:** `JobScheduler.tick()` every 60s → read all job files → for each active job where `next_run_at <= now` → execute (message: direct Feishu API / prompt: inject via `notifications/claude/channel` under a unique `thread_id` + bind session identity to `job.created_by`) → update `runtime` in job file. On startup, `recoverMissedJobs()` runs the same check once for crash recovery.
+
+**Identity flow (v0.9.0+):** Every inbound message calls `identitySession.setCaller(chatId, threadId, senderId)` before enqueue. Sensitive MCP tools (`save_memory`, `create_job`, `list_jobs`, `update_job`, `delete_job`) derive the caller from the session via `resolveCaller(chat_id, thread_id)` — they never trust Claude-declared identity parameters. Terminal skills use the reserved `chat_id = "__terminal__"` which resolves to `LARK_OWNER_OPEN_ID`.
 
 ## Key Design Decisions
 
@@ -46,6 +48,8 @@ src/memory/
 - **Single-instance lock**: PID-based lock file in `/tmp/` prevents duplicate WebSocket connections.
 - **Config location**: All user config lives at `~/.claude/channels/lark/.env`, not in the repo.
 - **Memory is local-only**: All memory (profiles, episodes, skills) lives as markdown files under `~/.claude/channels/lark/memories/`. No remote backends — this keeps the trust boundary at OS file permissions and avoids vector-index policy questions for sensitive content.
+- **Identity is server-derived**: `IdentitySession` maps `(chat_id, thread_id?) → open_id` from authenticated Feishu events. MCP tools never accept a client-declared `open_id` or `created_by` — those are resolved server-side. Trust anchor = Feishu webhook signature.
+- **CronJob visibility**: `list_jobs` filters by rendering-visibility — private chat shows caller's own jobs; group shows jobs whose `send_chat_id` matches the current chat (with prompt bodies redacted for non-owners). `update_job` / `delete_job` are owner-only.
 - **Image auto-download**: Images are downloaded to `~/.claude/channels/lark/inbox/` on receive. Claude reads local paths via `image_path` in notification meta.
 - **Ack reaction**: Configurable emoji (`LARK_ACK_EMOJI`, default `MeMeMe`) sent on receive, auto-revoked after reply. Fire-and-forget, won't block message processing.
 - **Bot message tracking**: `BotMessageTracker` (default 500, FIFO, configurable via `LARK_BOT_MESSAGE_TRACKER_SIZE`) tracks bot-sent message IDs. Used to filter reaction events — only reactions on bot messages are forwarded to Claude.
@@ -53,6 +57,8 @@ src/memory/
 ## Configuration
 
 Required env vars: `LARK_APP_ID`, `LARK_APP_SECRET` (in `~/.claude/channels/lark/.env`).
+
+Optional but recommended: `LARK_OWNER_OPEN_ID` — enables terminal-side skills (e.g. `/lark:jobs`) to act as the operator. Without it, terminal tool calls are denied.
 
 The `/lark:configure` skill (in `skills/configure/SKILL.md`) provides interactive setup within Claude Code.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ The plugin connects to Feishu via the Lark SDK WebSocket client, receives messag
 - User profiles, chat episodes, thread episodes, and global skills
 - Memory-enriched context injection on every incoming message
 
+### Privacy & Security (v0.9.0+)
+
+- **Server-derived caller identity**: sensitive tools (`save_memory`, `create_job`, `list_jobs`, `update_job`, `delete_job`) resolve the calling user from the authenticated Feishu event stream, not from tool arguments — socially-engineered prompts cannot act on behalf of another user
+- **`list_jobs` visibility filter**: in a group chat, members only see jobs whose `send_chat_id` matches that group (with prompt bodies redacted for non-owners); in a private chat, the caller sees their own jobs. Group members can no longer inspect each other's private jobs
+- **Owner-only mutations**: `update_job` / `delete_job` require `caller == created_by`
+- **CronJob isolation**: each cronjob execution runs under a unique `thread_id` so scheduled actions don't collide with concurrent human messages in the same chat
+- **Terminal fallback**: terminal skill invocations (e.g. `/lark:jobs`) resolve via the reserved `__terminal__` chat id → `LARK_OWNER_OPEN_ID`
+
 ### Scheduled Jobs (CronJob)
 
 - **Two job types**: `message` (send fixed content, deterministic) and `prompt` (Claude executes and replies, best-effort)
@@ -239,6 +247,13 @@ On every incoming message, the plugin injects relevant memory context in this or
 | `LARK_MAX_SEARCH_RESULTS` | `2` | Maximum number of memory search results to inject |
 | `LARK_INACTIVITY_HOURS` | `3` | Hours of inactivity before buffer flush to episodic memory |
 
+### Optional -- Identity / privacy (v0.9.0+)
+
+| Variable | Default | Description |
+|---|---|---|
+| `LARK_OWNER_OPEN_ID` | (empty) | Operator open_id. Enables terminal skill invocations (e.g. `/lark:jobs`) to resolve the caller via the reserved `__terminal__` chat id. When unset, terminal-side sensitive operations are denied. |
+| `LARK_IDENTITY_SESSION_TTL_MS` | `max(2h, LARK_INACTIVITY_HOURS × 2h)` | Lifetime of a server-side `(chat_id, thread_id?) → open_id` session entry. Must exceed the auto-flush window so distillation-triggered tool calls still resolve to the last real user. |
+
 ---
 
 ## Interactive Configuration
@@ -320,12 +335,12 @@ The plugin registers the following MCP tools for Claude to use:
 | `edit_message` | Edit a previously sent bot message (text or card_markdown). |
 | `react` | Add an emoji reaction to a message. |
 | `download_attachment` | Download an attachment (image, file, audio, video) from a message to the local inbox. |
-| `save_memory` | Save a memory entry (profile, chat episode, or thread episode) for cross-session recall. |
+| `save_memory` | Save a memory entry (profile / chat episode / thread episode) for cross-session recall. Profile writes target the resolved caller (server-derived, v0.9.0+). Requires `chat_id`. |
 | `save_skill` | Save a reusable procedure as a globally searchable skill. |
-| `create_job` | Create a scheduled cronjob (message or prompt type). |
-| `list_jobs` | List all cronjobs and their status. |
-| `update_job` | Update a cronjob (schedule, content, pause/resume). |
-| `delete_job` | Delete a cronjob. |
+| `create_job` | Create a scheduled cronjob (message or prompt type). Creator derived from session; requires `chat_id` (used to populate `origin_chat_id`). |
+| `list_jobs` | List cronjobs visible in the current chat. Filter follows rendering-visibility: private → caller's own jobs, group → jobs with `send_chat_id == currentChat` (prompts redacted for non-owners). Requires `chat_id`. |
+| `update_job` | Update a cronjob (schedule, content, pause/resume). Owner-only. Requires `chat_id`. |
+| `delete_job` | Delete a cronjob. Owner-only. Requires `chat_id`. |
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -42,6 +42,14 @@
 - 自动蒸馏：对话静默超时后自动触发摘要
 - 本地 markdown 文件存储，路径 `~/.claude/channels/lark/memories/`
 
+### 隐私与安全（v0.9.0+）
+
+- **服务端派生的调用者身份**：敏感工具（`save_memory` / `create_job` / `list_jobs` / `update_job` / `delete_job`）从飞书事件流派生调用者身份，不信任工具参数——社工提示无法假冒他人操作
+- **`list_jobs` 可见性过滤**：群聊里只能看到 `send_chat_id` 匹配本群的 job（非 owner 看不到 prompt 正文）；私聊里只能看到自己建的 job。群成员不再能互相窥探定时任务
+- **仅 owner 可改**：`update_job` / `delete_job` 要求 `caller == created_by`
+- **CronJob 身份隔离**：每次 cronjob 触发使用独立 `thread_id`，不会和同一 chat 的真人消息串线
+- **终端回退**：`/lark:jobs` 等终端技能通过保留的 `__terminal__` chat id 回退到 `LARK_OWNER_OPEN_ID`
+
 ### 定时任务（CronJob）
 
 - **两种任务类型**：`message`（发送固定内容，确定性）和 `prompt`（Claude 执行后回复，尽力而为）
@@ -223,6 +231,13 @@ node -e "console.log(require('./package.json').version)"
 | `LARK_MAX_SEARCH_RESULTS` | `2` | 每次查询返回的最大情景数 |
 | `LARK_INACTIVITY_HOURS` | `3` | 自动蒸馏触发的静默时长（小时） |
 
+### 可选 -- 身份 / 隐私（v0.9.0+）
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `LARK_OWNER_OPEN_ID` | （空） | 运营者 open_id。用于终端技能（如 `/lark:jobs`）通过 `__terminal__` 哨兵 chat_id 解析调用者。未设置时，终端侧的敏感操作将被拒绝 |
+| `LARK_IDENTITY_SESSION_TTL_MS` | `max(2h, LARK_INACTIVITY_HOURS × 2h)` | 服务端 `(chat_id, thread_id?) → open_id` 会话条目的 TTL。必须超过自动蒸馏窗口，以保证 flush 触发的工具调用仍能解析到最后的真实用户 |
+
 ---
 
 ## 交互式配置
@@ -313,8 +328,12 @@ tmux kill-session -t lark
 | `edit_message` | `(message_id, text, format?)` | 编辑已发送的机器人消息（支持 text 和 card_markdown 格式） |
 | `react` | `(message_id, emoji)` | 对消息添加表情回复 |
 | `download_attachment` | `(message_id, file_key)` | 下载消息中的附件到本地收件箱 |
-| `save_memory` | `(type, content, reason, chat_id?, thread_id?, open_id?)` | 保存用户画像、会话情景或话题情景 |
+| `save_memory` | `(type, content, reason, chat_id, thread_id?)` | 保存用户画像、会话情景或话题情景。画像写入总是针对调用者本人（v0.9.0 起），不再接受 `open_id` 参数 |
 | `save_skill` | `(name, description, content, chat_id?)` | 保存可复用的操作流程为全局技能 |
+| `create_job` | `(name, type, schedule, prompt?, content?, target_chat_id, chat_id, thread_id?)` | 创建定时任务。创建者由 session 派生，不再接受 `created_by`；`chat_id` 用于派生调用者身份并填充 `origin_chat_id` |
+| `list_jobs` | `(status?, chat_id, thread_id?)` | 列出当前 chat 可见的 job。私聊返回 caller 自己建的；群里返回 `send_chat_id` 为本群的（非 owner 视图脱敏 prompt）|
+| `update_job` | `(id, status?, schedule?, prompt?, content?, name?, chat_id, thread_id?)` | 修改 job。仅 owner 可操作 |
+| `delete_job` | `(id, chat_id, thread_id?)` | 删除 job。仅 owner 可操作 |
 
 ---
 

--- a/docs/superpowers/plans/2026-04-19-phase1-identity-cronjob-visibility.md
+++ b/docs/superpowers/plans/2026-04-19-phase1-identity-cronjob-visibility.md
@@ -1,0 +1,743 @@
+# Phase 1 — IdentitySession + CronJob Visibility
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the two highest-severity leaks — (a) MCP tools trusting Claude-declared identity and (b) `list_jobs` exposing other users' jobs in groups — by introducing a server-side `IdentitySession` and filtering `list_jobs` by `send_chat_id`.
+
+**Architecture:** Add in-memory `(chat_id, thread_id?) → open_id` mapping populated from Feishu events. Extend job schema with `send_chat_id`/`origin_chat_id`. Sensitive tools require `chat_id` in args and read caller from the session. Scheduler sets session on cronjob trigger under a unique `thread_id` to avoid clobbering inbound human messages. Terminal skills pass a reserved `__terminal__` chat id that falls back to `LARK_OWNER_OPEN_ID`.
+
+**Tech Stack:** TypeScript (ESM), MCP TypeScript SDK, tsx smoke tests, zod schemas.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-lark-privacy-design.md` (sections: "IdentitySession", "CronJob Visibility", "Rendering Visibility")
+
+**Issue:** #35 (phase 1 of 3)
+
+---
+
+## File Structure
+
+| File | Responsibility | Create/Modify |
+|---|---|---|
+| `src/identity-session.ts` | In-memory caller mapping, cleanup, terminal fallback | Create |
+| `scripts/identity-smoke.ts` | Unit coverage for session behavior | Create |
+| `src/job-store.ts` | Extend `JobMeta` with `send_chat_id`, `origin_chat_id` | Modify |
+| `src/channel.ts` | Call `setCaller` on inbound messages | Modify |
+| `src/scheduler.ts` | Call `setCaller` on cronjob trigger with generated thread_id | Modify |
+| `src/tools.ts` | Require `chat_id` on sensitive tools; filter by session + visibility | Modify |
+| `src/index.ts` | Instantiate and wire IdentitySession | Modify |
+| `scripts/test.sh` | Add identity smoke to test runner | Modify |
+| `CHANGELOG.md` | Document v0.9.0 | Modify |
+| `.claude-plugin/plugin.json`, `package.json` | Bump to v0.9.0 | Modify |
+
+---
+
+## Task 1: IdentitySession module
+
+**Files:**
+- Create: `src/identity-session.ts`
+
+- [ ] **Step 1.1: Write the module**
+
+```typescript
+// src/identity-session.ts
+/**
+ * In-memory mapping from (chat_id, thread_id?) to the Feishu open_id of the
+ * current caller. Populated by channel.ts on inbound messages and by
+ * scheduler.ts when a cronjob fires. Consumed by sensitive MCP tools so they
+ * never need to trust Claude-declared identity arguments.
+ *
+ * Intentionally not persisted — the next inbound message or cronjob tick will
+ * re-populate relevant entries, so crash/restart is safe.
+ */
+
+const TERMINAL_CHAT_ID = '__terminal__';
+
+interface SessionEntry {
+  userId: string;
+  updatedAt: number;
+}
+
+export class IdentitySession {
+  private map = new Map<string, SessionEntry>();
+
+  constructor(
+    private readonly ownerFallback: () => string | null,
+    private readonly maxAgeMs = 3600_000,
+  ) {}
+
+  private key(chatId: string, threadId?: string): string {
+    return threadId ? `${chatId}#${threadId}` : chatId;
+  }
+
+  setCaller(chatId: string, threadId: string | undefined, userId: string): void {
+    this.map.set(this.key(chatId, threadId), { userId, updatedAt: Date.now() });
+  }
+
+  /**
+   * Returns the current caller for the given chat/thread, or null if none.
+   * Prefers the thread-specific entry; falls back to chat-level.
+   * Special-cases the terminal sentinel to the owner fallback.
+   */
+  getCaller(chatId: string, threadId?: string): string | null {
+    if (chatId === TERMINAL_CHAT_ID) {
+      return this.ownerFallback();
+    }
+    if (threadId) {
+      const entry = this.map.get(this.key(chatId, threadId));
+      if (entry && !this.isStale(entry)) return entry.userId;
+    }
+    const chatEntry = this.map.get(this.key(chatId));
+    if (chatEntry && !this.isStale(chatEntry)) return chatEntry.userId;
+    return null;
+  }
+
+  cleanup(): void {
+    for (const [k, v] of this.map.entries()) {
+      if (this.isStale(v)) this.map.delete(k);
+    }
+  }
+
+  private isStale(entry: SessionEntry): boolean {
+    return Date.now() - entry.updatedAt > this.maxAgeMs;
+  }
+
+  /** Test-only helper. */
+  _size(): number {
+    return this.map.size;
+  }
+}
+
+export { TERMINAL_CHAT_ID };
+```
+
+- [ ] **Step 1.2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add src/identity-session.ts
+git commit -m "feat(identity): add IdentitySession module"
+```
+
+---
+
+## Task 2: Smoke tests for IdentitySession
+
+**Files:**
+- Create: `scripts/identity-smoke.ts`
+
+- [ ] **Step 2.1: Write smoke test**
+
+```typescript
+// scripts/identity-smoke.ts
+import { IdentitySession, TERMINAL_CHAT_ID } from '../src/identity-session.js';
+
+function fail(msg: string): never {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+// 1. set/get same chat, no thread
+{
+  const s = new IdentitySession(() => null);
+  s.setCaller('chat_A', undefined, 'ou_alice');
+  if (s.getCaller('chat_A') !== 'ou_alice') fail('basic chat get');
+}
+
+// 2. thread-scoped entry takes precedence over chat-scoped
+{
+  const s = new IdentitySession(() => null);
+  s.setCaller('chat_A', undefined, 'ou_chat');
+  s.setCaller('chat_A', 't1', 'ou_thread');
+  if (s.getCaller('chat_A', 't1') !== 'ou_thread') fail('thread precedence');
+  if (s.getCaller('chat_A') !== 'ou_chat') fail('chat still present');
+}
+
+// 3. getCaller falls back from thread to chat when thread missing
+{
+  const s = new IdentitySession(() => null);
+  s.setCaller('chat_A', undefined, 'ou_chat');
+  if (s.getCaller('chat_A', 'no-such-thread') !== 'ou_chat') fail('fallback to chat');
+}
+
+// 4. terminal sentinel uses owner fallback
+{
+  const s = new IdentitySession(() => 'ou_owner');
+  if (s.getCaller(TERMINAL_CHAT_ID) !== 'ou_owner') fail('terminal fallback');
+}
+
+// 5. terminal sentinel returns null when no owner configured
+{
+  const s = new IdentitySession(() => null);
+  if (s.getCaller(TERMINAL_CHAT_ID) !== null) fail('terminal null when unset');
+}
+
+// 6. unknown chat returns null
+{
+  const s = new IdentitySession(() => null);
+  if (s.getCaller('chat_unknown') !== null) fail('unknown chat');
+}
+
+// 7. stale entry is not returned and cleanup removes it
+{
+  const s = new IdentitySession(() => null, 10); // 10ms ttl
+  s.setCaller('chat_A', undefined, 'ou_alice');
+  await new Promise((r) => setTimeout(r, 30));
+  if (s.getCaller('chat_A') !== null) fail('stale should return null');
+  s.cleanup();
+  if (s._size() !== 0) fail('cleanup should remove stale');
+}
+
+// 8. overwrite refreshes
+{
+  const s = new IdentitySession(() => null);
+  s.setCaller('chat_A', undefined, 'ou_alice');
+  s.setCaller('chat_A', undefined, 'ou_bob');
+  if (s.getCaller('chat_A') !== 'ou_bob') fail('overwrite');
+}
+
+console.log('identity smoke: 8/8 PASS');
+```
+
+- [ ] **Step 2.2: Run the smoke test**
+
+Run: `npx tsx scripts/identity-smoke.ts`
+Expected: `identity smoke: 8/8 PASS`
+
+- [ ] **Step 2.3: Add to test runner**
+
+Edit `scripts/test.sh`, append before the final "All tests passed" line:
+
+```bash
+echo ""
+echo "=== Identity session unit checks ==="
+npx tsx scripts/identity-smoke.ts
+```
+
+- [ ] **Step 2.4: Run full test suite**
+
+Run: `bash scripts/test.sh`
+Expected: all sections PASS.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add scripts/identity-smoke.ts scripts/test.sh
+git commit -m "test(identity): add 8 smoke assertions for IdentitySession"
+```
+
+---
+
+## Task 3: Extend job schema with send_chat_id / origin_chat_id
+
+**Files:**
+- Modify: `src/job-store.ts` (JobMeta interface + backwards-compat read)
+
+- [ ] **Step 3.1: Add a failing smoke test first**
+
+Append to `scripts/job-smoke.ts`:
+
+```typescript
+// N+1. JobMeta accepts send_chat_id and origin_chat_id (type-level only)
+{
+  type Required = 'send_chat_id' | 'origin_chat_id';
+  type HasFields = Required extends keyof import('../src/job-store.js').JobMeta ? true : false;
+  const _check: HasFields = true as HasFields;
+  void _check;
+}
+```
+
+Run: `npx tsx scripts/job-smoke.ts`
+Expected: FAIL with type error about missing properties.
+
+- [ ] **Step 3.2: Extend JobMeta**
+
+In `src/job-store.ts`, find the `JobMeta` interface and add two fields alongside `target_chat_id`:
+
+```typescript
+export interface JobMeta {
+  // ... existing fields ...
+  target_chat_id: string;
+  /** Where the job delivers output. Same as target_chat_id for legacy jobs. */
+  send_chat_id: string;
+  /** Where the job was created. Group id for group-created jobs, p2p chat id for private-created. */
+  origin_chat_id: string;
+  // ... rest of existing fields ...
+}
+```
+
+- [ ] **Step 3.3: Backwards-compat read**
+
+In `readJob`, after parsing the JSON, backfill missing fields from `target_chat_id`:
+
+```typescript
+export async function readJob(id: string): Promise<JobFile | null> {
+  // ... existing read logic, after JSON.parse ...
+  const job = parsed as JobFile;
+  if (!job.meta.send_chat_id) job.meta.send_chat_id = job.meta.target_chat_id;
+  if (!job.meta.origin_chat_id) job.meta.origin_chat_id = job.meta.target_chat_id;
+  return job;
+}
+```
+
+Apply the same backfill in `listAllJobs` per-job.
+
+- [ ] **Step 3.4: Run smoke**
+
+Run: `npx tsx scripts/job-smoke.ts`
+Expected: PASS (type check now satisfied).
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add src/job-store.ts scripts/job-smoke.ts
+git commit -m "feat(jobs): add send_chat_id and origin_chat_id to JobMeta"
+```
+
+---
+
+## Task 4: Require chat_id on create_job and populate new fields
+
+**Files:**
+- Modify: `src/tools.ts` (create_job handler)
+
+- [ ] **Step 4.1: Update create_job schema**
+
+In `src/tools.ts`, find the `create_job` tool registration. Extend `inputSchema` with `origin_chat_id`, rename `target_chat_id` semantic to `send_chat_id`:
+
+```typescript
+inputSchema: z.object({
+  name: z.string().describe('Display name of the job'),
+  type: z.enum(['message', 'prompt']).describe('Job type'),
+  schedule: z.string().describe('Cron expression or alias (e.g. "daily at 09:00")'),
+  prompt: z.string().optional().describe('Prompt body (type=prompt)'),
+  content: z.string().optional().describe('Message body (type=message)'),
+  target_chat_id: z.string().describe('Chat that receives the job output (send_chat_id)'),
+  origin_chat_id: z.string().describe('Chat where the job was created (for visibility filtering)'),
+  created_by: z.string().describe('open_id of the creator'),
+}),
+```
+
+- [ ] **Step 4.2: Populate both fields in the handler**
+
+When constructing `JobMeta` inside the handler, set:
+
+```typescript
+const meta: JobMeta = {
+  // ... existing fields ...
+  target_chat_id,
+  send_chat_id: target_chat_id,
+  origin_chat_id,
+  // ...
+};
+```
+
+- [ ] **Step 4.3: Typecheck and run existing smoke**
+
+Run: `npx tsc --noEmit && npx tsx scripts/job-smoke.ts`
+Expected: both clean/PASS.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add src/tools.ts
+git commit -m "feat(jobs): create_job requires origin_chat_id, stores send_chat_id"
+```
+
+---
+
+## Task 5: Wire IdentitySession into channel.ts (inbound messages)
+
+**Files:**
+- Modify: `src/index.ts` (instantiate session)
+- Modify: `src/channel.ts` (accept session in constructor, call setCaller)
+
+- [ ] **Step 5.1: Add config key for owner fallback**
+
+In `src/config.ts`, add to the exported config shape:
+
+```typescript
+ownerOpenId: process.env.LARK_OWNER_OPEN_ID || null,
+```
+
+(Place alongside existing optional config fields.)
+
+- [ ] **Step 5.2: Instantiate the session in index.ts**
+
+In `src/index.ts`, near where other singletons are created:
+
+```typescript
+import { IdentitySession } from './identity-session.js';
+
+const identitySession = new IdentitySession(() => appConfig.ownerOpenId);
+```
+
+Pass `identitySession` into `LarkChannel` and `registerTools` (add it to both constructors/signatures).
+
+- [ ] **Step 5.3: Set caller on inbound messages**
+
+In `src/channel.ts` `handleMessageEvent`, after `senderId` is extracted from `data.sender.sender_id.open_id` and before `this.queue.enqueue(...)`:
+
+```typescript
+this.identitySession.setCaller(chatId, threadId, senderId);
+```
+
+(Add `identitySession: IdentitySession` to the constructor and store it as `this.identitySession`.)
+
+- [ ] **Step 5.4: Typecheck and dry-run**
+
+Run: `npx tsc --noEmit && npm run --silent start -- --dry-run`
+Expected: both clean.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add src/config.ts src/channel.ts src/index.ts
+git commit -m "feat(identity): wire IdentitySession into channel inbound path"
+```
+
+---
+
+## Task 6: Scheduler sets caller on cronjob trigger with unique thread_id
+
+**Files:**
+- Modify: `src/scheduler.ts` (accept session, generate thread id, set caller, include thread_id in meta)
+
+- [ ] **Step 6.1: Add session to scheduler**
+
+In `src/scheduler.ts`, add `private identitySession: IdentitySession` to the class and accept it in the constructor. Wire it from `src/index.ts` where the scheduler is instantiated.
+
+- [ ] **Step 6.2: Set caller before notifying Claude**
+
+In `executePromptJob`, before calling `this.server.notification(...)`:
+
+```typescript
+const jobThreadId = `job-${job.meta.id}-${Date.now()}`;
+this.identitySession.setCaller(
+  job.meta.send_chat_id,
+  jobThreadId,
+  job.meta.created_by,
+);
+
+await this.server.notification({
+  method: 'notifications/claude/channel',
+  params: {
+    content: promptContent,
+    meta: {
+      chat_id: job.meta.send_chat_id,
+      thread_id: jobThreadId,
+      source: 'cronjob',
+      job_id: job.meta.id,
+      job_name: job.meta.name,
+    },
+  },
+});
+```
+
+(Replace the previous `chat_id: job.meta.target_chat_id` with `send_chat_id`. Add `thread_id` to meta so downstream tool calls can pass it back.)
+
+- [ ] **Step 6.3: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add src/scheduler.ts src/index.ts
+git commit -m "feat(identity): scheduler sets caller on cron trigger with unique thread_id"
+```
+
+---
+
+## Task 7: Sensitive tools consult IdentitySession
+
+**Files:**
+- Modify: `src/tools.ts` (list_jobs, update_job, delete_job, save_memory, save_skill, create_job)
+
+- [ ] **Step 7.1: Add a shared auth helper**
+
+Near the top of `registerTools` in `src/tools.ts`:
+
+```typescript
+function resolveCaller(
+  chat_id: string | undefined,
+  thread_id: string | undefined,
+): { caller: string } | { error: { isError: true; content: [{ type: 'text'; text: string }] } } {
+  if (!chat_id) {
+    return {
+      error: {
+        isError: true,
+        content: [{ type: 'text' as const, text: 'chat_id is required for this tool' }],
+      },
+    };
+  }
+  const caller = identitySession.getCaller(chat_id, thread_id);
+  if (!caller) {
+    return {
+      error: {
+        isError: true,
+        content: [{ type: 'text' as const, text: 'no active identity session for this chat' }],
+      },
+    };
+  }
+  return { caller };
+}
+```
+
+Accept `identitySession: IdentitySession` as a new parameter to `registerTools`.
+
+- [ ] **Step 7.2: Require chat_id on sensitive tools**
+
+For each of `list_jobs`, `update_job`, `delete_job`, add `chat_id` and optional `thread_id` to their `inputSchema`:
+
+```typescript
+chat_id: z.string().describe('The chat this tool call is acting from'),
+thread_id: z.string().optional().describe('Thread id if applicable'),
+```
+
+For `save_memory`: `chat_id` is already present — also accept optional `thread_id` if not already, and **remove** the client-supplied `open_id` field (we will derive it from the session).
+
+- [ ] **Step 7.3: Gate each handler with resolveCaller**
+
+Example for `list_jobs`:
+
+```typescript
+async ({ status, chat_id, thread_id }) => {
+  const auth = resolveCaller(chat_id, thread_id);
+  if ('error' in auth) return auth.error;
+  const { caller } = auth;
+  // ... continue to list & filter ...
+}
+```
+
+Apply the same gate to `update_job`, `delete_job`, `save_memory`, `create_job`.
+
+- [ ] **Step 7.4: `save_memory` uses `caller` as owner**
+
+In the `save_memory` handler, replace any use of the (now removed) `open_id` input with `caller`. Profile writes are always for the calling user.
+
+- [ ] **Step 7.5: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add src/tools.ts
+git commit -m "feat(identity): sensitive tools resolve caller from IdentitySession"
+```
+
+---
+
+## Task 8: list_jobs visibility filter + redaction
+
+**Files:**
+- Modify: `src/tools.ts` (list_jobs handler)
+- Modify: `src/channel.ts` (chat type helper if not already present)
+
+- [ ] **Step 8.1: Expose chat type from channel**
+
+If `channel.ts` already caches chat type (p2p/group), add a tiny lookup method. Otherwise add:
+
+```typescript
+// In LarkChannel
+isPrivateChat(chatId: string): boolean {
+  return chatId.startsWith('ou_') || this.p2pChatIds.has(chatId);
+}
+```
+
+Pass this capability into `registerTools` (either the whole channel reference, or just a `isPrivateChat` function).
+
+- [ ] **Step 8.2: Apply rendering-visibility filter in list_jobs**
+
+Replace the body of `list_jobs` with:
+
+```typescript
+async ({ status, chat_id, thread_id }) => {
+  const auth = resolveCaller(chat_id, thread_id);
+  if ('error' in auth) return auth.error;
+  const { caller } = auth;
+
+  const jobs = await listAllJobs();
+  const byStatus = status === 'all' ? jobs : jobs.filter((j) => j.meta.status === status);
+
+  const isPrivate = isPrivateChat(chat_id);
+  const visible = byStatus.filter((j) => {
+    if (isPrivate) return j.meta.created_by === caller; // owner-only in private
+    return j.meta.send_chat_id === chat_id;              // group: posting-to-this-group
+  });
+
+  if (visible.length === 0) {
+    return { content: [{ type: 'text' as const, text: 'No jobs found.' }] };
+  }
+
+  const lines = visible.map((j) => {
+    const statusIcon = j.meta.status === 'active' ? '✅' : '⏸️';
+    const lastRun = j.runtime.last_run_at
+      ? new Date(j.runtime.last_run_at).toLocaleString()
+      : 'never';
+    const error = j.runtime.last_error ? ` ⚠️ ${j.runtime.last_error}` : '';
+    const isOwner = j.meta.created_by === caller;
+
+    // Group audit view: redact prompt/content/meta when caller is not owner
+    if (!isPrivate && !isOwner) {
+      return `${statusIcon} **${j.meta.id}** (${j.meta.type}) — ${j.meta.schedule_human}\n   By: ${j.meta.created_by} | Next: ${j.runtime.next_run_at}`;
+    }
+    return `${statusIcon} **${j.meta.id}** (${j.meta.type}) — ${j.meta.schedule_human}\n   Next: ${j.runtime.next_run_at} | Last: ${lastRun} | Runs: ${j.runtime.run_count}${error}`;
+  });
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: `Timezone: ${appConfig.cronTimezone}\n\n${lines.join('\n\n')}`,
+      },
+    ],
+  };
+}
+```
+
+- [ ] **Step 8.3: Typecheck + existing tests**
+
+Run: `bash scripts/test.sh`
+Expected: all PASS.
+
+- [ ] **Step 8.4: Commit**
+
+```bash
+git add src/channel.ts src/tools.ts
+git commit -m "feat(jobs): list_jobs filters by chat visibility and redacts group view"
+```
+
+---
+
+## Task 9: update_job / delete_job owner-only
+
+**Files:**
+- Modify: `src/tools.ts`
+
+- [ ] **Step 9.1: Gate delete_job**
+
+In the `delete_job` handler, after resolving caller and before calling `deleteJob(id)`:
+
+```typescript
+const existing = await readJob(id);
+if (!existing) {
+  return { content: [{ type: 'text' as const, text: `Job "${id}" not found.` }] };
+}
+if (existing.meta.created_by !== caller) {
+  return {
+    isError: true,
+    content: [
+      { type: 'text' as const, text: `You are not the owner of "${id}". Only ${existing.meta.created_by} can delete it.` },
+    ],
+  };
+}
+```
+
+- [ ] **Step 9.2: Gate update_job**
+
+Same pattern at the top of `update_job` handler.
+
+- [ ] **Step 9.3: Smoke — owner check**
+
+Add assertions to `scripts/job-smoke.ts` covering filename-level behavior (existing test patterns apply). If end-to-end behavior is hard to reach in the smoke, rely on typecheck + manual verification here.
+
+- [ ] **Step 9.4: Full test suite**
+
+Run: `bash scripts/test.sh`
+Expected: all PASS.
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add src/tools.ts scripts/job-smoke.ts
+git commit -m "feat(jobs): update/delete restricted to job owner"
+```
+
+---
+
+## Task 10: Document, bump version, PR
+
+**Files:**
+- Modify: `CHANGELOG.md`, `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
+
+- [ ] **Step 10.1: Bump version to 0.9.0**
+
+In `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` — set version to `0.9.0`.
+
+- [ ] **Step 10.2: Write CHANGELOG entry**
+
+At the top of `CHANGELOG.md`, under the Keep-a-Changelog header:
+
+```markdown
+## [0.9.0] - 2026-04-19
+
+### Added
+- `IdentitySession` (`src/identity-session.ts`) — server-side `(chat_id, thread_id?) → open_id` mapping populated from Feishu events. Sensitive MCP tools now consult the session instead of trusting Claude-declared identity parameters.
+- `send_chat_id` and `origin_chat_id` on `JobMeta` — enables visibility filtering based on where a job delivers output vs where it was created.
+- `LARK_OWNER_OPEN_ID` config key — identity fallback for terminal invocations (reserved `__terminal__` chat id).
+
+### Changed
+- `list_jobs` now filters by rendering visibility: in a group, only jobs with `send_chat_id == currentChat` are returned; in a private chat, only jobs `created_by == caller`. Group view redacts prompt/content/meta when caller is not the owner (creator_by remains visible for accountability).
+- `update_job` / `delete_job` now require `caller == created_by`.
+- `create_job` input now requires both `target_chat_id` (→ `send_chat_id`) and `origin_chat_id`.
+- `save_memory` no longer accepts a client-supplied `open_id` — the profile owner is derived from the session.
+- Scheduler attaches a unique `thread_id` to each cronjob execution so cronjob sessions don't clobber concurrent inbound human messages.
+
+### Security
+- Closes the path where a group member could list or inspect another user's jobs via `list_jobs`.
+- Closes the path where a socially-engineered prompt could direct tools to act on behalf of a different user.
+```
+
+- [ ] **Step 10.3: Full test**
+
+Run: `bash scripts/test.sh`
+Expected: all PASS.
+
+- [ ] **Step 10.4: Commit and push**
+
+```bash
+git add CHANGELOG.md package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json
+git commit -m "chore: release v0.9.0 — IdentitySession + CronJob visibility"
+git push -u origin "$(git branch --show-current)"
+```
+
+- [ ] **Step 10.5: Open PR**
+
+```bash
+gh pr create --base main --title "feat: IdentitySession + CronJob visibility (v0.9.0)" --body "$(cat <<'EOF'
+Closes #35 (phase 1 of 3)
+
+## Summary
+- Introduce `IdentitySession` — server-side caller mapping populated from Feishu events; sensitive tools consult it instead of trusting Claude-declared identity.
+- Extend job schema with `send_chat_id` / `origin_chat_id`; filter `list_jobs` by rendering visibility; redact prompt/meta in group audit view.
+- `update_job` / `delete_job` owner-only. `save_memory` uses session identity.
+- Scheduler tags each cronjob execution with a unique `thread_id` to isolate from concurrent inbound messages.
+- Terminal invocations fall back to `LARK_OWNER_OPEN_ID` via the reserved `__terminal__` chat id.
+
+Spec: `docs/superpowers/specs/2026-04-19-lark-privacy-design.md`
+
+## Test plan
+- [ ] `bash scripts/test.sh` (incl. new identity smoke)
+- [ ] Manual: group list_jobs shows only jobs posting to that group, private list shows all own jobs
+- [ ] Manual: non-owner in group receives redacted view (no prompt body)
+- [ ] Manual: cronjob fires and subsequent tool calls resolve identity correctly
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Checklist (already run)
+
+- Spec coverage — ✅ Sections "IdentitySession", "CronJob Visibility", "Rendering Visibility" and "Configuration additions/LARK_OWNER_OPEN_ID" all have tasks. Terminal `__terminal__` sentinel is implemented in Task 1; the consumer side (`/lark:jobs` skill) is deferred to Phase 3.
+- Placeholder scan — ✅ No TBDs. `isPrivateChat` helper has a fallback pattern that the engineer may need to tune to the actual channel code, but the intent is explicit and the code compiles against the interface.
+- Type consistency — ✅ `caller`, `send_chat_id`, `origin_chat_id`, `thread_id` consistent across tasks.

--- a/docs/superpowers/specs/2026-04-19-lark-privacy-design.md
+++ b/docs/superpowers/specs/2026-04-19-lark-privacy-design.md
@@ -1,0 +1,374 @@
+# Lark Privacy & Security Design
+
+## Context
+
+The plugin currently has three privacy leak paths that allow group members to indirectly extract information about other users:
+
+1. **Profile memory is cross-chat.** A fact distilled from a user's private chat (e.g. "筹备跳槽", "邮箱 kk@..." ) gets loaded into any chat where that user is mentioned. Group members can `@bot 问问 kk 最近在忙什么` and receive distilled private content.
+2. **`list_jobs` returns all jobs globally.** Any group member can list cronjobs created by anyone, exposing both the existence and the prompt contents (which may carry private context like "每天读我跟 XX 的邮件").
+3. **MCP tools accept Claude-declared identity.** Tools like `save_memory` / `delete_job` are callable with any `user_id` argument. A socially-engineered prompt can direct Claude to act as someone else.
+
+This spec defines:
+
+- A **rendering visibility principle** that distinguishes how data flows out of the bot and picks the appropriate filter.
+- A **tiered profile** (public/private) with a three-layer classifier (hard rules, source, LLM).
+- A **transparency surface** (`what_do_you_know`, `forget_memory`) with a self-learning rule file.
+- A **CronJob visibility model** keyed on `send_chat_id`.
+- A server-side **`IdentitySession`** that establishes the true caller for every MCP tool call without trusting Claude's declaration.
+- **Terminal safeguards** (default redaction, audit log, confirmation) for `/lark:jobs` and similar skills.
+
+Non-goals:
+
+- Message-content encryption at rest. OS-level file permissions are the trust boundary; adding encryption raises complexity without plugging the realistic threats.
+- Defense against a compromised `app_secret`. If the Feishu credentials leak, the bot itself is forged — no in-process logic can recover from that.
+- Multi-tenant terminal access. The plugin assumes one operator per Claude Code instance (matching current config model).
+
+## Core Principle — Rendering Visibility
+
+Every piece of sensitive data flows out of the bot through one of two paths. The path determines the filter.
+
+### Path A — Implicit context injection
+
+The data is loaded into Claude's prompt as background for its next turn. Claude decides whether and how to mention it.
+
+Examples: `profile` memory, `episode` memory, loaded skills.
+
+**Filter: by owner.** The owner always sees their own data regardless of channel; others only see the public tier. Claude's own discretion acts as a second layer — even with full context loaded, a well-behaved model won't unprompted-blurt private facts.
+
+### Path B — Explicit output return
+
+The data *is* the response. The tool's contract is "return this information to the caller," and Claude renders it back verbatim (or nearly so) into the current chat.
+
+Examples: `list_jobs`, `what_do_you_know`, `list_memories`, any `get_*` / `list_*`.
+
+**Filter: by current chat's visibility.** Because the reply lands in the current chat and is seen by everyone there, the filter ignores the caller's identity and asks: "is this row appropriate to render to this chat's audience?"
+
+### Why the distinction matters
+
+An owner invoking `list_jobs` in a group is not "me looking at my data" — it is "bot reading my jobs aloud to the group." Path-B filters protect against that re-rendering; path-A filters would incorrectly allow it.
+
+This principle is load-bearing: every new tool must be classified A or B at design time.
+
+## Tiered Profile Memory
+
+### Storage layout
+
+```
+memories/
+  profiles/
+    {userId}/
+      public.md     # cross-chat, shared, loaded when anyone references this user
+      private.md    # owner-only, loaded only when caller == owner
+```
+
+The existing single-file `profiles/{userId}.md` is migrated to `public.md` on first read after upgrade (conservative: everything pre-existing starts in public until the next distillation pass reclassifies).
+
+### Load logic
+
+```ts
+async loadProfile(ownerId: string, caller: string): Promise<string> {
+  const pub = await read(`profiles/${ownerId}/public.md`)
+  if (caller === ownerId) {
+    const priv = await read(`profiles/${ownerId}/private.md`)
+    return join(pub, priv)
+  }
+  return pub ?? ''
+}
+```
+
+This is path-A (implicit injection). The caller check is sufficient because Claude itself is expected to use discretion in phrasing.
+
+### Classification at distillation
+
+The distiller outputs two arrays instead of one blob:
+
+```json
+{
+  "public":  ["是 TikTok Live 团队的工程师", "熟悉 TypeScript 和 Rust"],
+  "private": ["邮件偏好正式语气", "最近在处理会议冲突"]
+}
+```
+
+Classification runs in three priority layers:
+
+**L1 — Hard rules (code-fixed).** Universal patterns that are always private regardless of source:
+
+- Email addresses (regex)
+- Phone numbers (regex)
+- ID numbers, bank cards, tokens, passwords
+- Specific monetary amounts ("薪资 3w", "奖金 5 万")
+- Specific date+time combinations that reveal schedule ("明天 3 点")
+
+Also L1-whitelist (always allowed in public): job titles, team names, public tech stack tags, public handles.
+
+L1 rules are shipped in `src/privacy-rules.ts` as exported constants. Not user-configurable to avoid footguns; universal enough that the correct default is clear.
+
+**L2 — User rules (markdown).** Personal/org-specific sensitivities at `~/.claude/channels/lark/privacy-rules.md`:
+
+```markdown
+## Always private
+- 公司内部项目代号（例如 Project Phoenix、代号 X-23）
+- 客户名：ACME Corp、Globex
+- 对同事或上级的评价和吐槽
+- 涉及换工作、面试的表述
+
+## Always public
+- 公开身份：TikTok Live 团队工程师
+- 公开的技术栈标签、GitHub handle
+```
+
+Natural language examples, not regex. The distiller reads this file and injects it into its classification prompt as context. Append-only; users add entries as they notice misclassifications.
+
+**L3 — LLM fallback.** Gray-area items classified by the distiller itself. The prompt's default rule is: **"If uncertain, classify as private."** Conservative default keeps errors biased toward overprotection.
+
+### Blacklist priority
+
+L1 blacklist overrides everything, including source and explicit user override. Even if a user writes their email in a public group chat, the bot will not store it in `public.md`. Rationale: the danger of blacklist items is bot-initiated re-broadcast, not the one-time disclosure.
+
+### Source as signal
+
+When L1 does not decide:
+
+- Facts distilled from **group messages** default to `public` (already spoken in front of the group).
+- Facts distilled from **private chat** default to `private` (not yet voluntarily shared).
+- An explicit `save_memory --scope=public` call overrides the default.
+
+## Memory Transparency & Self-Learning
+
+Silent distillation stays (no per-flush notification), but the user gains two path-B tools:
+
+### `what_do_you_know`
+
+Returns the caller's profile entries. Path-B, so filtered by current chat:
+
+- **In private chat**: returns `public.md` + `private.md`, both rendered.
+- **In a group**: returns only `public.md` (rendering private in group would defeat the whole point).
+- **In terminal**: returns both, in redacted summary form (see Terminal Safeguards).
+
+### `forget_memory`
+
+Removes a specific line from the caller's profile. Args: `id` or `line_hash`. Always caller-only (you can only forget things about yourself).
+
+### Self-learning rule loop
+
+When `forget_memory` removes a line, the bot asks:
+
+> "要不要加条规则，以后自动把这类归为 private？
+> 建议 rule：『涉及人际冲突、情绪表达的内容』。
+> [是，加入] [否，只本次]"
+
+On confirmation, the rule is appended to `~/.claude/channels/lark/privacy-rules.md` (L2). Future distillations read the updated file and avoid the same misclassification.
+
+Over time the rule file grows from empty to a personal privacy profile. If it exceeds ~100 entries, that signals L3 prompt needs improvement — the rule file is a patch layer, not a substitute.
+
+## CronJob Visibility
+
+### Fields
+
+Every job stores three identity-related fields:
+
+| Field | Meaning |
+|---|---|
+| `created_by` | open_id of the human who created the job |
+| `origin_chat_id` | chat where the creation conversation happened (debug/audit only) |
+| `send_chat_id` | chat where the job's output is delivered |
+
+### `list_jobs` filter
+
+Path-B tool. Filter by **current chat's visibility**:
+
+```
+return jobs where:
+  (current chat is private  AND  job.created_by == caller)          -- owner sees all their jobs in private
+  OR
+  (current chat is group G  AND  job.send_chat_id == G)             -- group sees all jobs posting here
+```
+
+Consequences:
+
+- Private-chat creation, private-chat list → visible.
+- Private-chat creation that sends to group G, listed in G → visible in G (audit right).
+- Private-chat creation that sends to private, listed in group → **not visible** (no reason to broadcast).
+- Group creation, listed in a different group → not visible.
+
+### Redaction in group view
+
+Even when a job is visible in a group, fields are redacted:
+
+| Field | Private (owner) view | Group audit view |
+|---|---|---|
+| `id` / `name` | ✅ | ✅ |
+| `schedule` | ✅ | ✅ |
+| `send_chat_id` | ✅ | ✅ (is current chat anyway) |
+| `created_by` | ✅ | ✅ (accountability) |
+| `next_run_at` | ✅ | ✅ |
+| `prompt` / `message` body | ✅ | ❌ (may contain private context) |
+| `meta` | ✅ | ❌ |
+
+The group view deliberately keeps `created_by` so group members have an accountable handle to contact if they find the job inappropriate.
+
+### Mutation
+
+`delete_job` / `update_job` remain **owner-only** regardless of visibility. Audit rights ≠ mutation rights.
+
+## IdentitySession — MCP Tool Authentication
+
+### Principle
+
+MCP server maintains `(chat_id, thread_id?) → open_id` mappings populated from Feishu events. Sensitive tools read the mapping server-side; they never trust Claude-declared identity parameters.
+
+The trust anchor is the Feishu webhook itself (authenticated by `app_secret`). The mapping transmits that anchor to the MCP layer.
+
+### API
+
+`src/identity-session.ts`:
+
+```ts
+interface SessionEntry { userId: string; updatedAt: number }
+
+class IdentitySession {
+  setCaller(chatId: string, threadId: string | undefined, userId: string): void
+  getCaller(chatId: string, threadId?: string): string | null    // thread-specific, falls back to chat
+  cleanup(maxAgeMs?: number): void                                // drop stale entries
+}
+```
+
+In-memory only. Not persisted across restarts — each incoming message or cronjob tick will re-populate the relevant entry.
+
+### Integration points
+
+1. **`channel.ts`** — inside `handleMessageEvent`, before enqueue:
+   ```ts
+   identitySession.setCaller(chatId, threadId, senderId)
+   ```
+
+2. **`scheduler.ts`** — when triggering a `prompt`-type job:
+   ```ts
+   identitySession.setCaller(job.send_chat_id, jobThreadId, job.created_by)
+   ```
+   `jobThreadId` is a newly-generated id scoped to this execution; it is included in the `notifications/claude/channel` metadata so Claude's subsequent tool calls arrive carrying `thread_id` matching the session entry.
+
+3. **`tools.ts`** — sensitive tools consult the session:
+   ```ts
+   const caller = identitySession.getCaller(chat_id, thread_id)
+   if (!caller) return { isError: true, content: "no active session" }
+   // proceed using `caller` as authoritative identity
+   ```
+
+Sensitive tool list (initial): `list_jobs`, `delete_job`, `update_job`, `save_memory`, `forget_memory`, `what_do_you_know`.
+
+Non-sensitive tools (`reply`, `react`, `edit_message`, `download_attachment`) do not need session checks.
+
+### Handling implementation edge cases
+
+**CronJob concurrency.** If a cronjob and a human message arrive to the same chat in close succession, a single `(chat_id, null)` entry would clobber. Solution: cronjob executions always run under a dedicated `jobThreadId`, so they occupy a different session key than human messages (which use `thread_id` from the event, or null).
+
+**Missing `chat_id` in tool args.** Every sensitive tool's schema must require `chat_id` (and optionally `thread_id`). If a tool's semantics don't naturally need chat_id, it probably shouldn't be sensitive.
+
+**Restart resilience.** The session table is ephemeral. Next Feishu event or cronjob tick repopulates. No persistence needed.
+
+**Observability.** Every `setCaller` and every denied tool call logs to `debug.log`:
+```
+[identity] setCaller chat=oc_xxx thread=t1 user=ou_yyy
+[identity] list_jobs denied: no session for chat=oc_xxx thread=t1
+```
+
+## Terminal Safeguards
+
+Threat model on the terminal differs fundamentally: the operator is superuser, so technical controls are futile. Real threats are shoulder-surfing, screen sharing, and accidental exposure by a borrowed laptop.
+
+### Default redaction, `--verbose` opt-in
+
+`/lark:jobs` default output:
+
+```
+[1] morning-brief   · daily 09:00   · → group "Team Sync"
+[2] mail-digest     · daily 22:00   · → private
+3 jobs. Use --verbose to show prompts.
+```
+
+Prompt body, meta, and other free-form content are hidden unless `--verbose` is passed. Same pattern applies to `/lark:memory show`, etc.
+
+### Audit log
+
+Every skill invocation appends to `~/.claude/channels/lark/audit.log`:
+
+```
+2026-04-19T14:32:01Z  list_jobs            verbose=false  count=3
+2026-04-19T14:33:15Z  delete_job           id=morning-brief
+2026-04-19T14:35:02Z  list_jobs            verbose=true   count=3   ⚠ exposed prompts
+```
+
+Append-only, not user-rotated. Its purpose is retrospective self-audit by the operator ("did anyone use my laptop while I was away?").
+
+### Destructive confirmation
+
+`delete_job`, `forget_memory`, and similar prompt for confirmation in terminal:
+
+```
+/lark:jobs delete morning-brief
+→ Delete job "morning-brief" (daily 09:00, → group "Team Sync")? [y/N]
+```
+
+Foot-gun prevention, not security.
+
+### Identity fallback
+
+Terminal skill invocations reach MCP tools with no Feishu event to seed the session. Resolution:
+
+- Terminal skills pass a reserved sentinel `chat_id = "__terminal__"`.
+- `IdentitySession.getCaller` recognizes the sentinel and returns `process.env.LARK_OWNER_OPEN_ID` (new config key).
+- `LARK_OWNER_OPEN_ID` is set at `/lark:configure` time (auto-detected from the first real human message received, confirmed with the operator, then written to `.env`).
+
+With this fallback, terminal invocations take the "owner in private chat" code path automatically — no separate permission branches needed.
+
+## Configuration additions
+
+New keys in `~/.claude/channels/lark/.env`:
+
+| Key | Purpose |
+|---|---|
+| `LARK_OWNER_OPEN_ID` | Fallback identity for terminal invocations |
+| `LARK_PRIVACY_RULES_FILE` | Optional override for L2 rules path (default: `privacy-rules.md` in channel dir) |
+| `LARK_IDENTITY_SESSION_TTL_MS` | Optional override for session stale cleanup (default: 1 hour) |
+
+## File-system changes
+
+```
+~/.claude/channels/lark/
+  .env                       # + LARK_OWNER_OPEN_ID
+  privacy-rules.md           # NEW — L2 user rules, append-only
+  audit.log                  # NEW — terminal invocation audit
+  memories/
+    profiles/
+      {userId}/
+        public.md            # NEW split (replaces {userId}.md)
+        private.md           # NEW
+      {userId}.md            # DEPRECATED — migrated on first read
+```
+
+## Migration
+
+1. First time the plugin boots with the new code:
+   - Any `profiles/{userId}.md` is moved to `profiles/{userId}/public.md`.
+   - A stub `profiles/{userId}/private.md` is created empty.
+2. On next distillation for that user, the three-layer classifier runs against the existing `public.md` contents and reclassifies lines that hit L1-blacklist or L2 rules into `private.md`. This happens lazily, not as a batch rewrite.
+3. `LARK_OWNER_OPEN_ID` is auto-populated at next `/lark:configure` run, or on the next human message in P2P with the bot (confirmed to the operator via terminal prompt before writing).
+
+Existing cronjobs gain `send_chat_id = target_chat_id` (rename) and `origin_chat_id` defaulted from existing metadata where available, else empty string (not null).
+
+## Test plan
+
+1. **Rendering visibility unit tests** — matrix of (tool kind, caller, chat type, data ownership) → expected filter result.
+2. **Profile tier classification** — table of sample utterances and expected public/private assignment under L1/L2/L3 rules.
+3. **`list_jobs` visibility** — 12-case matrix covering the four cells of (origin, send) × (list location).
+4. **IdentitySession concurrency** — simulate cronjob trigger overlapping with human message in the same chat, verify thread_id isolation prevents clobber.
+5. **Terminal safeguards** — `/lark:jobs` default vs `--verbose`; audit.log append; confirmation prompt.
+6. **Migration smoke** — start with legacy `profiles/{userId}.md`, boot, verify lazy migration on first load.
+7. **L2 self-learning** — call `forget_memory` on a misclassified line, accept rule suggestion, verify rule appended and subsequent distillation respects it.
+
+## Open questions
+
+1. **Group-visible job content search.** Should a group admin be able to query "show all jobs posting here in the last 30 days" for audit purposes? Deferred — out of v1 scope, add if operators ask.
+2. **Rule-file rotation.** If L2 grows past ~100 entries, UX degrades. No compaction mechanism in v1; revisit if it becomes a real issue.
+3. **Per-group L2 override.** Could users want different privacy posture per group (e.g., stricter in a cross-company group)? Deferred — single global L2 for v1 is simpler and matches current one-operator assumption.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "0.8.5",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/identity-smoke.ts
+++ b/scripts/identity-smoke.ts
@@ -1,0 +1,71 @@
+/**
+ * IdentitySession smoke test — runs as part of `npm test`.
+ * Exits non-zero if any assertion fails.
+ */
+import { IdentitySession, TERMINAL_CHAT_ID } from '../src/identity-session.js';
+
+function fail(msg: string): never {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+// 1. set/get same chat, no thread
+{
+  const s = new IdentitySession(() => null);
+  s.setCaller('chat_A', undefined, 'ou_alice');
+  if (s.getCaller('chat_A') !== 'ou_alice') fail('basic chat get');
+}
+
+// 2. thread-scoped entry takes precedence over chat-scoped
+{
+  const s = new IdentitySession(() => null);
+  s.setCaller('chat_A', undefined, 'ou_chat');
+  s.setCaller('chat_A', 't1', 'ou_thread');
+  if (s.getCaller('chat_A', 't1') !== 'ou_thread') fail('thread precedence');
+  if (s.getCaller('chat_A') !== 'ou_chat') fail('chat entry still present');
+}
+
+// 3. getCaller falls back from thread to chat when thread entry missing
+{
+  const s = new IdentitySession(() => null);
+  s.setCaller('chat_A', undefined, 'ou_chat');
+  if (s.getCaller('chat_A', 'no-such-thread') !== 'ou_chat') fail('fallback to chat');
+}
+
+// 4. terminal sentinel uses owner fallback
+{
+  const s = new IdentitySession(() => 'ou_owner');
+  if (s.getCaller(TERMINAL_CHAT_ID) !== 'ou_owner') fail('terminal fallback');
+}
+
+// 5. terminal sentinel returns null when no owner configured
+{
+  const s = new IdentitySession(() => null);
+  if (s.getCaller(TERMINAL_CHAT_ID) !== null) fail('terminal null when unset');
+}
+
+// 6. unknown chat returns null
+{
+  const s = new IdentitySession(() => null);
+  if (s.getCaller('chat_unknown') !== null) fail('unknown chat');
+}
+
+// 7. stale entry is not returned; cleanup removes it
+{
+  const s = new IdentitySession(() => null, 10); // 10ms ttl
+  s.setCaller('chat_A', undefined, 'ou_alice');
+  await new Promise((r) => setTimeout(r, 30));
+  if (s.getCaller('chat_A') !== null) fail('stale should return null');
+  s.cleanup();
+  if (s._size() !== 0) fail('cleanup should remove stale');
+}
+
+// 8. overwrite refreshes
+{
+  const s = new IdentitySession(() => null);
+  s.setCaller('chat_A', undefined, 'ou_alice');
+  s.setCaller('chat_A', undefined, 'ou_bob');
+  if (s.getCaller('chat_A') !== 'ou_bob') fail('overwrite');
+}
+
+console.log('identity smoke: 8/8 PASS');

--- a/scripts/job-smoke.ts
+++ b/scripts/job-smoke.ts
@@ -6,6 +6,8 @@ import {
   sanitizeJobId,
   expandSchedule,
   computeNextRun,
+  backfillJob,
+  type JobFile,
 } from '../src/job-store.js';
 
 function fail(msg: string): never {
@@ -133,5 +135,57 @@ if (nextA === nextB) fail('computeNextRun: different crons produced same time');
 // Verify alias result is consistent: daily at 09:00 → 0 9 * * *
 const aliasResult = expandSchedule('daily at 09:00');
 if (aliasResult.cron !== '0 9 * * *') fail(`alias validation: got ${aliasResult.cron}`);
+
+// ── Backfill tests (v0.9.0) ─────────────────────────────────
+
+function makeLegacyJob(overrides: Partial<JobFile['meta']> = {}): JobFile {
+  return {
+    meta: {
+      id: 'legacy-1',
+      name: 'Legacy Job',
+      type: 'prompt',
+      schedule: '0 9 * * *',
+      schedule_human: 'daily at 09:00',
+      target_chat_id: 'oc_legacy_chat',
+      send_chat_id: '', // intentionally missing — simulate pre-v0.9 job
+      origin_chat_id: '', // same
+      status: 'active',
+      created_by: '',
+      created_at: '2026-01-01T00:00:00Z',
+      ...overrides,
+    } as JobFile['meta'],
+    runtime: {
+      last_run_at: null,
+      next_run_at: '2026-12-31T01:00:00Z',
+      run_count: 0,
+      last_error: null,
+    },
+  };
+}
+
+// 25. backfill: send_chat_id defaults to target_chat_id
+const b1 = backfillJob(makeLegacyJob());
+if (b1.meta.send_chat_id !== 'oc_legacy_chat') fail(`backfill send_chat_id: got "${b1.meta.send_chat_id}"`);
+
+// 26. backfill: origin_chat_id defaults to target_chat_id
+if (b1.meta.origin_chat_id !== 'oc_legacy_chat') fail(`backfill origin_chat_id: got "${b1.meta.origin_chat_id}"`);
+
+// 27. backfill: does not overwrite existing send_chat_id
+const b2 = backfillJob(makeLegacyJob({ send_chat_id: 'oc_already_set' }));
+if (b2.meta.send_chat_id !== 'oc_already_set') fail(`backfill should not overwrite: got "${b2.meta.send_chat_id}"`);
+
+// 28. backfill: empty created_by attributes to LARK_OWNER_OPEN_ID when set
+// Simulate by setting the env and re-importing config; instead verify conditional:
+// when ownerOpenId is null (default in CI), empty created_by stays empty.
+const b3 = backfillJob(makeLegacyJob({ created_by: '' }));
+// In CI, LARK_OWNER_OPEN_ID is typically unset → backfill leaves empty
+// In dev with owner set → backfill assigns owner. Both are acceptable outcomes.
+// Assert only that the field is a string (not undefined/null) — the backfill
+// code path ran without throwing.
+if (typeof b3.meta.created_by !== 'string') fail(`created_by must be string: got ${typeof b3.meta.created_by}`);
+
+// 29. backfill: non-empty created_by is preserved
+const b4 = backfillJob(makeLegacyJob({ created_by: 'ou_alice' }));
+if (b4.meta.created_by !== 'ou_alice') fail(`backfill must preserve created_by: got "${b4.meta.created_by}"`);
 
 console.log('PASS');

--- a/scripts/reply-card-smoke.ts
+++ b/scripts/reply-card-smoke.ts
@@ -5,6 +5,8 @@
  */
 import { registerTools } from '../src/tools.js';
 import type { MemoryStore } from '../src/memory/file.js';
+import { IdentitySession } from '../src/identity-session.js';
+import type { LarkChannel } from '../src/channel.js';
 
 function fail(msg: string): never {
   console.error(`FAIL: ${msg}`);
@@ -104,10 +106,17 @@ async function run() {
   const ackReactions = new Map<string, string>();
 
   // Register tools (captures handlers via fake server)
+  const identitySession = new IdentitySession(() => null);
+  // Bind a fake caller so resolveCaller-gated tools can be exercised.
+  identitySession.setCaller('chat_001', undefined, 'ou_reply_smoke');
+  const fakeChannel = { isPrivateChat: () => true } as unknown as LarkChannel;
+
   registerTools(
     fakeServer as any,
     client as any,
     noopMemory,
+    identitySession,
+    fakeChannel,
     buffer as any,
     ackReactions,
     botTracker as any,

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -32,4 +32,8 @@ echo "=== Reply raw-card unit checks ==="
 npx tsx scripts/reply-card-smoke.ts
 
 echo ""
+echo "=== Identity session unit checks ==="
+npx tsx scripts/identity-smoke.ts
+
+echo ""
 echo "All tests passed."

--- a/skills/configure/SKILL.md
+++ b/skills/configure/SKILL.md
@@ -129,6 +129,8 @@ If user says "use defaults" or "skip", leave these at defaults.
 | `LARK_ALLOWED_CHAT_IDS` | Filtering | No | (empty) |
 | `LARK_TEXT_CHUNK_LIMIT` | Filtering | No | `4000` |
 | `LARK_ENABLED_SKILLS` | Filtering | No | (empty) |
+| `LARK_OWNER_OPEN_ID` | Identity | No | (empty) |
+| `LARK_IDENTITY_SESSION_TTL_MS` | Identity | No | auto |
 
 ## Notes
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -7,6 +7,8 @@ import { enrichmentPrompt } from './prompts.js';
 import { MessageQueue } from './queue.js';
 import type { MemoryStore } from './memory/file.js';
 import type { ConversationBuffer } from './memory/buffer.js';
+import type { IdentitySession } from './identity-session.js';
+import { TERMINAL_CHAT_ID } from './identity-session.js';
 
 const DEBUG_LOG = path.join(os.homedir(), '.claude', 'channels', 'lark', 'debug.log');
 function debugLog(msg: string) {
@@ -118,12 +120,14 @@ export class LatestMessageTracker {
 export class LarkChannel {
   private client: Lark.Client;
   private nameCache = new Map<string, string>(); // open_id/chat_id → display name
+  private chatTypeCache = new Map<string, 'p2p' | 'group'>(); // chatId → type (populated from inbound events)
   private botOpenId: string = '';
   private wsClient: Lark.WSClient | null = null;
   private queue = new MessageQueue();
   private messageHandler: MessageHandler | null = null;
   private memoryStore: MemoryStore | null = null;
   private conversationBuffer: ConversationBuffer | null = null;
+  private identitySession: IdentitySession | null = null;
   private ackReactions = new Map<string, string>(); // messageId → reactionId
   private botMessageTracker = new BotMessageTracker(appConfig.botMessageTrackerSize);
   private latestMessageTracker = new LatestMessageTracker();
@@ -152,6 +156,24 @@ export class LarkChannel {
 
   setMemoryStore(store: MemoryStore): void {
     this.memoryStore = store;
+  }
+
+  setIdentitySession(session: IdentitySession): void {
+    this.identitySession = session;
+  }
+
+  /**
+   * Returns true if the given chat_id should be treated as a private
+   * (caller-only visible) chat for rendering-visibility purposes.
+   *
+   * - Real p2p chats: inferred from inbound event chat_type, cached.
+   * - Terminal sentinel: treated as private (the operator is the sole viewer).
+   * - Unknown chat_ids: default to false (treat as group) to bias the filter
+   *   toward less exposure when we have no signal.
+   */
+  isPrivateChat(chatId: string): boolean {
+    if (chatId === TERMINAL_CHAT_ID) return true;
+    return this.chatTypeCache.get(chatId) === 'p2p';
   }
 
   setConversationBuffer(buffer: ConversationBuffer): void {
@@ -368,8 +390,17 @@ export class LarkChannel {
       }
     }
 
+    // Cache chat type for later lookups (e.g. list_jobs visibility filter).
+    if (chatType === 'p2p' || chatType === 'group') {
+      this.chatTypeCache.set(chatId, chatType);
+    }
+
     // Enqueue for sequential per-chat processing
     this.queue.enqueue(chatId, threadId, async () => {
+      // Bind identity for this chat/thread so MCP tools can resolve the
+      // true caller without trusting Claude-declared identity arguments.
+      this.identitySession?.setCaller(chatId, threadId, senderId);
+
       // Record in conversation buffer
       this.conversationBuffer?.record(chatId, {
         role: 'user',

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,22 @@ export const appConfig = {
   maxSearchResults: optionalNumber('LARK_MAX_SEARCH_RESULTS', 2),
   inactivityHours: optionalNumber('LARK_INACTIVITY_HOURS', 3),
 
+  // Identity / privacy
+  ownerOpenId: process.env.LARK_OWNER_OPEN_ID || null,
+  /**
+   * Session entry TTL. Must comfortably exceed the buffer auto-flush window
+   * (LARK_INACTIVITY_HOURS) so that save_memory / save_skill calls triggered
+   * by a flush still resolve to the last real user of the chat.
+   * Default: max(2h, inactivityHours × 2).
+   */
+  identitySessionTtlMs: optionalNumber(
+    'LARK_IDENTITY_SESSION_TTL_MS',
+    Math.max(
+      2 * 60 * 60 * 1000,
+      optionalNumber('LARK_INACTIVITY_HOURS', 3) * 2 * 60 * 60 * 1000,
+    ),
+  ),
+
   // Paths
   memoriesDir: path.join(os.homedir(), '.claude', 'channels', 'lark', 'memories'),
   inboxDir: path.join(os.homedir(), '.claude', 'channels', 'lark', 'inbox'),

--- a/src/identity-session.ts
+++ b/src/identity-session.ts
@@ -1,0 +1,82 @@
+/**
+ * In-memory mapping from (chat_id, thread_id?) to the Feishu open_id of the
+ * current caller. Populated by channel.ts on inbound messages and by
+ * scheduler.ts when a cronjob fires. Consumed by sensitive MCP tools so they
+ * never need to trust Claude-declared identity arguments.
+ *
+ * Intentionally not persisted — the next inbound message or cronjob tick will
+ * re-populate relevant entries, so crash/restart is safe.
+ *
+ * Terminal invocations (e.g. /lark:jobs) pass the reserved chat_id
+ * `__terminal__` which resolves through the owner fallback.
+ *
+ * SECURITY NOTE: the __terminal__ sentinel is a trust-but-verify fallback.
+ * A socially-engineered prompt could theoretically instruct Claude to pass
+ * __terminal__ from a Feishu-triggered turn, escalating to operator
+ * privileges. Defense in depth:
+ *   1. MCP server instructions (index.ts) tell Claude to use the chat_id
+ *      from notification metadata verbatim and never substitute sentinels.
+ *   2. Phase 3 adds audit logging so any such attempt leaves a trail.
+ *   3. Future work may add server-side heuristic (reject __terminal__ when
+ *      there is a fresh real-chat session entry within the last N seconds).
+ * The sentinel is not exposed in any notification metadata, so Claude would
+ * need to invent the string on its own — practical risk is low.
+ */
+
+export const TERMINAL_CHAT_ID = '__terminal__';
+
+interface SessionEntry {
+  userId: string;
+  updatedAt: number;
+}
+
+export class IdentitySession {
+  private map = new Map<string, SessionEntry>();
+
+  constructor(
+    private readonly ownerFallback: () => string | null,
+    private readonly maxAgeMs: number = 3600_000,
+  ) {}
+
+  private key(chatId: string, threadId?: string): string {
+    return threadId ? `${chatId}#${threadId}` : chatId;
+  }
+
+  setCaller(chatId: string, threadId: string | undefined, userId: string): void {
+    this.map.set(this.key(chatId, threadId), { userId, updatedAt: Date.now() });
+  }
+
+  /**
+   * Returns the current caller for the given chat/thread, or null if none.
+   * Prefers the thread-specific entry; falls back to chat-level.
+   * Special-cases the terminal sentinel to the owner fallback.
+   */
+  getCaller(chatId: string, threadId?: string): string | null {
+    if (chatId === TERMINAL_CHAT_ID) {
+      return this.ownerFallback();
+    }
+    if (threadId) {
+      const entry = this.map.get(this.key(chatId, threadId));
+      if (entry && !this.isStale(entry)) return entry.userId;
+    }
+    const chatEntry = this.map.get(this.key(chatId));
+    if (chatEntry && !this.isStale(chatEntry)) return chatEntry.userId;
+    return null;
+  }
+
+  /** Drop entries older than maxAgeMs. Safe to call periodically. */
+  cleanup(): void {
+    for (const [k, v] of this.map.entries()) {
+      if (this.isStale(v)) this.map.delete(k);
+    }
+  }
+
+  private isStale(entry: SessionEntry): boolean {
+    return Date.now() - entry.updatedAt > this.maxAgeMs;
+  }
+
+  /** Test-only helper. */
+  _size(): number {
+    return this.map.size;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,9 @@ import { registerTools } from './tools.js';
 import { ConversationBuffer } from './memory/buffer.js';
 import { buildFlushPrompt } from './memory/distiller.js';
 import { MemoryStore } from './memory/file.js';
+import { IdentitySession } from './identity-session.js';
 import { JobScheduler } from './scheduler.js';
+import { mcpServerInstructions } from './prompts.js';
 
 const LOCK_FILE = path.join(os.tmpdir(), `claude-lark-${appConfig.appId}.lock`);
 
@@ -48,9 +50,20 @@ async function main() {
   const memoryStore = new MemoryStore();
   console.error(`[memory] Using ${appConfig.memoriesDir}`);
 
+  // 1b. Create identity session (server-side caller tracking for sensitive tools)
+  const identitySession = new IdentitySession(
+    () => appConfig.ownerOpenId,
+    appConfig.identitySessionTtlMs,
+  );
+  if (appConfig.ownerOpenId) {
+    console.error(`[identity] owner fallback: ${appConfig.ownerOpenId}`);
+  } else {
+    console.error('[identity] no LARK_OWNER_OPEN_ID set — terminal skill invocations will be denied');
+  }
+
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '0.8.5' },
+    { name: 'claude-lark-plugin', version: '0.9.0' },
     {
       capabilities: {
         logging: {},
@@ -58,22 +71,14 @@ async function main() {
           'claude/channel': {},
         },
       },
-      instructions: [
-        'Users see Feishu, not this transcript. Use reply to respond; edit_message to update; react for acknowledgements.',
-        'Always pass reply_to=message_id so replies thread correctly in Feishu. When several <channel> notifications are in context, reply_to MUST be the message_id from the specific <channel> tag you are responding to — not any other.',
-        'If the triggering <channel> tag has thread_id, pass it to reply. The plugin uses thread_id to route the reply into the correct thread even if reply_to is omitted or ambiguous.',
-        'If metadata has image_path, Read that file to see the image.',
-        'If metadata has attachment_file_id, call download_attachment with message_id and file_key, then Read the path.',
-        'Long replies with headings, code blocks, or tables render as a Feishu card automatically. Pass format=\'card\' to force, format=\'text\' to force plain. Optionally pass footer for a small footnote at the card bottom.',
-        'CronJob notifications arrive with source=\'cronjob\' in metadata. Dispatch these to a subagent when possible so the main thread stays available for Feishu messages. The chat_id in metadata is the target for your reply.',
-        'Use save_memory for important facts; save_skill for reusable procedures.',
-      ].join('\n'),
+      instructions: mcpServerInstructions,
     }
   );
 
   // 3. Create Lark channel
   const channel = new LarkChannel();
   channel.setMemoryStore(memoryStore);
+  channel.setIdentitySession(identitySession);
 
   // 4. Create conversation buffer + wire flush handler
   const buffer = new ConversationBuffer();
@@ -102,6 +107,8 @@ async function main() {
     server,
     channel.getClient(),
     memoryStore,
+    identitySession,
+    channel,
     buffer,
     channel.getAckReactions(),
     channel.getBotMessageTracker(),
@@ -175,6 +182,7 @@ async function main() {
   const scheduler = new JobScheduler({
     server: server.server,
     client: channel.getClient(),
+    identitySession,
   });
   await scheduler.start();
 

--- a/src/job-store.ts
+++ b/src/job-store.ts
@@ -21,7 +21,12 @@ export interface JobMeta {
   prompt?: string;
   content?: string;
   msg_type?: string;
+  /** Legacy field, equivalent to send_chat_id. Backfilled for forward compatibility. */
   target_chat_id: string;
+  /** Where the job delivers output. Used by list_jobs visibility filter. */
+  send_chat_id: string;
+  /** Where the job was created (debug/audit). For legacy jobs, backfilled from target_chat_id. */
+  origin_chat_id: string;
   status: 'active' | 'paused';
   created_by: string;
   created_at: string;
@@ -150,10 +155,28 @@ function jobPath(id: string): string {
   return path.join(appConfig.jobsDir, `${id}.json`);
 }
 
+/**
+ * Backfill new fields on pre-v0.9 jobs so the rest of the code can rely on them.
+ * Exported for unit testing; production callers should use readJob / listAllJobs.
+ */
+export function backfillJob(job: JobFile): JobFile {
+  if (!job.meta.send_chat_id) job.meta.send_chat_id = job.meta.target_chat_id;
+  if (!job.meta.origin_chat_id) job.meta.origin_chat_id = job.meta.target_chat_id;
+  // Legacy jobs may have empty created_by (the old create_job defaulted to '').
+  // Without a valid owner, update_job / delete_job would permanently reject
+  // every caller. Attribute to the operator via LARK_OWNER_OPEN_ID so the
+  // person running the upgrade can still manage them. If LARK_OWNER_OPEN_ID
+  // is unset, we leave the field empty — operator can set it and restart.
+  if (!job.meta.created_by && appConfig.ownerOpenId) {
+    job.meta.created_by = appConfig.ownerOpenId;
+  }
+  return job;
+}
+
 export async function readJob(id: string): Promise<JobFile | null> {
   try {
     const data = await fs.readFile(jobPath(id), 'utf-8');
-    return JSON.parse(data) as JobFile;
+    return backfillJob(JSON.parse(data) as JobFile);
   } catch {
     return null;
   }
@@ -181,7 +204,7 @@ export async function listAllJobs(): Promise<JobFile[]> {
     for (const file of files.filter(f => f.endsWith('.json'))) {
       try {
         const data = await fs.readFile(path.join(dir, file), 'utf-8');
-        jobs.push(JSON.parse(data) as JobFile);
+        jobs.push(backfillJob(JSON.parse(data) as JobFile));
       } catch (err) {
         console.error(`[job-store] Skipping corrupt job file ${file}:`, err);
       }

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -5,15 +5,21 @@
 
 /**
  * Distillation Stage 1: Buffer → Episode.
- * Instructs Claude to summarize a conversation and persist it as memory.
+ * Instructs Claude to summarize a conversation and persist it as a chat
+ * episode. Note (v0.9.0+): `save_memory` with type="profile" writes facts
+ * about the CALLER only (derived server-side from the session). During
+ * auto-flush there is no single "caller", so we only produce a chat-level
+ * episode summary here — individual profile updates happen in the dedicated
+ * profileDistillationPrompt path where the target user is unambiguous.
  */
 export function flushPrompt(chatId: string, conversation: string, messageCount: number): string {
   return `[Auto-memory-flush]
 The following is a conversation from chat ${chatId} (${messageCount} messages).
 Please:
 1. Write a 3-5 sentence summary focusing on: what was discussed, what was decided, what was resolved, and any open items.
-2. If you identified new user preferences or important facts, call save_memory(type="profile", open_id=<userId>, ...) for each user.
-3. Call save_memory(type="chat", chat_id="${chatId}", ...) with the conversation summary.
+2. Call save_memory(type="chat", content=<summary>, reason=<why>, chat_id="${chatId}") to persist it.
+
+Do NOT call save_memory(type="profile", ...) in this turn — profile writes require a specific caller identity, which an auto-flush does not have. Individual profile updates are handled by a separate distillation stage.
 
 --- Conversation ---
 ${conversation}
@@ -22,7 +28,11 @@ ${conversation}
 
 /**
  * Distillation Stage 2: Episodes → Profile.
- * Instructs Claude to extract durable facts from episode summaries into a user profile.
+ * Instructs Claude to extract durable facts from episode summaries into a
+ * user profile. Note (v0.9.0+): `save_memory` writes profile facts about
+ * the CALLER (derived server-side); the caller must be `${userId}` when
+ * this prompt fires, i.e. this prompt is triggered from a turn originally
+ * initiated by the target user.
  */
 export function profileDistillationPrompt(
   userId: string,
@@ -30,6 +40,7 @@ export function profileDistillationPrompt(
   episodeSummaries: string[]
 ): string {
   return `[Profile-distillation]
+Target user: ${userId}
 Current user profile:
 ${currentProfile || '(empty — no profile yet)'}
 
@@ -40,17 +51,36 @@ Please update the user profile:
 - ADD: new preferences, facts, expertise discovered in conversations
 - UPDATE: information that has changed (e.g., switched tech stack, new project)
 - REMOVE: outdated information no longer relevant
-Output the complete updated profile and call save_memory(type="profile", open_id="${userId}", ...).`;
+Output the complete updated profile and call save_memory(type="profile", content=<full profile>, reason=<why>, chat_id=<current chat>). The profile is saved for the caller of this turn, who should be ${userId}.`;
 }
+
+/**
+ * MCP server startup instructions — sent once during the initialize handshake
+ * and resident in Claude's context for the whole session (cached on repeat
+ * requests). Keep this short: duplication with tool descriptions is waste,
+ * and long system-level prose dilutes what Claude actually notices.
+ *
+ * Covers only cross-tool patterns and rules that no individual tool owns:
+ * channel semantics, per-notification routing, meta interpretation, cronjob
+ * dispatch, and server-side caller identity. Per-tool mechanics (card
+ * rendering, save_memory vs save_skill, etc.) live in tool descriptions.
+ */
+export const mcpServerInstructions: string = [
+  'Users see Feishu, not this transcript. Interact via reply / edit_message / react.',
+  'Each reply targets exactly one <channel> notification: pass its message_id as reply_to and its thread_id (if present) as thread_id. Do not cross fields between different notifications.',
+  'Meta image_path → Read that file. Meta attachment_file_id → call download_attachment(message_id, file_key) then Read the returned path.',
+  'CronJob notifications carry source=\'cronjob\'. Dispatch to a subagent so the main thread stays responsive to Feishu messages.',
+  'Sensitive tools (save_memory, create_job, list_jobs, update_job, delete_job) authorize the caller server-side from chat_id + thread_id. Always pass BOTH verbatim from the current notification\'s metadata — never substitute sentinels like "__terminal__" for a real chat_id.',
+].join('\n');
 
 /**
  * CronJob prompt injection.
  * Wraps the user's prompt with execution instructions for Claude.
  */
-export function cronJobPrompt(jobName: string, targetChatId: string, prompt: string): string {
+export function cronJobPrompt(jobName: string, sendChatId: string, prompt: string): string {
   return [
     `[CronJob: ${jobName}]`,
-    `Execute this task and reply to chat_id=${targetChatId} with the result.`,
+    `Execute this task and reply to chat_id=${sendChatId} with the result.`,
     `Do NOT reply to any other chat. Use a subagent when possible so the main thread stays responsive.`,
     ``,
     prompt,

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -9,6 +9,7 @@ import * as Lark from '@larksuiteoapi/node-sdk';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { appConfig } from './config.js';
 import { cronJobPrompt } from './prompts.js';
+import type { IdentitySession } from './identity-session.js';
 import {
   listAllJobs,
   writeJob,
@@ -19,6 +20,7 @@ import {
 export interface SchedulerOptions {
   server: Server;
   client: Lark.Client;
+  identitySession: IdentitySession;
 }
 
 // ─── Retry Logic ────────────────────────────────────────────
@@ -71,11 +73,13 @@ export class JobScheduler {
   private timer: NodeJS.Timeout | null = null;
   private server: Server;
   private client: Lark.Client;
+  private identitySession: IdentitySession;
   private running = false;
 
   constructor(opts: SchedulerOptions) {
     this.server = opts.server;
     this.client = opts.client;
+    this.identitySession = opts.identitySession;
   }
 
   /**
@@ -133,8 +137,12 @@ export class JobScheduler {
 
   /**
    * Periodic tick: scan all active jobs and execute due ones.
+   * Also piggybacks a cleanup pass over the identity session to drop
+   * stale entries so the in-memory map does not grow unboundedly.
    */
   private async tick(): Promise<void> {
+    this.identitySession.cleanup();
+
     const jobs = await listAllJobs();
     const now = Date.now();
 
@@ -228,7 +236,7 @@ export class JobScheduler {
     await this.client.im.v1.message.create({
       params: { receive_id_type: 'chat_id' },
       data: {
-        receive_id: job.meta.target_chat_id,
+        receive_id: job.meta.send_chat_id,
         content: JSON.stringify(msgType === 'text' ? { text: content } : { content }),
         msg_type: msgType,
       },
@@ -237,11 +245,21 @@ export class JobScheduler {
 
   /**
    * prompt type: inject prompt into Claude's channel via MCP notification.
+   *
+   * Each execution runs under a unique thread_id so its IdentitySession entry
+   * does not clobber concurrent inbound human messages in the same chat.
    */
   private async executePromptJob(job: JobFile): Promise<void> {
+    const jobThreadId = `job-${job.meta.id}-${Date.now()}`;
+
+    // Bind the job owner as caller so tools invoked from this Claude turn
+    // (e.g. save_memory, list_jobs) resolve to the job creator, not to any
+    // human who happened to send a message to the same chat.
+    this.identitySession.setCaller(job.meta.send_chat_id, jobThreadId, job.meta.created_by);
+
     const promptContent = cronJobPrompt(
       job.meta.name,
-      job.meta.target_chat_id,
+      job.meta.send_chat_id,
       job.meta.prompt ?? ''
     );
 
@@ -250,7 +268,8 @@ export class JobScheduler {
       params: {
         content: promptContent,
         meta: {
-          chat_id: job.meta.target_chat_id,
+          chat_id: job.meta.send_chat_id,
+          thread_id: jobThreadId,
           source: 'cronjob',
           job_id: job.meta.id,
           job_name: job.meta.name,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -6,7 +6,8 @@ import { appConfig } from './config.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { MemoryStore } from './memory/file.js';
 import type { ConversationBuffer } from './memory/buffer.js';
-import type { BotMessageTracker, LatestMessageTracker } from './channel.js';
+import type { BotMessageTracker, LatestMessageTracker, LarkChannel } from './channel.js';
+import type { IdentitySession } from './identity-session.js';
 import { buildCards, shouldUseCard } from './feishu-card.js';
 import {
   sanitizeJobId,
@@ -27,11 +28,49 @@ export function registerTools(
   server: McpServer,
   client: Lark.Client,
   memoryStore: MemoryStore,
+  identitySession: IdentitySession,
+  channel: LarkChannel,
   conversationBuffer?: ConversationBuffer,
   ackReactions?: Map<string, string>,
   botMessageTracker?: BotMessageTracker,
   latestMessageTracker?: LatestMessageTracker
 ): void {
+  /**
+   * Resolve the true caller for a sensitive tool invocation via the server-side
+   * IdentitySession. Returns either `{ caller }` on success or `{ error }` —
+   * an MCP tool result to return directly — on failure. This deliberately
+   * ignores any Claude-declared identity parameters.
+   */
+  function resolveCaller(
+    chat_id: string | undefined,
+    thread_id: string | undefined,
+  ):
+    | { caller: string }
+    | { error: { isError: true; content: { type: 'text'; text: string }[] } } {
+    if (!chat_id) {
+      return {
+        error: {
+          isError: true,
+          content: [{ type: 'text' as const, text: 'chat_id is required for this tool' }],
+        },
+      };
+    }
+    const caller = identitySession.getCaller(chat_id, thread_id);
+    if (!caller) {
+      return {
+        error: {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: `No active identity session for chat ${chat_id}. This tool requires an inbound Feishu message to establish caller identity, or a terminal invocation with LARK_OWNER_OPEN_ID set.`,
+            },
+          ],
+        },
+      };
+    }
+    return { caller };
+  }
   // ── 1. reply ──
   server.registerTool(
     'reply',
@@ -428,40 +467,35 @@ export function registerTools(
     'save_memory',
     {
       description:
-        'Save a memory entry for cross-session recall. Only save durable, reusable facts — user preferences, communication style, key decisions, ongoing projects, resolved problems. Do NOT save pleasantries, failed attempts, ephemeral details, or conversation filler.',
+        'Save a memory entry for cross-session recall. Only save durable, reusable facts — user preferences, communication style, key decisions, ongoing projects, resolved problems. Do NOT save pleasantries, failed attempts, ephemeral details, or conversation filler. Profile writes always save facts about the CALLER of this tool (i.e. the Feishu user whose message triggered the current turn) — you cannot save profile facts about a different user.',
       inputSchema: z.object({
         type: z
           .enum(['profile', 'chat', 'thread'])
           .describe(
-            'Memory type: "profile" for user preferences/facts, "chat" for conversation summary, "thread" for thread-level summary'
+            'Memory type: "profile" for facts about the caller, "chat" for conversation summary, "thread" for thread-level summary'
           ),
         content: z.string().describe('The memory content to save (concise, factual)'),
         reason: z.string().describe('Why this is worth remembering'),
-        chat_id: z.string().optional().describe('Chat ID (required for chat/thread type)'),
-        thread_id: z.string().optional().describe('Thread ID (required for thread type)'),
-        open_id: z.string().optional().describe('User open_id (required for profile type)'),
+        chat_id: z.string().describe('Chat ID — required; also used to resolve caller identity'),
+        thread_id: z
+          .string()
+          .optional()
+          .describe(
+            'Thread ID from the current notification\'s metadata. Required whenever present — both for server-side caller resolution (omitting it silently attributes the call to the wrong user in cronjob turns) and when type="thread".'
+          ),
       }),
     },
-    async ({ type, content, reason, chat_id, thread_id, open_id }) => {
+    async ({ type, content, reason, chat_id, thread_id }) => {
+      const auth = resolveCaller(chat_id, thread_id);
+      if ('error' in auth) return auth.error;
+      const { caller } = auth;
+
       if (type === 'profile') {
-        if (!open_id) {
-          return {
-            content: [{ type: 'text' as const, text: 'open_id is required for profile type' }],
-            isError: true,
-          };
-        }
-        await memoryStore.saveProfile(open_id, content);
+        await memoryStore.saveProfile(caller, content);
         return {
           content: [
-            { type: 'text' as const, text: `Saved profile for ${open_id}. Reason: ${reason}` },
+            { type: 'text' as const, text: `Saved profile for ${caller}. Reason: ${reason}` },
           ],
-        };
-      }
-
-      if (!chat_id) {
-        return {
-          content: [{ type: 'text' as const, text: 'chat_id is required for chat/thread type' }],
-          isError: true,
         };
       }
 
@@ -507,7 +541,7 @@ export function registerTools(
     'create_job',
     {
       description:
-        'Create a scheduled cronjob. Use type="message" for fixed content (deterministic) or type="prompt" for Claude-executed tasks (best-effort). For critical notifications use message type.',
+        'Create a scheduled cronjob. Use type="message" for fixed content (deterministic) or type="prompt" for Claude-executed tasks (best-effort). For critical notifications use message type. The creator identity is derived from the server-side session — you cannot create a job "on behalf of" another user.',
       inputSchema: z.object({
         name: z.string().describe('Job display name (can be Chinese)'),
         type: z.enum(['prompt', 'message']).describe('Job type'),
@@ -524,14 +558,25 @@ export function registerTools(
           .string()
           .optional()
           .describe('Fixed message content (type=message)'),
-        target_chat_id: z.string().describe('Chat ID to send results to'),
-        created_by: z
+        target_chat_id: z
+          .string()
+          .describe('Chat ID that receives job output (stored as send_chat_id for visibility filtering)'),
+        chat_id: z
+          .string()
+          .describe('Chat ID where this create_job call was triggered — used to resolve caller identity and to populate origin_chat_id'),
+        thread_id: z
           .string()
           .optional()
-          .describe('Creator open_id (auto-filled from channel context if omitted)'),
+          .describe(
+            'Thread ID from the current notification\'s metadata. Required whenever present — the server resolves caller identity from (chat_id, thread_id); omitting it falls back to chat-level and will silently attribute the call to the wrong user in cronjob turns.'
+          ),
       }),
     },
-    async ({ name, type, schedule, prompt, content, target_chat_id, created_by }) => {
+    async ({ name, type, schedule, prompt, content, target_chat_id, chat_id, thread_id }) => {
+      const auth = resolveCaller(chat_id, thread_id);
+      if ('error' in auth) return auth.error;
+      const { caller } = auth;
+
       // Validate type-specific fields
       if (type === 'prompt' && !prompt) {
         return {
@@ -587,8 +632,10 @@ export function registerTools(
           schedule_human: scheduleHuman,
           ...(type === 'prompt' ? { prompt } : { content, msg_type: 'text' }),
           target_chat_id,
+          send_chat_id: target_chat_id,
+          origin_chat_id: chat_id,
           status: 'active',
-          created_by: created_by ?? '',
+          created_by: caller,
           created_at: new Date().toISOString(),
         },
         runtime: {
@@ -616,32 +663,57 @@ export function registerTools(
   server.registerTool(
     'list_jobs',
     {
-      description: 'List all cronjobs and their status.',
+      description:
+        'List cronjobs visible in the current chat. Filter follows the rendering-visibility principle: in a private chat the caller sees all jobs they created; in a group chat everyone sees jobs that deliver output to that group (with prompt bodies redacted for non-owners).',
       inputSchema: z.object({
         status: z
           .enum(['active', 'paused', 'all'])
           .optional()
           .default('all')
           .describe('Filter by status'),
+        chat_id: z.string().describe('Chat ID where this list call is acting from'),
+        thread_id: z
+          .string()
+          .optional()
+          .describe(
+            'Thread ID from the current notification\'s metadata. Required whenever present — the server resolves caller identity from (chat_id, thread_id); omitting it falls back to chat-level and will silently attribute the call to the wrong user in cronjob turns.'
+          ),
       }),
     },
-    async ({ status }) => {
+    async ({ status, chat_id, thread_id }) => {
+      const auth = resolveCaller(chat_id, thread_id);
+      if ('error' in auth) return auth.error;
+      const { caller } = auth;
+
       const jobs = await listAllJobs();
-      const filtered =
+      const byStatus =
         status === 'all' ? jobs : jobs.filter((j) => j.meta.status === status);
 
-      if (filtered.length === 0) {
+      const isPrivate = channel.isPrivateChat(chat_id);
+      const visible = byStatus.filter((j) => {
+        if (isPrivate) return j.meta.created_by === caller;
+        return j.meta.send_chat_id === chat_id;
+      });
+
+      if (visible.length === 0) {
         return {
           content: [{ type: 'text' as const, text: 'No jobs found.' }],
         };
       }
 
-      const lines = filtered.map((j) => {
+      const lines = visible.map((j) => {
         const statusIcon = j.meta.status === 'active' ? '✅' : '⏸️';
         const lastRun = j.runtime.last_run_at
           ? new Date(j.runtime.last_run_at).toLocaleString()
           : 'never';
         const error = j.runtime.last_error ? ` ⚠️ ${j.runtime.last_error}` : '';
+        const isOwner = j.meta.created_by === caller;
+
+        // Group audit view — redact free-form content for non-owners.
+        // Keep created_by and schedule so the group retains accountability.
+        if (!isPrivate && !isOwner) {
+          return `${statusIcon} **${j.meta.id}** (${j.meta.type}) — ${j.meta.schedule_human}\n   By: ${j.meta.created_by} | Next: ${j.runtime.next_run_at}`;
+        }
         return `${statusIcon} **${j.meta.id}** (${j.meta.type}) — ${j.meta.schedule_human}\n   Next: ${j.runtime.next_run_at} | Last: ${lastRun} | Runs: ${j.runtime.run_count}${error}`;
       });
 
@@ -661,7 +733,7 @@ export function registerTools(
     'update_job',
     {
       description:
-        'Update a cronjob — change schedule, content, pause, or resume.',
+        'Update a cronjob — change schedule, content, pause, or resume. Only the job owner can mutate a job.',
       inputSchema: z.object({
         id: z.string().describe('Job ID'),
         status: z.enum(['active', 'paused']).optional().describe('Set status'),
@@ -669,13 +741,35 @@ export function registerTools(
         prompt: z.string().optional().describe('New prompt (type=prompt)'),
         content: z.string().optional().describe('New content (type=message)'),
         name: z.string().optional().describe('New display name'),
+        chat_id: z.string().describe('Chat ID where this update call is acting from'),
+        thread_id: z
+          .string()
+          .optional()
+          .describe(
+            'Thread ID from the current notification\'s metadata. Required whenever present — the server resolves caller identity from (chat_id, thread_id); omitting it falls back to chat-level and will silently attribute the call to the wrong user in cronjob turns.'
+          ),
       }),
     },
-    async ({ id, status, schedule, prompt, content, name }) => {
+    async ({ id, status, schedule, prompt, content, name, chat_id, thread_id }) => {
+      const auth = resolveCaller(chat_id, thread_id);
+      if ('error' in auth) return auth.error;
+      const { caller } = auth;
+
       const job = await readJob(id);
       if (!job) {
         return {
           content: [{ type: 'text' as const, text: `Job "${id}" not found.` }],
+          isError: true,
+        };
+      }
+      if (job.meta.created_by !== caller) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `You are not the owner of "${id}". Only ${job.meta.created_by} can update it.`,
+            },
+          ],
           isError: true,
         };
       }
@@ -733,12 +827,42 @@ export function registerTools(
   server.registerTool(
     'delete_job',
     {
-      description: 'Delete a cronjob permanently.',
+      description: 'Delete a cronjob permanently. Only the job owner can delete.',
       inputSchema: z.object({
         id: z.string().describe('Job ID to delete'),
+        chat_id: z.string().describe('Chat ID where this delete call is acting from'),
+        thread_id: z
+          .string()
+          .optional()
+          .describe(
+            'Thread ID from the current notification\'s metadata. Required whenever present — the server resolves caller identity from (chat_id, thread_id); omitting it falls back to chat-level and will silently attribute the call to the wrong user in cronjob turns.'
+          ),
       }),
     },
-    async ({ id }) => {
+    async ({ id, chat_id, thread_id }) => {
+      const auth = resolveCaller(chat_id, thread_id);
+      if ('error' in auth) return auth.error;
+      const { caller } = auth;
+
+      const existing = await readJob(id);
+      if (!existing) {
+        return {
+          content: [{ type: 'text' as const, text: `Job "${id}" not found.` }],
+          isError: true,
+        };
+      }
+      if (existing.meta.created_by !== caller) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `You are not the owner of "${id}". Only ${existing.meta.created_by} can delete it.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
       const deleted = await deleteJobFile(id);
       if (!deleted) {
         return {


### PR DESCRIPTION
Closes #35 (phase 1 of 3).
Builds on #36 (Phase 0: dropped the pluggable memory abstraction, v0.8.5).

## What this phase does

**Stops the two highest-severity privacy leaks from #35:**

1. **`list_jobs` no longer exposes everyone's jobs to everyone.** Rendering-visibility filter: private chat → caller sees their own jobs; group chat → members see jobs delivering output to that group, with prompt bodies redacted for non-owners.

2. **Sensitive tools stop trusting Claude-declared identity.** Server-side `IdentitySession` maps `(chat_id, thread_id?) → open_id` using the authenticated Feishu event stream. Tools derive the caller from the session, not from arguments — so "act as kk and save this to her profile" no longer works.

## Design recap

- **`IdentitySession`** (`src/identity-session.ts`): in-memory table, TTL-based cleanup piggybacked on scheduler tick. Populated by `channel.ts` on every inbound message and by `scheduler.ts` before each cronjob trigger. Reserved `__terminal__` chat id resolves via `LARK_OWNER_OPEN_ID`.
- **Cronjob isolation**: each execution runs under a unique `thread_id` (`job-<id>-<timestamp>`) so its session entry doesn't clobber concurrent human messages.
- **Job schema**: new `send_chat_id` and `origin_chat_id` fields. Legacy jobs backfill on read. Empty `created_by` on legacy jobs is attributed to `LARK_OWNER_OPEN_ID` so operator keeps mutation rights.
- **Rendering-visibility principle**: filter by *where the answer renders*, not *who's asking*.

Full design in `docs/superpowers/specs/2026-04-19-lark-privacy-design.md`; task-by-task plan in `docs/superpowers/plans/2026-04-19-phase1-identity-cronjob-visibility.md` (both included in this PR).

## User-visible API changes

- `save_memory` no longer accepts `open_id` — profile writes target the caller.
- `create_job` requires `chat_id` (for caller resolution) and no longer accepts `created_by`.
- `list_jobs` / `update_job` / `delete_job` require `chat_id`.
- New config: `LARK_OWNER_OPEN_ID` (required for terminal skills), `LARK_IDENTITY_SESSION_TTL_MS` (auto-computed default of `max(2h, LARK_INACTIVITY_HOURS × 2h)`).

## Commits (3)

| Commit | Scope |
|---|---|
| `feat(identity): ...` | All source code + scripts + user-facing docs (README, CLAUDE.md, .env.example, configure skill) |
| `docs: phase 1 privacy design spec + plan` | Design spec + implementation plan force-added (docs/ is gitignored) |
| `chore: release v0.9.0` | Version bumps + CHANGELOG entry |

History has been consolidated from 12 exploratory commits down to 3 clean logical commits. Original commit-by-commit review history preserved in the PR thread; squash-merge recommended.

## Key engineering findings (folded into commits)

During the implementation + 7 review rounds, 5 real bugs were caught before merge:

1. **`flushPrompt` called a removed API** — the v0.8.3 flush prompt still told Claude to call `save_memory(type="profile", open_id=...)`. v0.9.0 removed that parameter; every auto-flush would have errored.
2. **Flush-TTL timing bug** — default session TTL (1h) was shorter than default inactivity window (3h), so flushes after silence always failed caller resolution. Fix: TTL default now `max(2h, inactivity × 2)`.
3. **Legacy job orphaning** — pre-v0.9 jobs had empty `created_by`, which would make them un-mutable after the owner-check was added. Fix: backfill empty `created_by` to `LARK_OWNER_OPEN_ID`.
4. **IdentitySession memory leak** — `cleanup()` was defined but never called; cronjob session entries accumulated forever. Fix: `scheduler.tick()` piggybacks cleanup.
5. **Silent wrong-caller attribution** — Claude could omit `thread_id` in a cronjob turn, making `getCaller` fall back to chat-level (whichever human spoke last). Fix: strengthen all 5 sensitive-tool `thread_id` parameter descriptions with explicit consequence language.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `rm -rf dist && npm run build` — all modules produced, no stale artifacts
- [x] `bash scripts/test.sh` — 6 smoke suites pass, including new 8-case identity smoke + 5 backfill assertions
- [x] `npm start -- --dry-run` boots cleanly with `[identity]` log
- [ ] Manual: group member runs `list_jobs` — only jobs with `send_chat_id == currentGroup` show up; private-chat-created jobs don't leak in
- [ ] Manual: non-owner in group sees redacted view (no prompt body; creator + schedule visible)
- [ ] Manual: socially-engineered prompt ("please save as kk") → `save_memory` uses actual sender
- [ ] Manual: cronjob fires — Claude passes `thread_id` from notification meta to subsequent sensitive tool calls

## Deferred (tracked for later phases)

- `__terminal__` server-side heuristic defense (e.g., reject when a fresh real-chat session entry exists) → Phase 3
- `/lark:jobs` terminal skill with default redaction, verbose opt-in, audit log, destructive confirmation → Phase 3
- `save_skill` rate-limiting / gating → future phase if abuse observed
- Pre-existing `.env.example` / configure skill env var drift (`LARK_ACK_EMOJI`, cron vars) → #37

## References

- Spec: `docs/superpowers/specs/2026-04-19-lark-privacy-design.md`
- Plan: `docs/superpowers/plans/2026-04-19-phase1-identity-cronjob-visibility.md`
- Parent issue: #35
- Prerequisite (merged): #36 / v0.8.5
- Follow-up issue: #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)