### PR TITLE
feat: memory transparency + self-learning + terminal safeguards (v0.11.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "author": {
     "name": "IS908"
   },

--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,4 @@ LARK_APP_SECRET=
 # LARK_OWNER_OPEN_ID=            # Operator open_id — enables terminal skills like /lark:jobs
 # LARK_IDENTITY_SESSION_TTL_MS=  # Session entry TTL in ms (default: max(2h, inactivity × 2))
 # LARK_PRIVACY_RULES_FILE=       # L2 user rules file path (default: ~/.claude/channels/lark/privacy-rules.md)
+# LARK_AUDIT_LOG=                # Audit log path (default: ~/.claude/channels/lark/audit.log)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.11.0] - 2026-04-19
+
+Phase 3 of the privacy redesign. Adds user-facing control over what the bot remembers, a self-learning loop that promotes user corrections into persistent rules, and terminal-side safeguards against incidental exposure.
+
+### Added
+- **`what_do_you_know` tool** — lists the caller's profile entries with per-line 8-char hashes. Path-B tool (filtered by rendering visibility): in private chat, both public + private tiers are shown; in a group, only the public tier (the reply is visible to the whole group). Each line's hash is the handle that `forget_memory` uses to remove it.
+- **`forget_memory` tool** — removes a specific line from the caller's profile by hash. Always caller-scoped; idempotent. Optional `promote_to_rule: true` appends the removed line to `privacy-rules.md` under `## Always private` so future distillations classify similar content as private — this is the **self-learning loop**: user corrections become persistent L2 rules without requiring manual file editing.
+- **Append-only audit log** (`src/audit-log.ts`) at `~/.claude/channels/lark/audit.log`. Every sensitive-tool invocation (save_memory / create_job / list_jobs / update_job / delete_job / what_do_you_know / forget_memory) writes a line recording the timestamp, tool name, outcome (ok/denied/error), caller, and a redacted args preview. Long string fields are truncated to 60 chars + length marker. Best-effort — log failures never propagate.
+- **`/lark:jobs` terminal skill** (`skills/jobs/SKILL.md`) — reworked to default to a **redacted** output view that hides `prompt`, `content`, and free-form `meta` fields. The user must explicitly ask "verbose" / "show full" / "dump prompt" to see them. Destructive operations (delete / pause / reschedule / prompt-change) prompt for interactive confirmation.
+- `LARK_AUDIT_LOG` config key — optional override for the audit log path.
+- `MemoryStore.listProfileLines(ownerId, tier)` / `removeProfileLine(ownerId, tier, hash)` — line-level profile helpers that power `what_do_you_know` and `forget_memory`. New exported `ProfileLine` type.
+- `scripts/transparency-smoke.ts` — 9 smoke assertions covering list/remove/idempotency, cross-tier isolation, L2 rule-append round-trip, audit log redaction, and audit-log guard against unserializable args (BigInt, circular refs).
+
+### Changed
+- **`resolveCaller` now audit-logs denials automatically.** Takes `toolName` and `args` as new parameters; all 7 sensitive tool handlers updated to pass them. Callers only need to emit an `ok` audit on successful completion — denial paths are handled in the helper.
+- Sensitive tools emit `void audit(toolName, caller, args, 'ok')` at each success return path, completing the audit coverage.
+
+### Security
+- **Users gain inspection + correction rights over their own profile.** Previously, profiles were silently distilled without any user-facing way to review or remove entries. `what_do_you_know` + `forget_memory` close this gap, and the `promote_to_rule` option turns each correction into a durable policy.
+- **Terminal-side exposure reduced.** The `/lark:jobs` skill no longer dumps prompt bodies by default — a significant mitigation against screen-share and shoulder-surfing leaks. Destructive operations require confirmation.
+- **Retrospective auditability.** The operator can inspect `audit.log` to see exactly which tools were invoked on their machine, when, by whom, and whether the call succeeded or was denied. Useful for post-incident review (borrowed laptop, accidental invocation, etc.).
+
+### Migration
+- **No operator action required.** The existing `/lark:jobs` skill continues to work; invocations now return the redacted view by default. The audit log file is created on first use.
+- The `buildProfileDistillationPrompt` + `parseTieredProfile` infrastructure added in v0.10.0 is still not triggered by any production code path in this release — explicit distillation loops are left for future work.
+
 ## [0.10.0] - 2026-04-19
 
 Phase 2 of the privacy redesign (#35). Closes the profile-memory cross-chat leak — facts distilled from a user's private chat no longer surface when someone else @mentions that user in a group.
@@ -228,6 +254,7 @@ Precondition for the privacy redesign (#35). A pluggable abstraction made every 
 - Score-based filtering (`LARK_MIN_SEARCH_SCORE`)
 - HealthCheck for memory provider connectivity
 
+[0.11.0]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.11.0
 [0.10.0]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.10.0
 [0.9.0]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.9.0
 [0.8.5]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.8.5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ npm start -- --dry-run # Validate config and module loading without connecting
 src/index.ts        – Entry point: wires MCP server, LarkChannel, memory, and buffer together
 src/config.ts       – Loads config from ~/.claude/channels/lark/.env (dotenv)
 src/channel.ts      – LarkChannel: Feishu WebSocket client, message parsing, memory enrichment pipeline
-src/tools.ts        – Registers 10 MCP tools: reply, edit_message, react, download_attachment, save_memory, save_skill, create_job, list_jobs, update_job, delete_job
+src/tools.ts        – Registers 12 MCP tools: reply, edit_message, react, download_attachment, save_memory, save_skill, create_job, list_jobs, update_job, delete_job, what_do_you_know, forget_memory
+src/audit-log.ts    – Append-only audit log for sensitive tool invocations
 src/feishu-card.ts  – Card builder: markdown optimization, Schema 2.0 card assembly
 src/job-store.ts    – Job CRUD: read/write JSON files, sanitizeJobId, expandScheduleAlias
 src/scheduler.ts    – JobScheduler: periodic scan (60s), trigger execution, crash recovery
@@ -40,7 +41,7 @@ src/privacy-rules.ts  – L1 hardcoded regex + keyword rules; L2 user-rules file
 
 **CronJob flow:** `JobScheduler.tick()` every 60s → read all job files → for each active job where `next_run_at <= now` → execute (message: direct Feishu API / prompt: inject via `notifications/claude/channel` under a unique `thread_id` + bind session identity to `job.created_by`) → update `runtime` in job file. On startup, `recoverMissedJobs()` runs the same check once for crash recovery.
 
-**Identity flow (v0.9.0+):** Every inbound message calls `identitySession.setCaller(chatId, threadId, senderId)` before enqueue. Sensitive MCP tools (`save_memory`, `create_job`, `list_jobs`, `update_job`, `delete_job`) derive the caller from the session via `resolveCaller(chat_id, thread_id)` — they never trust Claude-declared identity parameters. Terminal skills use the reserved `chat_id = "__terminal__"` which resolves to `LARK_OWNER_OPEN_ID`.
+**Identity flow (v0.9.0+):** Every inbound message calls `identitySession.setCaller(chatId, threadId, senderId)` before enqueue. Sensitive MCP tools (`save_memory`, `create_job`, `list_jobs`, `update_job`, `delete_job`, `what_do_you_know`, `forget_memory`) derive the caller from the session via `resolveCaller(chat_id, thread_id)` — they never trust Claude-declared identity parameters. Terminal skills use the reserved `chat_id = "__terminal__"` which resolves to `LARK_OWNER_OPEN_ID`.
 
 ## Key Design Decisions
 
@@ -53,6 +54,8 @@ src/privacy-rules.ts  – L1 hardcoded regex + keyword rules; L2 user-rules file
 - **3-layer privacy classification**: L1 hardcoded regex/keyword rules (in code) > L2 user-edited `privacy-rules.md` (injected into distiller prompt) > L3 LLM judgment. `parseTieredProfile` applies L1 as a safety net over LLM output.
 - **Identity is server-derived**: `IdentitySession` maps `(chat_id, thread_id?) → open_id` from authenticated Feishu events. MCP tools never accept a client-declared `open_id` or `created_by` — those are resolved server-side. Trust anchor = Feishu webhook signature.
 - **CronJob visibility**: `list_jobs` filters by rendering-visibility — private chat shows caller's own jobs; group shows jobs whose `send_chat_id` matches the current chat (with prompt bodies redacted for non-owners). `update_job` / `delete_job` are owner-only.
+- **Memory transparency (v0.11.0+)**: `what_do_you_know` returns the caller's profile entries (filtered by current-chat visibility); `forget_memory` removes a line by 8-char hash. `forget_memory(promote_to_rule=true)` appends the removed line to `privacy-rules.md` so future distillations classify similar content as private — the self-learning loop that completes the L1/L2/L3 infrastructure from v0.10.0.
+- **Audit log (v0.11.0+)**: every sensitive-tool invocation appends a line to `~/.claude/channels/lark/audit.log` (ok/denied/error with redacted args). Best-effort — log failures never propagate into tool behavior.
 - **Image auto-download**: Images are downloaded to `~/.claude/channels/lark/inbox/` on receive. Claude reads local paths via `image_path` in notification meta.
 - **Ack reaction**: Configurable emoji (`LARK_ACK_EMOJI`, default `MeMeMe`) sent on receive, auto-revoked after reply. Fire-and-forget, won't block message processing.
 - **Bot message tracking**: `BotMessageTracker` (default 500, FIFO, configurable via `LARK_BOT_MESSAGE_TRACKER_SIZE`) tracks bot-sent message IDs. Used to filter reaction events — only reactions on bot messages are forwarded to Claude.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ The plugin connects to Feishu via the Lark SDK WebSocket client, receives messag
 
 ### Privacy & Security (v0.9.0+)
 
-- **Server-derived caller identity**: sensitive tools (`save_memory`, `create_job`, `list_jobs`, `update_job`, `delete_job`) resolve the calling user from the authenticated Feishu event stream, not from tool arguments — socially-engineered prompts cannot act on behalf of another user
+- **Server-derived caller identity**: sensitive tools (`save_memory`, `create_job`, `list_jobs`, `update_job`, `delete_job`, `what_do_you_know`, `forget_memory`) resolve the calling user from the authenticated Feishu event stream, not from tool arguments — socially-engineered prompts cannot act on behalf of another user
+- **Memory transparency (v0.11.0+)**: `what_do_you_know` lists what the bot has stored about the caller (filtered by current-chat visibility); `forget_memory` removes a specific line by hash. Optional `promote_to_rule` feeds corrections into `privacy-rules.md` — a self-learning loop that makes future misclassifications less likely
+- **Append-only audit log (v0.11.0+)**: `~/.claude/channels/lark/audit.log` records every sensitive-tool invocation (timestamp / tool / caller / outcome / redacted args) so the operator can retrospectively inspect what was accessed on their machine
+- **Terminal skills default to redacted output (v0.11.0+)**: `/lark:jobs` hides prompt bodies by default; verbose opt-in is required. Destructive operations require interactive confirmation
 - **Tiered profile memory (v0.10.0+)**: each user's profile is split into `public.md` (visible to anyone who @mentions the user) and `private.md` (owner-only). Private-chat preferences no longer leak into groups via @mention injection
 - **L1/L2/L3 classification** (v0.10.0+): hardcoded regex + keyword rules catch phones / credentials / sensitive Chinese keywords. Email is intentionally NOT in L1 — the plugin targets **work-chat use cases** where emails are commonly shared via signatures/directories; personal deployments can add their own "Always private" email rule to `privacy-rules.md`. User-editable `privacy-rules.md` covers personal/org-specific cases; LLM handles the nuance. `parseTieredProfile` applies an L1 safety net over LLM output so misclassified credentials get forced to private
 - **`list_jobs` visibility filter**: in a group chat, members only see jobs whose `send_chat_id` matches that group (with prompt bodies redacted for non-owners); in a private chat, the caller sees their own jobs. Group members can no longer inspect each other's private jobs
@@ -256,6 +259,7 @@ On every incoming message, the plugin injects relevant memory context in this or
 | `LARK_OWNER_OPEN_ID` | (empty) | Operator open_id. Enables terminal skill invocations (e.g. `/lark:jobs`) to resolve the caller via the reserved `__terminal__` chat id. When unset, terminal-side sensitive operations are denied. |
 | `LARK_IDENTITY_SESSION_TTL_MS` | `max(2h, LARK_INACTIVITY_HOURS × 2h)` | Lifetime of a server-side `(chat_id, thread_id?) → open_id` session entry. Must exceed the auto-flush window so distillation-triggered tool calls still resolve to the last real user. |
 | `LARK_PRIVACY_RULES_FILE` | `~/.claude/channels/lark/privacy-rules.md` | Override the path to the L2 user rules file. The distiller injects this file's contents into its classification prompt. |
+| `LARK_AUDIT_LOG` | `~/.claude/channels/lark/audit.log` | Override the path to the append-only audit log. Every sensitive-tool invocation is recorded (best-effort; log failures never propagate). (v0.11.0+) |
 
 ---
 
@@ -344,6 +348,8 @@ The plugin registers the following MCP tools for Claude to use:
 | `list_jobs` | List cronjobs visible in the current chat. Filter follows rendering-visibility: private → caller's own jobs, group → jobs with `send_chat_id == currentChat` (prompts redacted for non-owners). Requires `chat_id`. |
 | `update_job` | Update a cronjob (schedule, content, pause/resume). Owner-only. Requires `chat_id`. |
 | `delete_job` | Delete a cronjob. Owner-only. Requires `chat_id`. |
+| `what_do_you_know` | List what the bot has stored in the caller's profile. Filtered by rendering visibility (both tiers in p2p, public only in groups). Each line carries an 8-char hash for use with `forget_memory`. (v0.11.0+) |
+| `forget_memory` | Remove a specific line from the caller's profile by hash. Caller-scoped and idempotent. Optional `promote_to_rule` promotes the removal into a durable `## Always private` rule in `privacy-rules.md`. (v0.11.0+) |
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -45,7 +45,10 @@
 
 ### 隐私与安全（v0.9.0+）
 
-- **服务端派生的调用者身份**：敏感工具（`save_memory` / `create_job` / `list_jobs` / `update_job` / `delete_job`）从飞书事件流派生调用者身份，不信任工具参数——社工提示无法假冒他人操作
+- **服务端派生的调用者身份**：敏感工具（`save_memory` / `create_job` / `list_jobs` / `update_job` / `delete_job` / `what_do_you_know` / `forget_memory`）从飞书事件流派生调用者身份，不信任工具参数——社工提示无法假冒他人操作
+- **记忆透明度（v0.11.0+）**：`what_do_you_know` 列出 bot 记住了调用者的哪些信息（按当前 chat 可见性过滤）；`forget_memory` 按 hash 删除特定条目，可选 `promote_to_rule` 把删除动作沉淀为 `privacy-rules.md` 中的规则——**自学习闭环**让误判随使用递减
+- **追加式审计日志（v0.11.0+）**：`~/.claude/channels/lark/audit.log` 记录每次敏感工具调用（时间戳 / 工具名 / 调用者 / 结果 / 脱敏后的参数摘要），运营者可事后回溯查看本机上发生了什么
+- **终端技能默认脱敏（v0.11.0+）**：`/lark:jobs` 默认不展示 prompt 正文，需显式要求 verbose；破坏性操作需交互确认
 - **分层 profile 记忆（v0.10.0+）**：每个用户的 profile 拆成 `public.md`（他人 @mention 时可见）和 `private.md`（仅 owner 可见）。私聊里的偏好不会通过 @mention 注入泄露到群聊
 - **L1/L2/L3 分类体系**（v0.10.0+）：硬编码的 regex + 关键词规则拦截手机/凭据/敏感中文词。邮箱**不在** L1——本插件定位为**工作 IM 场景**，工作邮箱常通过签名和通讯录公开；个人使用的部署可以在自己的 `privacy-rules.md` 里加一条 "Always private" 规则专门归类邮箱。用户可编辑的 `privacy-rules.md` 处理个人和组织特有场景；LLM 处理灰色地带。`parseTieredProfile` 在 LLM 分类之上加 L1 兜底——误判为 public 的凭据被强制归 private
 - **`list_jobs` 可见性过滤**：群聊里只能看到 `send_chat_id` 匹配本群的 job（非 owner 看不到 prompt 正文）；私聊里只能看到自己建的 job。群成员不再能互相窥探定时任务
@@ -241,6 +244,7 @@ node -e "console.log(require('./package.json').version)"
 | `LARK_OWNER_OPEN_ID` | （空） | 运营者 open_id。用于终端技能（如 `/lark:jobs`）通过 `__terminal__` 哨兵 chat_id 解析调用者。未设置时，终端侧的敏感操作将被拒绝 |
 | `LARK_IDENTITY_SESSION_TTL_MS` | `max(2h, LARK_INACTIVITY_HOURS × 2h)` | 服务端 `(chat_id, thread_id?) → open_id` 会话条目的 TTL。必须超过自动蒸馏窗口，以保证 flush 触发的工具调用仍能解析到最后的真实用户 |
 | `LARK_PRIVACY_RULES_FILE` | `~/.claude/channels/lark/privacy-rules.md` | L2 用户规则文件路径。蒸馏器会把文件内容注入分类 prompt（v0.10.0+）|
+| `LARK_AUDIT_LOG` | `~/.claude/channels/lark/audit.log` | 审计日志路径。每次敏感工具调用都会追加一行（尽力而为，写入失败不影响工具行为）（v0.11.0+）|
 
 ---
 
@@ -338,6 +342,8 @@ tmux kill-session -t lark
 | `list_jobs` | `(status?, chat_id, thread_id?)` | 列出当前 chat 可见的 job。私聊返回 caller 自己建的；群里返回 `send_chat_id` 为本群的（非 owner 视图脱敏 prompt）|
 | `update_job` | `(id, status?, schedule?, prompt?, content?, name?, chat_id, thread_id?)` | 修改 job。仅 owner 可操作 |
 | `delete_job` | `(id, chat_id, thread_id?)` | 删除 job。仅 owner 可操作 |
+| `what_do_you_know` | `(chat_id, thread_id?)` | 列出 bot 存储的当前调用者 profile 条目。按可见性过滤（私聊展示 public+private，群里只展示 public）。每行附带 8 位 hash，供 `forget_memory` 使用（v0.11.0+）|
+| `forget_memory` | `(chat_id, thread_id?, hash, tier?, promote_to_rule?)` | 按 hash 删除 profile 里的某行。调用者本人才能操作。可选 `promote_to_rule=true` 把本次删除沉淀为 `privacy-rules.md` 的永久规则（v0.11.0+）|
 
 ---
 

--- a/docs/superpowers/plans/2026-04-19-phase3-transparency-terminal.md
+++ b/docs/superpowers/plans/2026-04-19-phase3-transparency-terminal.md
@@ -1,0 +1,569 @@
+# Phase 3 — Transparency Tools, Self-Learning, Terminal Safeguards
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give users visibility and control over what the bot remembers (`what_do_you_know`, `forget_memory`), a self-learning loop that feeds removals back into the L2 rules, and terminal-side safeguards (default redaction, audit log, destructive confirmation) for `/lark:jobs` and similar skills.
+
+**Architecture:** Two new MCP tools implement the transparency surface using the rendering-visibility principle from Phase 1 (`what_do_you_know` filters by current chat). `forget_memory` removes a line from the caller's profile and surfaces a rule-append prompt. A new `/lark:jobs` skill (skills/jobs/SKILL.md existing or created) wraps `list_jobs` with default redaction + `--verbose`. Audit log is append-only file writes. Destructive confirmations are implemented as interactive skill steps, not tool-layer logic.
+
+**Tech Stack:** TypeScript, MCP tools, Claude Code skills (markdown).
+
+**Spec:** `docs/superpowers/specs/2026-04-19-lark-privacy-design.md` (sections: "Memory Transparency & Self-Learning", "Terminal Safeguards")
+
+**Issue:** #35 (phase 3 of 3)
+
+**Prerequisites:** Phase 0, Phase 1, and Phase 2 merged.
+
+---
+
+## File Structure
+
+| File | Responsibility | Create/Modify |
+|---|---|---|
+| `src/tools.ts` | `what_do_you_know`, `forget_memory` tools + audit-log wrapper | Modify |
+| `src/memory/file.ts` | `removeProfileLine`, `listProfileLines` helpers on `MemoryStore` | Modify |
+| `src/audit-log.ts` | Append-only audit log writer | Create |
+| `skills/jobs/SKILL.md` | `/lark:jobs` terminal skill with redaction + confirmation | Create or modify |
+| `scripts/transparency-smoke.ts` | Tool + rule-append smoke | Create |
+| `scripts/test.sh` | Wire in new smoke | Modify |
+| `CHANGELOG.md`, version files | Bump to v0.11.0 | Modify |
+
+---
+
+## Task 1: Profile line-level helpers
+
+**Files:**
+- Modify: `src/memory/file.ts`
+
+- [ ] **Step 1.1: Add methods to MemoryStore**
+
+Append inside the `MemoryStore` class in `src/memory/file.ts`:
+
+```typescript
+import { createHash } from 'node:crypto';
+
+function lineHash(line: string): string {
+  return createHash('sha1').update(line).digest('hex').slice(0, 8);
+}
+
+export async function listProfileLines(
+  ownerId: string,
+  tier: 'public' | 'private',
+): Promise<Array<{ index: number; hash: string; text: string }>> {
+  await migrateIfNeeded(ownerId);
+  const p = tierPath(ownerId, tier);
+  if (!existsSync(p)) return [];
+  const content = await readFile(p, 'utf8');
+  return content
+    .split('\n')
+    .map((raw) => raw.trim())
+    .filter(Boolean)
+    .map((text, index) => ({ index, hash: lineHash(text), text }));
+}
+
+export async function removeProfileLine(
+  ownerId: string,
+  tier: 'public' | 'private',
+  hash: string,
+): Promise<boolean> {
+  const lines = await listProfileLines(ownerId, tier);
+  const kept = lines.filter((l) => l.hash !== hash);
+  if (kept.length === lines.length) return false;
+  const next = kept.map((l) => l.text).join('\n') + '\n';
+  await writeFile(tierPath(ownerId, tier), next, 'utf8');
+  return true;
+}
+```
+
+- [ ] **Step 1.2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add src/memory/file.ts
+git commit -m "feat(memory): listProfileLines / removeProfileLine helpers"
+```
+
+---
+
+## Task 2: `what_do_you_know` tool
+
+**Files:**
+- Modify: `src/tools.ts`
+
+- [ ] **Step 2.1: Register the tool**
+
+Inside `registerTools`, add:
+
+```typescript
+// ── what_do_you_know ──
+server.registerTool(
+  'what_do_you_know',
+  {
+    description:
+      "Show the caller what the bot has stored in their profile. Path-B (explicit output): filtered by current chat's visibility — in groups, only the public tier is returned.",
+    inputSchema: z.object({
+      chat_id: z.string().describe('The chat this call is acting from'),
+      thread_id: z.string().optional(),
+    }),
+  },
+  async ({ chat_id, thread_id }) => {
+    const auth = resolveCaller(chat_id, thread_id);
+    if ('error' in auth) return auth.error;
+    const { caller } = auth;
+
+    const isPrivate = isPrivateChat(chat_id);
+    const pub = await memoryStore.listProfileLines(caller, 'public');
+    const priv = isPrivate
+      ? await memoryStore.listProfileLines(caller, 'private')
+      : [];
+
+    const render = (
+      tier: string,
+      lines: Array<{ hash: string; text: string }>,
+    ) =>
+      lines.length === 0
+        ? `_${tier}: (empty)_`
+        : `**${tier}:**\n${lines.map((l) => `- [${l.hash}] ${l.text}`).join('\n')}`;
+
+    const parts = [render('public', pub)];
+    if (isPrivate) parts.push(render('private', priv));
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text:
+            `What I know about you (in this chat's visibility):\n\n${parts.join('\n\n')}\n\n_Use \`forget_memory\` with a hash to remove a line._`,
+        },
+      ],
+    };
+  },
+);
+```
+
+- [ ] **Step 2.2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add src/tools.ts
+git commit -m "feat(memory): add what_do_you_know MCP tool"
+```
+
+---
+
+## Task 3: `forget_memory` tool with rule-append suggestion
+
+**Files:**
+- Modify: `src/tools.ts`
+
+- [ ] **Step 3.1: Register the tool**
+
+```typescript
+// ── forget_memory ──
+server.registerTool(
+  'forget_memory',
+  {
+    description:
+      'Remove a specific line from the caller’s profile. Always caller-scoped — you can only forget things about yourself. Optionally promotes the removal into a persistent L2 rule.',
+    inputSchema: z.object({
+      chat_id: z.string(),
+      thread_id: z.string().optional(),
+      hash: z.string().describe('8-char line hash from what_do_you_know'),
+      tier: z.enum(['public', 'private']).default('public'),
+      promote_to_rule: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          'If true, the removed line is appended to privacy-rules.md under "Always private" so future distillations respect it.',
+        ),
+    }),
+  },
+  async ({ chat_id, thread_id, hash, tier, promote_to_rule }) => {
+    const auth = resolveCaller(chat_id, thread_id);
+    if ('error' in auth) return auth.error;
+    const { caller } = auth;
+
+    const lines = await memoryStore.listProfileLines(caller, tier);
+    const target = lines.find((l) => l.hash === hash);
+    if (!target) {
+      return {
+        isError: true,
+        content: [{ type: 'text' as const, text: `No line with hash ${hash} in ${tier} tier.` }],
+      };
+    }
+
+    const removed = await memoryStore.removeProfileLine(caller, tier, hash);
+    if (!removed) {
+      return {
+        isError: true,
+        content: [{ type: 'text' as const, text: `Failed to remove line ${hash}.` }],
+      };
+    }
+
+    if (promote_to_rule) {
+      const { appendL2Rule } = await import('./privacy-rules.js');
+      await appendL2Rule(target.text, 'Always private');
+    }
+
+    const tail = promote_to_rule
+      ? ' Rule also added to privacy-rules.md so future distillations will classify similar content as private.'
+      : '';
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Removed "${target.text}" from ${tier} profile.${tail}`,
+        },
+      ],
+    };
+  },
+);
+```
+
+- [ ] **Step 3.2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add src/tools.ts
+git commit -m "feat(memory): add forget_memory with optional promote_to_rule"
+```
+
+---
+
+## Task 4: Audit log writer
+
+**Files:**
+- Create: `src/audit-log.ts`
+- Modify: `src/tools.ts` (wrap sensitive tool calls)
+
+- [ ] **Step 4.1: Module**
+
+```typescript
+// src/audit-log.ts
+import { appendFile, mkdir } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+
+const LOG_PATH =
+  process.env.LARK_AUDIT_LOG ||
+  join(homedir(), '.claude', 'channels', 'lark', 'audit.log');
+
+export async function audit(
+  tool: string,
+  caller: string | null,
+  args: Record<string, unknown>,
+  outcome: 'ok' | 'denied' | 'error',
+): Promise<void> {
+  const line =
+    [
+      new Date().toISOString(),
+      tool.padEnd(20),
+      outcome.padEnd(7),
+      `caller=${caller ?? '-'}`,
+      `args=${JSON.stringify(redact(args))}`,
+    ].join('  ') + '\n';
+  try {
+    await mkdir(dirname(LOG_PATH), { recursive: true });
+    await appendFile(LOG_PATH, line, 'utf8');
+  } catch {
+    // Best-effort — don't crash the tool on log failures.
+  }
+}
+
+function redact(args: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(args)) {
+    if (typeof v === 'string' && v.length > 80) out[k] = `${v.slice(0, 60)}...`;
+    else out[k] = v;
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4.2: Wrap sensitive tools**
+
+In `src/tools.ts`, add a helper near `resolveCaller`:
+
+```typescript
+import { audit } from './audit-log.js';
+
+async function withAudit<T>(
+  toolName: string,
+  chat_id: string | undefined,
+  thread_id: string | undefined,
+  args: Record<string, unknown>,
+  fn: (caller: string) => Promise<T>,
+): Promise<T> {
+  const auth = resolveCaller(chat_id, thread_id);
+  if ('error' in auth) {
+    await audit(toolName, null, args, 'denied');
+    return auth.error as unknown as T;
+  }
+  try {
+    const result = await fn(auth.caller);
+    await audit(toolName, auth.caller, args, 'ok');
+    return result;
+  } catch (e) {
+    await audit(toolName, auth.caller, args, 'error');
+    throw e;
+  }
+}
+```
+
+Replace the direct `resolveCaller` calls in sensitive tools (`list_jobs`, `update_job`, `delete_job`, `save_memory`, `what_do_you_know`, `forget_memory`, `create_job`) with `withAudit`. Each handler is wrapped to ensure every outcome hits the log.
+
+- [ ] **Step 4.3: Typecheck and dry-run**
+
+Run: `npx tsc --noEmit && npm run --silent start -- --dry-run`
+Expected: clean.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add src/audit-log.ts src/tools.ts
+git commit -m "feat(audit): append-only audit log for sensitive tool invocations"
+```
+
+---
+
+## Task 5: Transparency smoke test
+
+**Files:**
+- Create: `scripts/transparency-smoke.ts`
+
+- [ ] **Step 5.1: Write smoke**
+
+```typescript
+// scripts/transparency-smoke.ts
+// Smoke for listProfileLines / removeProfileLine and the promote_to_rule path.
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.LARK_MEM_ROOT = mkdtempSync(join(tmpdir(), 'transparency-'));
+process.env.LARK_PRIVACY_RULES_FILE = join(process.env.LARK_MEM_ROOT, 'privacy-rules.md');
+
+const { saveProfile, listProfileLines, removeProfileLine } = await import(
+  '../src/memory/file.js'
+);
+const { appendL2Rule, loadL2Rules } = await import('../src/privacy-rules.js');
+
+function fail(msg: string): never {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+// 1. write and list
+await saveProfile('ou_alice', '- is engineer\n- likes tea\n- uses TypeScript', 'public');
+const lines = await listProfileLines('ou_alice', 'public');
+if (lines.length !== 3) fail(`expected 3 lines got ${lines.length}`);
+
+// 2. remove by hash
+const removedHash = lines[1].hash;
+const ok = await removeProfileLine('ou_alice', 'public', removedHash);
+if (!ok) fail('remove should succeed');
+const after = await listProfileLines('ou_alice', 'public');
+if (after.length !== 2) fail(`expected 2 lines after remove got ${after.length}`);
+if (after.some((l) => l.hash === removedHash)) fail('removed line still present');
+
+// 3. idempotent remove
+const again = await removeProfileLine('ou_alice', 'public', removedHash);
+if (again) fail('second remove should return false');
+
+// 4. rule append round-trip
+await appendL2Rule('涉及人际冲突的表述', 'Always private');
+const rules = await loadL2Rules();
+if (!rules.includes('涉及人际冲突')) fail('rule should persist');
+
+rmSync(process.env.LARK_MEM_ROOT!, { recursive: true, force: true });
+console.log('transparency smoke: 4/4 PASS');
+```
+
+- [ ] **Step 5.2: Run**
+
+Run: `npx tsx scripts/transparency-smoke.ts`
+Expected: `transparency smoke: 4/4 PASS`
+
+- [ ] **Step 5.3: Wire into test runner**
+
+Add to `scripts/test.sh`:
+
+```bash
+echo ""
+echo "=== Transparency unit checks ==="
+npx tsx scripts/transparency-smoke.ts
+```
+
+- [ ] **Step 5.4: Run full suite**
+
+Run: `bash scripts/test.sh`
+Expected: all PASS.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add scripts/transparency-smoke.ts scripts/test.sh
+git commit -m "test(transparency): add 4 smoke assertions"
+```
+
+---
+
+## Task 6: `/lark:jobs` terminal skill with default redaction
+
+**Files:**
+- Create or modify: `skills/jobs/SKILL.md`
+
+- [ ] **Step 6.1: Inspect existing skill (if any)**
+
+Read `skills/jobs/SKILL.md` to understand the current contract. If it doesn't exist, create the file.
+
+- [ ] **Step 6.2: Write skill content**
+
+Save to `skills/jobs/SKILL.md`:
+
+```markdown
+---
+name: lark:jobs
+description: >-
+  Manage lark cronjobs from the Claude Code terminal. Lists, pauses, resumes,
+  and deletes jobs. Calls the plugin's MCP tools with the reserved
+  `__terminal__` chat id so identity falls back to LARK_OWNER_OPEN_ID.
+---
+
+# Lark Jobs (terminal)
+
+Invoke this skill when the user asks to list, inspect, pause, resume, or delete
+lark cronjobs from the Claude Code terminal.
+
+## Default behavior (redacted)
+
+When the user says "list jobs" or similar without asking for detail, call
+`list_jobs` with `chat_id="__terminal__"` and render a compact view:
+
+```
+[1] morning-brief      daily 09:00      → group "Team Sync"
+[2] mail-digest        daily 22:00      → private
+Use `/lark:jobs verbose` to include prompt bodies.
+```
+
+Do NOT print `prompt` or `content` fields in default mode. This protects
+against screen-share and shoulder-surfing leaks.
+
+## Verbose mode
+
+When the user explicitly says "verbose", "show full", "dump", or "include
+prompt", include `prompt` / `content` / `meta` in the rendered output.
+Warn in one line above the output: `⚠ verbose mode — prompt bodies visible.`
+
+## Destructive operations
+
+For `delete_job`, `update_job` when setting `status=paused` or changing
+`schedule`, always confirm before calling the tool:
+
+> "Confirm: delete job `<id>` (runs `<schedule>`, targets `<send_chat_id>`)?
+> Reply `yes` to proceed."
+
+Do not proceed without an affirmative reply.
+
+## Audit
+
+Every invocation writes to `~/.claude/channels/lark/audit.log` automatically
+via the plugin's tool wrapper; this skill does not need to log explicitly.
+
+## Identity
+
+All tool calls pass `chat_id="__terminal__"`. The MCP server resolves this to
+the operator identity via `LARK_OWNER_OPEN_ID` in the .env file. If that env
+var is missing, the tool will return an error; prompt the user to run
+`/lark:configure` to set it.
+```
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git add skills/jobs/SKILL.md
+git commit -m "feat(skill): lark:jobs terminal skill with default redaction"
+```
+
+---
+
+## Task 7: Document, bump, PR
+
+**Files:**
+- Modify: `CHANGELOG.md`, version files
+
+- [ ] **Step 7.1: Bump to 0.11.0**
+
+- [ ] **Step 7.2: CHANGELOG**
+
+```markdown
+## [0.11.0] - 2026-04-21
+
+### Added
+- `what_do_you_know` MCP tool — returns the caller's profile. Path-B: in groups only the public tier is rendered; in private chat both tiers.
+- `forget_memory` MCP tool — removes a specific line from the caller's profile. Optional `promote_to_rule: true` appends the line as a new entry in `privacy-rules.md` under "Always private" so future distillations respect it (self-learning loop).
+- `src/audit-log.ts` — append-only audit log at `~/.claude/channels/lark/audit.log` records every sensitive tool invocation (caller, args preview, outcome).
+- `skills/jobs/SKILL.md` — `/lark:jobs` terminal skill. Default output hides prompt bodies; `verbose` mode opts in. Destructive operations require interactive confirmation.
+
+### Changed
+- All sensitive tool invocations now flow through a `withAudit` wrapper that logs outcome (ok/denied/error).
+
+### Security
+- Terminal invocations default to a redacted view to reduce shoulder-surfing and screen-share leaks.
+- Users now have a self-serve path to inspect and remove misclassified memories, closing the trust gap introduced by silent auto-distillation.
+```
+
+- [ ] **Step 7.3: Full test**
+
+Run: `bash scripts/test.sh`
+Expected: all PASS.
+
+- [ ] **Step 7.4: Commit, push, PR**
+
+```bash
+git add CHANGELOG.md package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json
+git commit -m "chore: release v0.11.0 — transparency tools + terminal safeguards"
+git push -u origin "$(git branch --show-current)"
+gh pr create --base main --title "feat: transparency tools + self-learning + terminal safeguards (v0.11.0)" --body "$(cat <<'EOF'
+Closes #35 (phase 3 of 3 — completes the privacy redesign)
+
+## Summary
+- `what_do_you_know` / `forget_memory` tools — users can inspect and remove their own profile entries; `forget_memory` optionally promotes the removal into a persistent L2 rule.
+- Append-only audit log for every sensitive tool invocation.
+- `/lark:jobs` terminal skill with default redaction, verbose opt-in, and destructive confirmation.
+
+Spec: `docs/superpowers/specs/2026-04-19-lark-privacy-design.md`
+Depends on: #<phase2 PR>  (merged)
+
+## Test plan
+- [ ] `bash scripts/test.sh`
+- [ ] Manual: `/lark:jobs` default hides prompts; `verbose` shows them; delete prompts for confirmation
+- [ ] Manual: `what_do_you_know` in a group returns only public tier; in p2p returns both
+- [ ] Manual: `forget_memory` with promote_to_rule=true adds rule to privacy-rules.md and influences next distillation
+- [ ] Manual: audit.log accumulates entries after a few tool calls
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage — ✅ "Memory Transparency & Self-Learning" (what_do_you_know / forget_memory / rule append) in Tasks 2–3. "Terminal Safeguards" (redaction, audit log, confirmation, identity fallback) in Tasks 4, 6 (the identity fallback is already implemented in Phase 1).
+- Placeholder scan — ✅ All tool signatures concrete; no TODO language.
+- Type consistency — ✅ `listProfileLines` / `removeProfileLine` / `tier` / `hash` are consistent across Tasks 1–3 and smoke.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -44,4 +44,8 @@ echo "=== Profile tiering unit checks ==="
 npx tsx scripts/profile-tier-smoke.ts
 
 echo ""
+echo "=== Transparency unit checks ==="
+npx tsx scripts/transparency-smoke.ts
+
+echo ""
 echo "All tests passed."

--- a/scripts/transparency-smoke.ts
+++ b/scripts/transparency-smoke.ts
@@ -1,0 +1,145 @@
+/**
+ * Transparency smoke test — runs as part of `npm test`.
+ * Covers MemoryStore.listProfileLines / removeProfileLine and the L2
+ * rule-append path that forget_memory's promote_to_rule feature drives.
+ * Also exercises the audit log writer.
+ */
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function fail(msg: string): never {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+// Route L2 rules file + audit log to a tmpdir before importing modules that
+// capture paths from env at import time.
+const tmp = mkdtempSync(join(tmpdir(), 'transparency-'));
+process.env.LARK_PRIVACY_RULES_FILE = join(tmp, 'privacy-rules.md');
+process.env.LARK_AUDIT_LOG = join(tmp, 'audit.log');
+
+const { MemoryStore } = await import('../src/memory/file.js');
+const { loadL2Rules, addL2Rule } = await import('../src/privacy-rules.js');
+const { audit } = await import('../src/audit-log.js');
+
+const root = join(tmp, 'mem');
+const store = new MemoryStore(root);
+
+let passed = 0;
+
+// ── 1. listProfileLines returns [] for unknown user ──
+{
+  const lines = await store.listProfileLines('ou_ghost', 'public');
+  if (lines.length !== 0) fail('1: unknown user should have no lines');
+  passed++;
+}
+
+// ── 2. list + hash stability ──
+{
+  await store.saveProfile('ou_a', '- first\n- second\n- third', 'public');
+  const lines = await store.listProfileLines('ou_a', 'public');
+  if (lines.length !== 3) fail(`2: expected 3 lines, got ${lines.length}`);
+  if (lines.some((l) => l.hash.length !== 8)) fail('2: hash must be 8 chars');
+  if (new Set(lines.map((l) => l.hash)).size !== 3) fail('2: hashes should be unique for different lines');
+
+  // Hash is deterministic: call again, same hashes
+  const again = await store.listProfileLines('ou_a', 'public');
+  if (again[0].hash !== lines[0].hash) fail('2: hash must be stable across calls');
+  passed++;
+}
+
+// ── 3. removeProfileLine by hash ──
+{
+  const lines = await store.listProfileLines('ou_a', 'public');
+  const target = lines[1]; // "- second"
+  const ok = await store.removeProfileLine('ou_a', 'public', target.hash);
+  if (!ok) fail('3: remove should succeed');
+
+  const after = await store.listProfileLines('ou_a', 'public');
+  if (after.length !== 2) fail(`3: expected 2 lines after remove, got ${after.length}`);
+  if (after.some((l) => l.text === '- second')) fail('3: removed line must be gone');
+  passed++;
+}
+
+// ── 4. removeProfileLine is idempotent ──
+{
+  const lines = await store.listProfileLines('ou_a', 'public');
+  const removedHash = 'deadbeef'; // not present
+  const ok = await store.removeProfileLine('ou_a', 'public', removedHash);
+  if (ok) fail('4: removing a non-existent hash should return false');
+  const after = await store.listProfileLines('ou_a', 'public');
+  if (after.length !== lines.length) fail('4: removing a non-existent hash should not mutate');
+  passed++;
+}
+
+// ── 5. removeProfileLine doesn't cross tiers ──
+{
+  await store.saveProfile('ou_b', '- public-only', 'public');
+  await store.saveProfile('ou_b', '- private-secret', 'private');
+  const pubLines = await store.listProfileLines('ou_b', 'public');
+  const privHash = (await store.listProfileLines('ou_b', 'private'))[0].hash;
+
+  const okCross = await store.removeProfileLine('ou_b', 'public', privHash);
+  if (okCross) fail('5: private-tier hash must not match against public tier');
+
+  const pubAfter = await store.listProfileLines('ou_b', 'public');
+  if (pubAfter.length !== pubLines.length) fail('5: cross-tier call must not mutate public');
+  passed++;
+}
+
+// ── 6. L2 rule append round-trip (what forget_memory(promote_to_rule=true) drives) ──
+{
+  await addL2Rule('涉及人际冲突的表述', 'Always private');
+  const rules = await loadL2Rules();
+  if (!rules.includes('## Always private')) fail('6: section header missing');
+  if (!rules.includes('- 涉及人际冲突的表述')) fail('6: rule missing');
+  passed++;
+}
+
+// ── 7. audit log writes a line per call ──
+{
+  await audit('test_tool', 'ou_x', { chat_id: 'oc_1' }, 'ok');
+  await audit('test_tool', null, { chat_id: 'oc_1' }, 'denied');
+  // Log is flushed synchronously by appendFile within this scope
+  if (!existsSync(process.env.LARK_AUDIT_LOG!)) fail('7: audit log not created');
+  const log = readFileSync(process.env.LARK_AUDIT_LOG!, 'utf8');
+  const lines = log.trim().split('\n');
+  if (lines.length !== 2) fail(`7: expected 2 log lines, got ${lines.length}`);
+  if (!lines[0].includes('ok') || !lines[0].includes('ou_x')) fail('7: ok line content wrong');
+  if (!lines[1].includes('denied') || !lines[1].includes('caller=-')) fail('7: denied line content wrong');
+  passed++;
+}
+
+// ── 8. audit log redacts long strings ──
+{
+  const longPrompt = 'x'.repeat(500);
+  await audit('t', 'ou_x', { prompt: longPrompt }, 'ok');
+  const log = readFileSync(process.env.LARK_AUDIT_LOG!, 'utf8');
+  if (log.includes('x'.repeat(500))) fail('8: long string not redacted');
+  if (!log.includes('500 chars')) fail('8: truncation marker missing');
+  passed++;
+}
+
+// ── 9. audit log handles unserializable args (BigInt / circular) ──
+{
+  // BigInt cannot be serialized by JSON.stringify — guard must fall back.
+  const before = readFileSync(process.env.LARK_AUDIT_LOG!, 'utf8').length;
+  await audit('t', 'ou_x', { weird: 123n as unknown as string }, 'ok');
+  const after = readFileSync(process.env.LARK_AUDIT_LOG!, 'utf8');
+  if (after.length <= before) fail('9: audit line not written for unserializable arg');
+  if (!after.includes('<unserializable>')) fail('9: missing unserializable fallback marker');
+
+  // Circular reference — JSON.stringify also throws here.
+  const circular: Record<string, unknown> = { a: 1 };
+  circular.self = circular;
+  await audit('t', 'ou_x', circular, 'ok');
+  const final = readFileSync(process.env.LARK_AUDIT_LOG!, 'utf8');
+  // Log grew by at least one more line
+  const lineCount = final.trim().split('\n').length;
+  if (lineCount < 5) fail(`9: expected at least 5 log lines, got ${lineCount}`);
+  passed++;
+}
+
+rmSync(tmp, { recursive: true, force: true });
+console.log(`transparency smoke: ${passed}/9 PASS`);

--- a/skills/configure/SKILL.md
+++ b/skills/configure/SKILL.md
@@ -132,6 +132,7 @@ If user says "use defaults" or "skip", leave these at defaults.
 | `LARK_OWNER_OPEN_ID` | Identity | No | (empty) |
 | `LARK_IDENTITY_SESSION_TTL_MS` | Identity | No | auto |
 | `LARK_PRIVACY_RULES_FILE` | Privacy | No | `~/.claude/channels/lark/privacy-rules.md` |
+| `LARK_AUDIT_LOG` | Privacy | No | `~/.claude/channels/lark/audit.log` |
 
 ## Notes
 

--- a/skills/jobs/SKILL.md
+++ b/skills/jobs/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Manage scheduled jobs (cronjobs) — create, list, pause, resume, and delete recurring tasks.
+description: Manage scheduled jobs (cronjobs) — create, list, pause, resume, and delete recurring tasks. Invokes the plugin's MCP tools from the Claude Code terminal; defaults to a redacted view to reduce incidental exposure (screen share, shoulder surfing).
 ---
 
 # CronJob Management
@@ -10,6 +10,63 @@ Use the cronjob tools to manage scheduled tasks:
 - `list_jobs` — show all jobs and their status
 - `update_job` — modify a job (change schedule, pause/resume, update content)
 - `delete_job` — remove a job
+
+## Invocation context (v0.10.0+)
+
+This skill is invoked from the Claude Code **terminal**, so there is no
+Feishu message to establish a caller identity. Pass the reserved
+`chat_id="__terminal__"` to every sensitive tool call. The MCP server
+resolves this to `LARK_OWNER_OPEN_ID` (set in
+`~/.claude/channels/lark/.env`). If the env var is missing, the tool will
+refuse — prompt the user to run `/lark:configure` to set it.
+
+## Default (redacted) view
+
+When the user asks to list or inspect jobs WITHOUT saying "verbose",
+"full", "dump", or "show prompt", render a compact view that hides
+prompt bodies and content:
+
+```
+[1] morning-brief      · daily 09:00   · → group "Team Sync"
+[2] mail-digest        · daily 22:00   · → private
+3 jobs. Use `list verbose` to include prompt bodies.
+```
+
+Hide these fields by default: `prompt`, `content`, `msg_type`,
+free-form `meta`. Rationale: screen-share and shoulder-surfing are the
+realistic threats on the terminal side, so we don't splash sensitive
+content unless the user explicitly asks.
+
+## Verbose mode
+
+When the user explicitly says "verbose", "show full", "dump prompt",
+"include prompt bodies", or similar: include the hidden fields. Prefix
+the output with one line:
+
+```
+⚠ verbose mode — prompt bodies and meta visible in output.
+```
+
+## Destructive operations require confirmation
+
+Before calling `delete_job`, or `update_job` with `status=paused` /
+`schedule=<new>` / `prompt=<new>` / `content=<new>` — confirm with the
+user first:
+
+> "Confirm: delete job `<id>` (runs `<schedule>`, targets
+> `<send_chat_id>`)? Reply `yes` to proceed."
+
+Do not proceed without an affirmative response. For read-only calls
+(`list_jobs`) and for `update_job` that only changes `name`, no
+confirmation is needed.
+
+## Audit
+
+Every sensitive tool invocation is written to
+`~/.claude/channels/lark/audit.log` automatically by the MCP server.
+You do not need to log explicitly — but remind the user on first
+invocation of a session that the log exists, so they can review
+retrospectively if they suspect someone else used their terminal.
 
 ## Job Types
 
@@ -30,8 +87,9 @@ Simplified aliases:
 ## Examples
 
 "Create a job that sends a standup reminder every weekday at 10:00 to this chat"
-"List all active cronjobs"
-"Pause the daily-pr-summary job"
-"Delete the morning-standup job"
-"Change the schedule of weekly-report to every Monday at 9:00"
+"List all active cronjobs"  → default redacted view
+"Show jobs verbose"          → full prompt bodies
+"Pause the daily-pr-summary job"   → confirm first
+"Delete the morning-standup job"   → confirm first
+"Change the schedule of weekly-report to every Monday at 9:00"   → confirm first
 "Create a prompt job that summarizes yesterday's PRs every weekday at 9:00"

--- a/src/audit-log.ts
+++ b/src/audit-log.ts
@@ -1,0 +1,73 @@
+/**
+ * Append-only audit log for sensitive MCP tool invocations.
+ *
+ * Purpose: the operator can retrospectively inspect which tools were called
+ * on their machine, by whom, and with what outcome. This is primarily a
+ * defense against terminal-side incidents (borrowed laptop, screen share,
+ * accidental invocation) — the log itself is plaintext on the same disk,
+ * so the trust boundary is OS file permissions.
+ *
+ * Best-effort: log failures never propagate out of this module (would be
+ * worse to crash a tool call because of a log I/O issue).
+ */
+import { appendFile, mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+
+const DEFAULT_PATH = join(homedir(), '.claude', 'channels', 'lark', 'audit.log');
+
+function resolvePath(): string {
+  return process.env.LARK_AUDIT_LOG || DEFAULT_PATH;
+}
+
+export type AuditOutcome = 'ok' | 'denied' | 'error';
+
+/** Best-effort append. Never throws. */
+export async function audit(
+  tool: string,
+  caller: string | null,
+  args: Record<string, unknown>,
+  outcome: AuditOutcome,
+): Promise<void> {
+  // Wrap the whole body — JSON.stringify can throw on non-serializable args
+  // (circular refs, bigint, etc.), and a logging side-effect must never
+  // affect the calling tool's behavior.
+  try {
+    let argsStr: string;
+    try {
+      argsStr = JSON.stringify(redact(args));
+    } catch {
+      argsStr = '<unserializable>';
+    }
+    const line =
+      [
+        new Date().toISOString(),
+        tool.padEnd(18),
+        outcome.padEnd(7),
+        `caller=${caller ?? '-'}`,
+        `args=${argsStr}`,
+      ].join('  ') + '\n';
+
+    const path = resolvePath();
+    await mkdir(dirname(path), { recursive: true });
+    await appendFile(path, line, 'utf8');
+  } catch {
+    // Silent — log failures should never affect tool behavior.
+  }
+}
+
+/**
+ * Truncate long string fields so the log stays scannable and doesn't balloon
+ * on large save_memory / prompt payloads.
+ */
+function redact(args: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(args)) {
+    if (typeof v === 'string' && v.length > 80) {
+      out[k] = `${v.slice(0, 60)}… (${v.length} chars)`;
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '0.10.0' },
+    { name: 'claude-lark-plugin', version: '0.11.0' },
     {
       capabilities: {
         logging: {},

--- a/src/memory/file.ts
+++ b/src/memory/file.ts
@@ -1,10 +1,22 @@
 import fs from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { appConfig } from '../config.js';
 import { applyL1 } from '../privacy-rules.js';
 
 export type Tier = 'public' | 'private';
+
+/** Short, stable-per-text identifier for a profile line (used by forget_memory). */
+export interface ProfileLine {
+  index: number;
+  hash: string;
+  text: string;
+}
+
+function lineHash(text: string): string {
+  return createHash('sha1').update(text).digest('hex').slice(0, 8);
+}
 
 export interface Episode {
   id: string;
@@ -151,6 +163,42 @@ export class MemoryStore {
     const dir = this.profileDir(userId);
     await fs.mkdir(dir, { recursive: true });
     await fs.writeFile(this.profileTierPath(userId, tier), content, 'utf-8');
+  }
+
+  /**
+   * Return the lines of a profile tier as addressable items. Each line carries
+   * a short sha1-based hash that is stable per content — callers (e.g. the
+   * forget_memory tool) use the hash to identify a line without the file
+   * needing a durable row id.
+   *
+   * Blank lines are skipped. Leading/trailing whitespace is trimmed.
+   */
+  async listProfileLines(ownerId: string, tier: Tier): Promise<ProfileLine[]> {
+    await this.migrateIfNeeded(ownerId);
+    const p = this.profileTierPath(ownerId, tier);
+    if (!existsSync(p)) return [];
+    const content = await fs.readFile(p, 'utf-8');
+    return content
+      .split('\n')
+      .map((raw) => raw.trim())
+      .filter(Boolean)
+      .map((text, index) => ({ index, hash: lineHash(text), text }));
+  }
+
+  /**
+   * Remove a single line (identified by its hash from {@link listProfileLines})
+   * from the given tier file. Returns true if a line was removed, false if
+   * nothing matched. Idempotent — removing the same hash twice returns false
+   * on the second call.
+   */
+  async removeProfileLine(ownerId: string, tier: Tier, hash: string): Promise<boolean> {
+    const lines = await this.listProfileLines(ownerId, tier);
+    const kept = lines.filter((l) => l.hash !== hash);
+    if (kept.length === lines.length) return false;
+
+    const next = kept.map((l) => l.text).join('\n') + (kept.length > 0 ? '\n' : '');
+    await fs.writeFile(this.profileTierPath(ownerId, tier), next, 'utf-8');
+    return true;
   }
 
   // ── Episodes ──

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -8,6 +8,7 @@ import type { MemoryStore } from './memory/file.js';
 import type { ConversationBuffer } from './memory/buffer.js';
 import type { BotMessageTracker, LatestMessageTracker, LarkChannel } from './channel.js';
 import type { IdentitySession } from './identity-session.js';
+import { audit } from './audit-log.js';
 import { buildCards, shouldUseCard } from './feishu-card.js';
 import {
   sanitizeJobId,
@@ -40,14 +41,20 @@ export function registerTools(
    * IdentitySession. Returns either `{ caller }` on success or `{ error }` —
    * an MCP tool result to return directly — on failure. This deliberately
    * ignores any Claude-declared identity parameters.
+   *
+   * Denials are audit-logged here so callers only need to log 'ok' in their
+   * success path.
    */
   function resolveCaller(
+    toolName: string,
     chat_id: string | undefined,
     thread_id: string | undefined,
+    args: Record<string, unknown>,
   ):
     | { caller: string }
     | { error: { isError: true; content: { type: 'text'; text: string }[] } } {
     if (!chat_id) {
+      void audit(toolName, null, args, 'denied');
       return {
         error: {
           isError: true,
@@ -57,6 +64,7 @@ export function registerTools(
     }
     const caller = identitySession.getCaller(chat_id, thread_id);
     if (!caller) {
+      void audit(toolName, null, args, 'denied');
       return {
         error: {
           isError: true,
@@ -492,13 +500,15 @@ export function registerTools(
       }),
     },
     async ({ type, content, reason, chat_id, thread_id, tier }) => {
-      const auth = resolveCaller(chat_id, thread_id);
+      const auditArgs = { type, chat_id, thread_id, tier };
+      const auth = resolveCaller('save_memory', chat_id, thread_id, auditArgs);
       if ('error' in auth) return auth.error;
       const { caller } = auth;
 
       if (type === 'profile') {
         const effectiveTier = tier ?? 'private';
         await memoryStore.saveProfile(caller, content, effectiveTier);
+        void audit('save_memory', caller, auditArgs, 'ok');
         return {
           content: [
             { type: 'text' as const, text: `Saved ${effectiveTier} profile for ${caller}. Reason: ${reason}` },
@@ -510,6 +520,7 @@ export function registerTools(
         chatId: chat_id,
         threadId: thread_id,
       });
+      void audit('save_memory', caller, auditArgs, 'ok');
 
       return {
         content: [
@@ -580,7 +591,8 @@ export function registerTools(
       }),
     },
     async ({ name, type, schedule, prompt, content, target_chat_id, chat_id, thread_id }) => {
-      const auth = resolveCaller(chat_id, thread_id);
+      const auditArgs = { name, type, schedule, target_chat_id, chat_id, thread_id };
+      const auth = resolveCaller('create_job', chat_id, thread_id, auditArgs);
       if ('error' in auth) return auth.error;
       const { caller } = auth;
 
@@ -654,6 +666,7 @@ export function registerTools(
       };
 
       await writeJob(job);
+      void audit('create_job', caller, auditArgs, 'ok');
 
       return {
         content: [
@@ -688,7 +701,8 @@ export function registerTools(
       }),
     },
     async ({ status, chat_id, thread_id }) => {
-      const auth = resolveCaller(chat_id, thread_id);
+      const auditArgs = { status, chat_id, thread_id };
+      const auth = resolveCaller('list_jobs', chat_id, thread_id, auditArgs);
       if ('error' in auth) return auth.error;
       const { caller } = auth;
 
@@ -724,6 +738,7 @@ export function registerTools(
         return `${statusIcon} **${j.meta.id}** (${j.meta.type}) — ${j.meta.schedule_human}\n   Next: ${j.runtime.next_run_at} | Last: ${lastRun} | Runs: ${j.runtime.run_count}${error}`;
       });
 
+      void audit('list_jobs', caller, auditArgs, 'ok');
       return {
         content: [
           {
@@ -758,7 +773,8 @@ export function registerTools(
       }),
     },
     async ({ id, status, schedule, prompt, content, name, chat_id, thread_id }) => {
-      const auth = resolveCaller(chat_id, thread_id);
+      const auditArgs = { id, status, schedule, name, chat_id, thread_id };
+      const auth = resolveCaller('update_job', chat_id, thread_id, auditArgs);
       if ('error' in auth) return auth.error;
       const { caller } = auth;
 
@@ -770,6 +786,7 @@ export function registerTools(
         };
       }
       if (job.meta.created_by !== caller) {
+        void audit('update_job', caller, auditArgs, 'denied');
         return {
           content: [
             {
@@ -818,6 +835,7 @@ export function registerTools(
       }
 
       await writeJob(job);
+      void audit('update_job', caller, auditArgs, 'ok');
 
       return {
         content: [
@@ -847,7 +865,8 @@ export function registerTools(
       }),
     },
     async ({ id, chat_id, thread_id }) => {
-      const auth = resolveCaller(chat_id, thread_id);
+      const auditArgs = { id, chat_id, thread_id };
+      const auth = resolveCaller('delete_job', chat_id, thread_id, auditArgs);
       if ('error' in auth) return auth.error;
       const { caller } = auth;
 
@@ -859,6 +878,7 @@ export function registerTools(
         };
       }
       if (existing.meta.created_by !== caller) {
+        void audit('delete_job', caller, auditArgs, 'denied');
         return {
           content: [
             {
@@ -877,8 +897,141 @@ export function registerTools(
           isError: true,
         };
       }
+      void audit('delete_job', caller, auditArgs, 'ok');
       return {
         content: [{ type: 'text' as const, text: `Deleted job "${id}".` }],
+      };
+    }
+  );
+
+  // ── what_do_you_know ──
+  server.registerTool(
+    'what_do_you_know',
+    {
+      description:
+        "List what the bot has stored in the caller's profile. Output is filtered by current-chat rendering visibility (path B): in a private chat both public and private tiers are rendered; in a group chat only the public tier — because the reply is visible to the whole group. Each returned line has a short hash that forget_memory uses to target the exact line.",
+      inputSchema: z.object({
+        chat_id: z.string().describe('Chat ID where this call is acting from'),
+        thread_id: z
+          .string()
+          .optional()
+          .describe(
+            'Thread ID from the current notification\'s metadata. Required whenever present — the server resolves caller identity from (chat_id, thread_id); omitting it falls back to chat-level and will silently attribute the call to the wrong user in cronjob turns.'
+          ),
+      }),
+    },
+    async ({ chat_id, thread_id }) => {
+      const auditArgs = { chat_id, thread_id };
+      const auth = resolveCaller('what_do_you_know', chat_id, thread_id, auditArgs);
+      if ('error' in auth) return auth.error;
+      const { caller } = auth;
+
+      const isPrivate = channel.isPrivateChat(chat_id);
+      const pub = await memoryStore.listProfileLines(caller, 'public');
+      const priv = isPrivate ? await memoryStore.listProfileLines(caller, 'private') : [];
+
+      const renderSection = (tier: string, lines: { hash: string; text: string }[]) =>
+        lines.length === 0
+          ? `_${tier}: (empty)_`
+          : `**${tier}:**\n${lines.map((l) => `- [${l.hash}] ${l.text}`).join('\n')}`;
+
+      const parts = [renderSection('public', pub)];
+      if (isPrivate) parts.push(renderSection('private', priv));
+
+      const footer = isPrivate
+        ? '\n\n_Use `forget_memory(hash, tier)` to remove a line._'
+        : '\n\n_Private tier hidden in this group. Ask in private chat to see both tiers._';
+
+      void audit('what_do_you_know', caller, auditArgs, 'ok');
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `What I've stored about you:\n\n${parts.join('\n\n')}${footer}`,
+          },
+        ],
+      };
+    }
+  );
+
+  // ── forget_memory ──
+  server.registerTool(
+    'forget_memory',
+    {
+      description:
+        "Remove a specific line from the caller's profile. Always caller-scoped — you can only forget things about yourself. Optionally promotes the removed line into a persistent L2 rule so future distillations classify similar content as private.",
+      inputSchema: z.object({
+        chat_id: z.string().describe('Chat ID where this call is acting from'),
+        thread_id: z
+          .string()
+          .optional()
+          .describe(
+            'Thread ID from the current notification\'s metadata. Required whenever present — the server resolves caller identity from (chat_id, thread_id); omitting it falls back to chat-level and will silently attribute the call to the wrong user in cronjob turns.'
+          ),
+        hash: z.string().describe('Short 8-char line hash obtained from what_do_you_know'),
+        tier: z
+          .enum(['public', 'private'])
+          .default('public')
+          .describe('Which tier the line lives in. Default "public" since that is where misclassifications are externally visible.'),
+        promote_to_rule: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "If true, also append the removed line's text to privacy-rules.md under '## Always private' so future distillations classify similar content as private. Use when the removal reflects a durable preference ('I never want anything like this public') rather than a one-off cleanup."
+          ),
+      }),
+    },
+    async ({ chat_id, thread_id, hash, tier, promote_to_rule }) => {
+      const auditArgs = { chat_id, thread_id, hash, tier, promote_to_rule };
+      const auth = resolveCaller('forget_memory', chat_id, thread_id, auditArgs);
+      if ('error' in auth) return auth.error;
+      const { caller } = auth;
+
+      const lines = await memoryStore.listProfileLines(caller, tier);
+      const target = lines.find((l) => l.hash === hash);
+      if (!target) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: `No line with hash "${hash}" in ${tier} tier. Call what_do_you_know to list current lines.`,
+            },
+          ],
+        };
+      }
+
+      const removed = await memoryStore.removeProfileLine(caller, tier, hash);
+      if (!removed) {
+        return {
+          isError: true,
+          content: [{ type: 'text' as const, text: `Failed to remove line "${hash}".` }],
+        };
+      }
+
+      // Line removal above is the primary effect; rule promotion is
+      // a best-effort enhancement. If addL2Rule fails, don't undo the
+      // removal — just report the partial outcome so the user knows.
+      let tail = '';
+      if (promote_to_rule) {
+        try {
+          const { addL2Rule } = await import('./privacy-rules.js');
+          await addL2Rule(target.text, 'Always private');
+          tail = ' Also appended to privacy-rules.md under "Always private" — future distillations will classify similar content accordingly.';
+        } catch (err) {
+          tail = ` (Warning: removal succeeded but failed to append rule to privacy-rules.md: ${err instanceof Error ? err.message : String(err)}. You can add the rule manually.)`;
+        }
+      }
+
+      void audit('forget_memory', caller, auditArgs, 'ok');
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Removed "${target.text}" from ${tier} profile.${tail}`,
+          },
+        ],
       };
     }
   );


### PR DESCRIPTION
Closes #39. Phase 3 of the privacy redesign — the final phase. Completes the user-control surface and terminal safeguards that complement the leak defense in v0.9.0 / v0.10.0.

## What this phase does

Gives users **inspection and correction rights** over their own profile memory, turns each correction into a **persistent L2 rule** (self-learning), adds an **append-only audit log** for every sensitive-tool invocation, and reworks `/lark:jobs` to default to a **redacted** view that reduces incidental exposure on the terminal side.

## New tools

| Tool | Purpose |
|---|---|
| **`what_do_you_know`** | List the caller's profile entries with per-line 8-char hashes. Path-B: private chat renders both tiers; group renders only public. |
| **`forget_memory`** | Remove a specific line by hash. Caller-scoped, idempotent. Optional `promote_to_rule: true` appends the removed line to `privacy-rules.md` — the **self-learning loop**. |

## Audit log

`src/audit-log.ts` + refactored `resolveCaller` — every sensitive-tool invocation writes a line to `~/.claude/channels/lark/audit.log` (timestamp / tool / outcome / caller / redacted args). Denials are logged automatically by `resolveCaller`; success paths emit explicit `audit(..., 'ok')`. Best-effort — log failures never propagate. Non-serializable args (BigInt, circular refs) fall back to a `<unserializable>` marker rather than throwing.

## Terminal safeguards

`/lark:jobs` skill reworked:
- **Default** compact view: `id / name / schedule / target` only. Prompt bodies + meta hidden.
- **Verbose** opt-in via "verbose" / "show full" / "dump prompt" — prefixed with `⚠ verbose mode`.
- **Destructive confirmation**: `delete_job` and schedule/prompt/content changes prompt for `yes` before calling the tool.
- Reuses the `__terminal__` sentinel → `LARK_OWNER_OPEN_ID` fallback from v0.9.0.

## Commits (3)

| Commit | Scope |
|---|---|
| `feat(privacy): memory transparency + self-learning + terminal safeguards` | 2 new tools + audit log + storage helpers + skill rewrite + docs |
| `docs: phase 3 transparency + terminal safeguards plan` | Plan force-added (docs/ is gitignored) |
| `chore: release v0.11.0` | Version bumps + CHANGELOG |

History consolidated from 8 exploratory commits to 3 clean logical commits. Squash-merge recommended.

## Self-learning loop (end-to-end)

With this PR, the full privacy-correction cycle works:

1. Auto-distillation classifies a fact into public when it should have been private.
2. User calls `what_do_you_know` (in private chat) and spots the misclassified line by its 8-char hash.
3. User calls `forget_memory(hash, tier='public', promote_to_rule=true)`.
4. Bot removes the line from `public.md` **and** appends it to `privacy-rules.md` under `## Always private`.
5. Next time `buildProfileDistillationPrompt` runs, L2 rules go into the prompt; similar content gets classified correctly.

This completes the feedback loop that Phase 2 infrastructure (`parseTieredProfile`, `profileDistillationPrompt`, `addL2Rule`) was built to support.

## Key engineering findings (folded into commits)

During implementation + 9 review rounds, 3 real bugs and 4 hardening / consistency fixes were caught:

1. **Audit coverage gap (R1)** — ownership-check denials in `update_job` / `delete_job` weren't audited. Fixed; the "someone tried to delete kk's job" case now leaves a trail.
2. **audit() could throw on unserializable args (R1)** — `JSON.stringify(redact(args))` was outside the try/catch; BigInt or circular args would bubble out as unhandled promise rejections. Fixed with nested try/catch + `<unserializable>` fallback.
3. **forget_memory partial-failure (R2)** — if `addL2Rule` threw after `removeProfileLine` succeeded, the tool returned error, user saw "failure", but the profile line was already removed. Fixed: rule-append is best-effort with a warning suffix; line removal is the primary effect.
4. **CLAUDE.md stale tool list (R3)** — Identity-flow section listed 5 sensitive tools but there are now 7. Fixed.
5. **CLAUDE.md missing design decisions (R3)** — no Key Design Decisions entries for v0.11.0 (memory transparency, audit log). Added.
6. **R1 fix had no regression test (R4)** — added test #9 covering BigInt and circular-reference cases for the audit guard.
7. **CHANGELOG test count drift (R5)** — said 8 transparency assertions, actually 9 after R4. Fixed.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `bash scripts/test.sh` green — includes **9 new transparency assertions** (58 total across the suite)
- [x] `npm start -- --dry-run` boots cleanly
- [ ] Manual: call `what_do_you_know` in p2p, see both tiers with hashes
- [ ] Manual: call `what_do_you_know` in group, see only public tier
- [ ] Manual: call `forget_memory(hash, tier, promote_to_rule=true)`, verify `privacy-rules.md` grows
- [ ] Manual: `/lark:jobs` default returns redacted view; "verbose" returns full
- [ ] Manual: `/lark:jobs` delete prompts for confirmation
- [ ] Manual: `audit.log` grows with ok + denied entries after invocations

## User-visible API

- 2 new MCP tools: `what_do_you_know`, `forget_memory`.
- 1 new config: `LARK_AUDIT_LOG` (optional path override).

## Migration

**No operator action required.** Audit log is created on first use. `/lark:jobs` continues to work but returns the redacted view by default (verbose available on explicit ask).

## References

- Plan: `docs/superpowers/plans/2026-04-19-phase3-transparency-terminal.md`
- Spec: `docs/superpowers/specs/2026-04-19-lark-privacy-design.md`
- Closes: #39
- Completes the privacy redesign tracked in #35 (already closed after Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)