### PR TITLE
feat(cronjob): per-job model override + fix P2P reply_to auto-fill (v1.0.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.1] - 2026-04-21
+
+Small follow-ups on top of 1.0.0: prompt-type CronJobs can now override which model the dispatched subagent uses, and the `reply` tool correctly threads P2P replies onto the latest inbound message even when Claude omits `reply_to`.
+
+### Added
+- **Per-job model override** (#47) — `JobMeta` gains an optional `model` field (e.g. `"sonnet"`, `"haiku"`, `"opus"`). `create_job` / `update_job` accept a `model` parameter; `update_job` with an empty string clears the override. When set, the scheduler forwards `model` in the `notifications/claude/channel` meta so the dispatched subagent executes on the specified model. Only applies to `type=prompt` jobs; `type=message` jobs ignore it. `list_jobs` owner view surfaces `Model: <name>` when set.
+
+### Fixed
+- **P2P `reply_to` auto-fill** (#48) — the `reply` tool previously only auto-filled `reply_to` from `latestMessageTracker` when `thread_id` was present, which meant private-chat replies without an explicit `reply_to` sent as standalone messages instead of threading onto the latest inbound message. The `thread_id` precondition is dropped; `LatestMessageTracker.getLatest(chat_id, thread_id?)` already handles the undefined case by keying on `chat_id` alone. Group-chat behavior unchanged; explicit `reply_to` from Claude still wins.
+
 ## [1.0.0] - 2026-04-21
 
 First stable release. This version marks the project as production-ready: the core feature set (messaging, memory, cronjobs, privacy tiers, cards, reactions, scheduled jobs) is complete, and every env var read by the codebase is now discoverable via `.env.example`, `README.md` / `README_CN.md`, and `/lark:configure` — with no remaining stale references to removed variables.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/skills/jobs/SKILL.md
+++ b/skills/jobs/SKILL.md
@@ -71,7 +71,7 @@ retrospectively if they suspect someone else used their terminal.
 ## Job Types
 
 - **message**: Send fixed content directly via Feishu API. Deterministic, no Claude involvement. Use for critical notifications.
-- **prompt**: Inject a prompt for Claude to execute. Claude thinks, may call tools, and replies to the target chat. Best-effort.
+- **prompt**: Inject a prompt for Claude to execute. Claude thinks, may call tools, and replies to the target chat. Best-effort. Optionally pass `model` (e.g. `sonnet`, `haiku`, `opus`) to override which model the dispatched subagent uses.
 
 ## Schedule Formats
 

--- a/src/job-store.ts
+++ b/src/job-store.ts
@@ -25,6 +25,8 @@ export interface JobMeta {
   target_chat_id: string;
   /** Where the job was created (debug/audit). For legacy jobs, backfilled from target_chat_id. */
   origin_chat_id: string;
+  /** Optional model override for prompt-type jobs (e.g. "sonnet", "haiku"). Passed in notification meta so Claude dispatches the subagent with the specified model. */
+  model?: string;
   status: 'active' | 'paused';
   created_by: string;
   created_at: string;

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -273,6 +273,7 @@ export class JobScheduler {
           source: 'cronjob',
           job_id: job.meta.id,
           job_name: job.meta.name,
+          ...(job.meta.model ? { model: job.meta.model } : {}),
         },
       },
     });

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -126,14 +126,15 @@ export function registerTools(
     },
     async ({ chat_id, text, card, reply_to, thread_id, format, footer, files }) => {
       // Auto-correct reply_to from the plugin's per-thread tracker when Claude
-      // omits it but passes thread_id. Explicit reply_to from Claude always wins.
+      // omits it. Works for both threaded and non-threaded (P2P) messages.
+      // Explicit reply_to from Claude always wins.
       let effectiveReplyTo = reply_to;
-      if (!effectiveReplyTo && thread_id && latestMessageTracker) {
+      if (!effectiveReplyTo && latestMessageTracker) {
         const latest = latestMessageTracker.getLatest(chat_id, thread_id);
         if (latest) {
           effectiveReplyTo = latest.messageId;
           console.error(
-            `[tools] Auto-filled reply_to=${latest.messageId} for thread ${thread_id}`
+            `[tools] Auto-filled reply_to=${latest.messageId} for chat=${chat_id} thread=${thread_id ?? '(none)'}`
           );
         }
       }
@@ -579,6 +580,10 @@ export function registerTools(
         target_chat_id: z
           .string()
           .describe('Chat ID that receives job output. Used by scheduler delivery and list_jobs visibility filter.'),
+        model: z
+          .string()
+          .optional()
+          .describe('Model override for prompt-type jobs (e.g. "sonnet", "haiku", "opus"). When set, the subagent executing this job uses the specified model instead of the default.'),
         chat_id: z
           .string()
           .describe('Chat ID where this create_job call was triggered — used to resolve caller identity and to populate origin_chat_id'),
@@ -590,8 +595,8 @@ export function registerTools(
           ),
       }),
     },
-    async ({ name, type, schedule, prompt, content, target_chat_id, chat_id, thread_id }) => {
-      const auditArgs = { name, type, schedule, target_chat_id, chat_id, thread_id };
+    async ({ name, type, schedule, prompt, content, target_chat_id, model, chat_id, thread_id }) => {
+      const auditArgs = { name, type, schedule, target_chat_id, model, chat_id, thread_id };
       const auth = resolveCaller('create_job', chat_id, thread_id, auditArgs);
       if ('error' in auth) return auth.error;
       const { caller } = auth;
@@ -651,6 +656,7 @@ export function registerTools(
           schedule_human: scheduleHuman,
           ...(type === 'prompt' ? { prompt } : { content, msg_type: 'text' }),
           target_chat_id,
+          ...(model ? { model } : {}),
           origin_chat_id: chat_id,
           status: 'active',
           created_by: caller,
@@ -734,7 +740,8 @@ export function registerTools(
         if (!isPrivate && !isOwner) {
           return `${statusIcon} **${j.meta.id}** (${j.meta.type}) — ${j.meta.schedule_human}\n   By: ${j.meta.created_by} | Next: ${j.runtime.next_run_at}`;
         }
-        return `${statusIcon} **${j.meta.id}** (${j.meta.type}) — ${j.meta.schedule_human}\n   Next: ${j.runtime.next_run_at} | Last: ${lastRun} | Runs: ${j.runtime.run_count}${error}`;
+        const modelNote = j.meta.model ? ` | Model: ${j.meta.model}` : '';
+        return `${statusIcon} **${j.meta.id}** (${j.meta.type}) — ${j.meta.schedule_human}\n   Next: ${j.runtime.next_run_at} | Last: ${lastRun} | Runs: ${j.runtime.run_count}${modelNote}${error}`;
       });
 
       void audit('list_jobs', caller, auditArgs, 'ok');
@@ -762,6 +769,10 @@ export function registerTools(
         prompt: z.string().optional().describe('New prompt (type=prompt)'),
         content: z.string().optional().describe('New content (type=message)'),
         name: z.string().optional().describe('New display name'),
+        model: z
+          .string()
+          .optional()
+          .describe('Model override for prompt-type jobs (e.g. "sonnet", "haiku", "opus"). Pass empty string to clear.'),
         chat_id: z.string().describe('Chat ID where this update call is acting from'),
         thread_id: z
           .string()
@@ -771,8 +782,8 @@ export function registerTools(
           ),
       }),
     },
-    async ({ id, status, schedule, prompt, content, name, chat_id, thread_id }) => {
-      const auditArgs = { id, status, schedule, name, chat_id, thread_id };
+    async ({ id, status, schedule, prompt, content, name, model, chat_id, thread_id }) => {
+      const auditArgs = { id, status, schedule, name, model, chat_id, thread_id };
       const auth = resolveCaller('update_job', chat_id, thread_id, auditArgs);
       if ('error' in auth) return auth.error;
       const { caller } = auth;
@@ -820,6 +831,7 @@ export function registerTools(
       if (name !== undefined) job.meta.name = name;
       if (prompt !== undefined) job.meta.prompt = prompt;
       if (content !== undefined) job.meta.content = content;
+      if (model !== undefined) job.meta.model = model || undefined; // empty string clears
       if (expandedSchedule) {
         job.meta.schedule = expandedSchedule.cron;
         job.meta.schedule_human = expandedSchedule.human;


### PR DESCRIPTION
## Summary
- **feat(cronjob)**: `JobMeta` gains an optional `model` field. `create_job` / `update_job` accept it; empty string on update clears the override. Scheduler forwards `model` via `notifications/claude/channel` meta so prompt-type jobs dispatch on the specified model (sonnet/haiku/opus). `list_jobs` owner view surfaces `Model: <name>` when set; audit log records it. Closes #47.
- **fix(reply)**: `reply` tool now auto-fills `reply_to` from `latestMessageTracker` for P2P messages too — previously required `thread_id`, which meant private-chat replies without an explicit `reply_to` sent as standalone messages instead of threading. `LatestMessageTracker` already normalizes the undefined thread key via `threadId || '_'`. Closes #48.
- **chore**: bump version to 1.0.1 across `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`; update `CHANGELOG.md` and `/lark:jobs` skill doc.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm start -- --dry-run` loads modules and registers tools cleanly
- [x] Version string consistent across `package.json` / `plugin.json` / `marketplace.json`
- [x] `model` field traced end-to-end: schema → handler → `JobMeta` → persistence → scheduler → notification meta → `list_jobs` render → audit log
- [x] P2P reply edge case verified against `LatestMessageTracker` key normalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)