### PR TITLE
fix: preserve private.md on single-fact save + resolve @_user_N in group mentions (v1.0.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Two field-reported bug fixes on top of 1.0.1.
 ### Changed
 - `save_memory` MCP tool gains a `mode` parameter (profile only) documented in the tool schema. The distiller flush prompt now passes `mode="replace"` explicitly.
 - `LarkMessage` gains `botMentioned?: boolean`; surfaces as `meta.bot_mentioned` on the MCP notification.
+- **Profile line storage/display is now bullet-normalized.** `listProfileLines` strips a leading `-`/`*` marker before hashing, so a fact saved by the distiller as `"foo"` and later merged via append as `"- foo"` share one hash and render identically in `what_do_you_know`. `removeProfileLine` rewrites the tier with a consistent `- ` prefix on every remaining line. Fixes a double-bullet visual artefact (`- [hash] - foo`) that would otherwise appear on content saved after 1.0.2 append-mode.
 
 ## [1.0.1] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.2] - 2026-04-22
+
+Two field-reported bug fixes on top of 1.0.1.
+
+### Fixed
+- **`save_memory` no longer overwrites existing profile content** (#51). `saveProfile` was doing an unconditional `fs.writeFile`, so a single-fact save (e.g. "记住我不吃鱼") wiped the entire tier file. Introduces a `mode` parameter: `"append"` (new default) reads the existing tier, merges incoming lines deduped case-insensitively (punctuation not normalized — `"喜欢茶"` and `"喜欢茶。"` are kept as distinct), preserves all original content, and auto-bullets lines missing a `-`/`*` prefix; `"replace"` keeps the old overwrite behavior and is now only used by the distiller auto-flush path, which intentionally rewrites the full tier from history. Near-duplicates (prefix containment either direction, normalized) emit a `[memory] Possible near-duplicate` warning to stderr.
+- **Group @bot misrouted as @other-user** (#52). Feishu text messages carry opaque placeholders (`@_user_1`, `@_user_2`, …) in the `text` field with the identity mapping in the `mentions` array. The plugin's group-mention filter already matched by `open_id` correctly, but the text forwarded to Claude still contained raw placeholders — so Claude's own reasoning, reading `@_user_1`, concluded the message was addressed to a different user and stayed silent. `extractText` results (and `parentContent` in threaded replies) are now post-processed: each `@_user_N` is replaced with `@<name>` from `mentions[N-1]`. Masked / empty names (user privacy settings) and out-of-range indices keep the placeholder verbatim. A new `bot_mentioned: "true"` field is added to the `<channel>` notification `meta` when the bot's `open_id` is present in mentions — a text-independent signal that complements the resolved names.
+
+### Changed
+- `save_memory` MCP tool gains a `mode` parameter (profile only) documented in the tool schema. The distiller flush prompt now passes `mode="replace"` explicitly.
+- `LarkMessage` gains `botMentioned?: boolean`; surfaces as `meta.bot_mentioned` on the MCP notification.
+
 ## [1.0.1] - 2026-04-21
 
 Small follow-ups on top of 1.0.0: prompt-type CronJobs can now override which model the dispatched subagent uses, and the `reply` tool correctly threads P2P replies onto the latest inbound message even when Claude omits `reply_to`.
@@ -299,6 +311,8 @@ Precondition for the privacy redesign (#35). A pluggable abstraction made every 
 - Score-based filtering (`LARK_MIN_SEARCH_SCORE`)
 - HealthCheck for memory provider connectivity
 
+[1.0.2]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.2
+[1.0.1]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.1
 [1.0.0]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.0
 [0.11.1]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.11.1
 [0.11.0]: https://github.com/IS908/claude-lark-plugin/releases/tag/v0.11.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/mention-resolver-smoke.ts
+++ b/scripts/mention-resolver-smoke.ts
@@ -1,0 +1,110 @@
+/**
+ * Mention placeholder resolution smoke test — runs as part of `npm test`.
+ *
+ * Covers @_user_N → @<name> substitution using the mentions array.
+ * Exits non-zero on any assertion failure.
+ */
+import { resolveMentionPlaceholders } from '../src/channel.js';
+
+function fail(msg: string): never {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+let passed = 0;
+
+// ── 1. single mention resolved ──────────────────────────────
+{
+  const out = resolveMentionPlaceholders(
+    '@_user_1 help me',
+    [{ id: 'ou_bot', name: '我的助手' }],
+  );
+  if (out !== '@我的助手 help me') fail(`1: got ${JSON.stringify(out)}`);
+  passed++;
+}
+
+// ── 2. multiple mentions — bot + other user ────────────────
+{
+  const out = resolveMentionPlaceholders(
+    '@_user_1 @_user_2 看下这个',
+    [
+      { id: 'ou_alice', name: 'Alice' },
+      { id: 'ou_bot', name: 'Bot' },
+    ],
+  );
+  if (out !== '@Alice @Bot 看下这个') fail(`2: got ${JSON.stringify(out)}`);
+  passed++;
+}
+
+// ── 3. empty name kept as placeholder (privacy masked) ──────
+{
+  const out = resolveMentionPlaceholders(
+    '@_user_1 hello',
+    [{ id: 'ou_masked', name: '' }],
+  );
+  if (out !== '@_user_1 hello') fail(`3: masked name should keep placeholder, got ${JSON.stringify(out)}`);
+  passed++;
+}
+
+// ── 4. @_all untouched ──────────────────────────────────────
+{
+  const out = resolveMentionPlaceholders(
+    '@_all please review',
+    [{ id: 'ou_bot', name: 'Bot' }],
+  );
+  if (out !== '@_all please review') fail(`4: @_all should be untouched, got ${JSON.stringify(out)}`);
+  passed++;
+}
+
+// ── 5. out-of-range index kept as placeholder ──────────────
+{
+  const out = resolveMentionPlaceholders(
+    '@_user_3 ping',
+    [{ id: 'ou_a', name: 'A' }, { id: 'ou_b', name: 'B' }],
+  );
+  if (out !== '@_user_3 ping') fail(`5: out-of-range should keep placeholder, got ${JSON.stringify(out)}`);
+  passed++;
+}
+
+// ── 6. no mentions → no-op ─────────────────────────────────
+{
+  const out = resolveMentionPlaceholders('@_user_1 orphan', []);
+  if (out !== '@_user_1 orphan') fail(`6: no mentions should no-op, got ${JSON.stringify(out)}`);
+  passed++;
+}
+
+// ── 7. undefined mentions → no-op ─────────────────────────
+{
+  const out = resolveMentionPlaceholders('@_user_1 orphan', undefined);
+  if (out !== '@_user_1 orphan') fail(`7: undefined mentions should no-op, got ${JSON.stringify(out)}`);
+  passed++;
+}
+
+// ── 8. empty text → no-op ─────────────────────────────────
+{
+  const out = resolveMentionPlaceholders('', [{ id: 'ou_a', name: 'A' }]);
+  if (out !== '') fail(`8: empty text should remain empty`);
+  passed++;
+}
+
+// ── 9. same placeholder multiple times replaced each occurrence ──
+{
+  const out = resolveMentionPlaceholders(
+    '@_user_1 ping @_user_1 pong',
+    [{ id: 'ou_bot', name: 'Bot' }],
+  );
+  if (out !== '@Bot ping @Bot pong') fail(`9: got ${JSON.stringify(out)}`);
+  passed++;
+}
+
+// ── 10. unicode / emoji in name preserved ─────────────────
+{
+  const out = resolveMentionPlaceholders(
+    '@_user_1 go',
+    [{ id: 'ou_x', name: '小助手 🤖' }],
+  );
+  if (out !== '@小助手 🤖 go') fail(`10: got ${JSON.stringify(out)}`);
+  passed++;
+}
+
+console.log(`mention-resolver smoke: ${passed}/10 PASS`);

--- a/scripts/profile-tier-smoke.ts
+++ b/scripts/profile-tier-smoke.ts
@@ -241,6 +241,18 @@ passed++;
   passed++;
 }
 
+// ── 11b. append mode: dedup within a single incoming batch ──
+{
+  const r = mkdtempSync(join(tmpdir(), 'profile-append-batch-dedup-'));
+  const s = new MemoryStore(r);
+  await s.saveProfile('ou_batch', '- foo\n- foo\n- FOO\n- bar', 'private');
+  const body = readFileSync(join(r, 'profiles', 'ou_batch', 'private.md'), 'utf-8');
+  const lines = body.split('\n').filter(Boolean);
+  if (lines.length !== 2) fail(`11b: expected 2 lines after intra-batch dedup, got ${lines.length}: ${JSON.stringify(lines)}`);
+  rmSync(r, { recursive: true, force: true });
+  passed++;
+}
+
 // ── 12. append mode: empty file gets first entry with auto-bullet ──
 {
   const r = mkdtempSync(join(tmpdir(), 'profile-append-first-'));
@@ -313,4 +325,4 @@ rmSync(legacyRoot, { recursive: true, force: true });
 rmSync(partialRoot, { recursive: true, force: true });
 rmSync(writeRoot, { recursive: true, force: true });
 
-console.log(`profile-tier smoke: ${passed}/21 PASS`);
+console.log(`profile-tier smoke: ${passed}/22 PASS`);

--- a/scripts/profile-tier-smoke.ts
+++ b/scripts/profile-tier-smoke.ts
@@ -264,26 +264,40 @@ passed++;
   passed++;
 }
 
-// ── 13. listProfileLines strips leading bullet in text + hash ──
+// ── 13. listProfileLines strips bullet; hash is storage-format independent ──
 {
   const r = mkdtempSync(join(tmpdir(), 'profile-list-strip-'));
   const s = new MemoryStore(r);
-  // Mix: one bullet-stored (append) and one bullet-less (as distiller would write via replace)
+  // Private starts via `replace` with a bullet-less body — simulates the
+  // state a distiller flush would leave on disk.
+  await s.saveProfile('ou_mix', 'plain line', 'private', 'replace');
+  // Then a subsequent append adds a bulleted line — simulates a one-off
+  // save_memory call on top. File ends up bullet-mixed on disk.
   await s.saveProfile('ou_mix', '- bulleted line', 'private');
-  await s.saveProfile('ou_mix', 'plain line\n- bulleted line', 'private', 'replace');
   const listed = await s.listProfileLines('ou_mix', 'private');
   if (listed.length !== 2) fail(`13: expected 2 lines, got ${listed.length}`);
-  // text should be bullet-stripped on both
-  if (listed.some((l) => l.text.startsWith('- '))) fail(`13: text should be bullet-stripped, got ${JSON.stringify(listed)}`);
-  // Same hash whether saved with or without bullet (storage-format independence)
-  const withBullet = await s.listProfileLines('ou_mix', 'private');
-  await s.saveProfile('ou_mix', 'plain line', 'public'); // same content in public
+  if (listed.some((l) => l.text.startsWith('- ') || l.text.startsWith('* '))) {
+    fail(`13: text should be bullet-stripped, got ${JSON.stringify(listed)}`);
+  }
+
+  // Same content saved via append in a different tier must share the hash.
+  await s.saveProfile('ou_mix', 'plain line', 'public');
   const publicListed = await s.listProfileLines('ou_mix', 'public');
-  const plainHashPriv = withBullet.find((l) => l.text === 'plain line')?.hash;
+  const plainHashPriv = listed.find((l) => l.text === 'plain line')?.hash;
   const plainHashPub = publicListed.find((l) => l.text === 'plain line')?.hash;
   if (!plainHashPriv || plainHashPriv !== plainHashPub) {
     fail(`13: hash should be storage-format independent, priv=${plainHashPriv} pub=${plainHashPub}`);
   }
+
+  // And the bulleted entry also gets a hash equal to its content saved plain.
+  await s.saveProfile('ou_mix', 'bulleted line', 'public');
+  const pubListed2 = await s.listProfileLines('ou_mix', 'public');
+  const bHashPriv = listed.find((l) => l.text === 'bulleted line')?.hash;
+  const bHashPub = pubListed2.find((l) => l.text === 'bulleted line')?.hash;
+  if (!bHashPriv || bHashPriv !== bHashPub) {
+    fail(`13: bulleted↔unbulleted hash should match, priv=${bHashPriv} pub=${bHashPub}`);
+  }
+
   rmSync(r, { recursive: true, force: true });
   passed++;
 }

--- a/scripts/profile-tier-smoke.ts
+++ b/scripts/profile-tier-smoke.ts
@@ -47,7 +47,7 @@ passed++;
 {
   const r = mkdtempSync(join(tmpdir(), 'profile-private-only-'));
   const s = new MemoryStore(r);
-  await s.saveProfile('ou_priv', 'top-secret content', 'private');
+  await s.saveProfile('ou_priv', 'top-secret content', 'private', 'replace');
   // Owner sees it
   const own = await s.getProfile('ou_priv', 'ou_priv');
   if (own !== 'top-secret content') fail(`3b: owner should see private, got ${JSON.stringify(own)}`);
@@ -194,13 +194,63 @@ passed++;
 // ── 9. saveProfile writes to correct tier file ──
 const writeRoot = mkdtempSync(join(tmpdir(), 'profile-write-'));
 const writeStore = new MemoryStore(writeRoot);
-await writeStore.saveProfile('ou_w', 'public content', 'public');
-await writeStore.saveProfile('ou_w', 'private content', 'private');
+await writeStore.saveProfile('ou_w', 'public content', 'public', 'replace');
+await writeStore.saveProfile('ou_w', 'private content', 'private', 'replace');
 const pubFile = readFileSync(join(writeRoot, 'profiles', 'ou_w', 'public.md'), 'utf-8');
 const privFile = readFileSync(join(writeRoot, 'profiles', 'ou_w', 'private.md'), 'utf-8');
 if (pubFile !== 'public content') fail(`9: public.md content wrong: ${pubFile}`);
 if (privFile !== 'private content') fail(`9: private.md content wrong: ${privFile}`);
 passed++;
+
+// ── 10. append mode: preserves existing, dedupes case-insensitive ──
+{
+  const r = mkdtempSync(join(tmpdir(), 'profile-append-'));
+  const s = new MemoryStore(r);
+  // Start with an existing tier
+  await s.saveProfile('ou_app', '- Prefers tea', 'private', 'replace');
+  // Single-fact save (default append) should add the new line, keep existing
+  await s.saveProfile('ou_app', "Doesn't eat fish", 'private');
+  const body1 = readFileSync(join(r, 'profiles', 'ou_app', 'private.md'), 'utf-8');
+  if (!body1.includes('Prefers tea')) fail('10: append dropped existing line');
+  if (!body1.includes("- Doesn't eat fish")) fail('10: append did not add new line (with auto-bullet)');
+  // Exact-duplicate save should be a no-op
+  const before = body1;
+  await s.saveProfile('ou_app', "Doesn't eat fish", 'private');
+  const body2 = readFileSync(join(r, 'profiles', 'ou_app', 'private.md'), 'utf-8');
+  if (body2 !== before) fail('10: exact duplicate should not change file');
+  // Case-insensitive dedupe
+  await s.saveProfile('ou_app', '- prefers tea', 'private');
+  const body3 = readFileSync(join(r, 'profiles', 'ou_app', 'private.md'), 'utf-8');
+  if (body3 !== before) fail('10: case-insensitive dedupe failed');
+  rmSync(r, { recursive: true, force: true });
+  passed++;
+}
+
+// ── 11. append mode: multi-line, partial dedupe ────────────────
+{
+  const r = mkdtempSync(join(tmpdir(), 'profile-append-multi-'));
+  const s = new MemoryStore(r);
+  await s.saveProfile('ou_multi', '- existing one\n- existing two', 'private', 'replace');
+  await s.saveProfile('ou_multi', '- existing one\n- new three\n- new four', 'private');
+  const body = readFileSync(join(r, 'profiles', 'ou_multi', 'private.md'), 'utf-8');
+  const lines = body.split('\n').filter(Boolean);
+  if (lines.length !== 4) fail(`11: expected 4 lines, got ${lines.length}: ${JSON.stringify(lines)}`);
+  if (!lines.includes('- new three')) fail('11: missing new three');
+  if (!lines.includes('- new four')) fail('11: missing new four');
+  rmSync(r, { recursive: true, force: true });
+  passed++;
+}
+
+// ── 12. append mode: empty file gets first entry with auto-bullet ──
+{
+  const r = mkdtempSync(join(tmpdir(), 'profile-append-first-'));
+  const s = new MemoryStore(r);
+  await s.saveProfile('ou_first', 'bare fact no bullet', 'private');
+  const body = readFileSync(join(r, 'profiles', 'ou_first', 'private.md'), 'utf-8');
+  if (body !== '- bare fact no bullet\n') fail(`12: first-entry auto-bullet wrong: ${JSON.stringify(body)}`);
+  rmSync(r, { recursive: true, force: true });
+  passed++;
+}
 
 // ── parseTieredProfile: well-formed JSON ─────────────────────
 {
@@ -263,4 +313,4 @@ rmSync(legacyRoot, { recursive: true, force: true });
 rmSync(partialRoot, { recursive: true, force: true });
 rmSync(writeRoot, { recursive: true, force: true });
 
-console.log(`profile-tier smoke: ${passed}/18 PASS`);
+console.log(`profile-tier smoke: ${passed}/21 PASS`);

--- a/scripts/profile-tier-smoke.ts
+++ b/scripts/profile-tier-smoke.ts
@@ -264,6 +264,61 @@ passed++;
   passed++;
 }
 
+// ── 13. listProfileLines strips leading bullet in text + hash ──
+{
+  const r = mkdtempSync(join(tmpdir(), 'profile-list-strip-'));
+  const s = new MemoryStore(r);
+  // Mix: one bullet-stored (append) and one bullet-less (as distiller would write via replace)
+  await s.saveProfile('ou_mix', '- bulleted line', 'private');
+  await s.saveProfile('ou_mix', 'plain line\n- bulleted line', 'private', 'replace');
+  const listed = await s.listProfileLines('ou_mix', 'private');
+  if (listed.length !== 2) fail(`13: expected 2 lines, got ${listed.length}`);
+  // text should be bullet-stripped on both
+  if (listed.some((l) => l.text.startsWith('- '))) fail(`13: text should be bullet-stripped, got ${JSON.stringify(listed)}`);
+  // Same hash whether saved with or without bullet (storage-format independence)
+  const withBullet = await s.listProfileLines('ou_mix', 'private');
+  await s.saveProfile('ou_mix', 'plain line', 'public'); // same content in public
+  const publicListed = await s.listProfileLines('ou_mix', 'public');
+  const plainHashPriv = withBullet.find((l) => l.text === 'plain line')?.hash;
+  const plainHashPub = publicListed.find((l) => l.text === 'plain line')?.hash;
+  if (!plainHashPriv || plainHashPriv !== plainHashPub) {
+    fail(`13: hash should be storage-format independent, priv=${plainHashPriv} pub=${plainHashPub}`);
+  }
+  rmSync(r, { recursive: true, force: true });
+  passed++;
+}
+
+// ── 14. removeProfileLine rewrites with bullet normalization ──
+{
+  const r = mkdtempSync(join(tmpdir(), 'profile-remove-renorm-'));
+  const s = new MemoryStore(r);
+  // Write a mixed file via replace (some bulleted, some not)
+  await s.saveProfile('ou_rm', '- first\nsecond\n- third', 'private', 'replace');
+  const listed = await s.listProfileLines('ou_rm', 'private');
+  const secondHash = listed.find((l) => l.text === 'second')!.hash;
+  const ok = await s.removeProfileLine('ou_rm', 'private', secondHash);
+  if (!ok) fail('14: removeProfileLine should report success');
+  const body = readFileSync(join(r, 'profiles', 'ou_rm', 'private.md'), 'utf-8');
+  // Remaining lines should both carry bullets now
+  if (body !== '- first\n- third\n') fail(`14: expected bullet-normalized rewrite, got ${JSON.stringify(body)}`);
+  rmSync(r, { recursive: true, force: true });
+  passed++;
+}
+
+// ── 15. saveProfile append with empty/whitespace content is a no-op ──
+{
+  const r = mkdtempSync(join(tmpdir(), 'profile-empty-append-'));
+  const s = new MemoryStore(r);
+  await s.saveProfile('ou_e', '- existing', 'private', 'replace');
+  const before = readFileSync(join(r, 'profiles', 'ou_e', 'private.md'), 'utf-8');
+  await s.saveProfile('ou_e', '', 'private');
+  await s.saveProfile('ou_e', '\n\n\n', 'private');
+  const after = readFileSync(join(r, 'profiles', 'ou_e', 'private.md'), 'utf-8');
+  if (after !== before) fail(`15: empty append should no-op, before=${JSON.stringify(before)} after=${JSON.stringify(after)}`);
+  rmSync(r, { recursive: true, force: true });
+  passed++;
+}
+
 // ── parseTieredProfile: well-formed JSON ─────────────────────
 {
   const { public: pub, private: priv } = parseTieredProfile(
@@ -325,4 +380,4 @@ rmSync(legacyRoot, { recursive: true, force: true });
 rmSync(partialRoot, { recursive: true, force: true });
 rmSync(writeRoot, { recursive: true, force: true });
 
-console.log(`profile-tier smoke: ${passed}/22 PASS`);
+console.log(`profile-tier smoke: ${passed}/25 PASS`);

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -48,4 +48,8 @@ echo "=== Transparency unit checks ==="
 npx tsx scripts/transparency-smoke.ts
 
 echo ""
+echo "=== Mention resolver unit checks ==="
+npx tsx scripts/mention-resolver-smoke.ts
+
+echo ""
 echo "All tests passed."

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -420,10 +420,17 @@ export class LarkChannel {
         });
         const parentItem = parentMsg?.data?.items?.[0];
         if (parentItem?.body?.content) {
+          // Parent-message mentions may arrive either as the receive-event
+          // shape (`id: { open_id, union_id, user_id }`) or, in some API
+          // responses, as a flat string. Normalize both so name-based
+          // resolution works and `id` never stringifies to "[object Object]".
           const parentMentions: Array<{ id: string; name: string }> = (
             parentItem.mentions ?? []
           ).map((m: any) => ({
-            id: m.id ?? '',
+            id:
+              m.id?.open_id ??
+              m.id?.union_id ??
+              (typeof m.id === 'string' ? m.id : ''),
             name: m.name ?? '',
           }));
           larkMessage.parentContent = resolveMentionPlaceholders(

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -46,10 +46,36 @@ export interface LarkMessage {
   parentContent?: string;
   threadId?: string;
   mentions?: Array<{ id: string; name: string }>;
+  /** True when this bot's open_id appears in mentions. Forwarded to Claude as meta.bot_mentioned. */
+  botMentioned?: boolean;
   attachments?: Array<{ fileKey: string; fileName: string; fileType: string }>;
   rawContent: string;
   imagePath?: string;
   imagePaths?: string[];
+}
+
+/**
+ * Resolve Feishu's @_user_N placeholders in a text body to `@<name>` using
+ * the mentions array. mentions[N-1] corresponds to @_user_N (1-indexed).
+ *
+ * If the mention has no name (user privacy settings, masked) the placeholder
+ * is kept verbatim — a synthetic alias would be misleading.
+ * Out-of-range indices (defensive) are also kept verbatim.
+ *
+ * Does NOT touch @_all or any other Feishu-specific placeholder; only matches
+ * /@_user_(\d+)/.
+ */
+export function resolveMentionPlaceholders(
+  text: string,
+  mentions: Array<{ id: string; name: string }> | undefined,
+): string {
+  if (!text || !mentions || mentions.length === 0) return text;
+  return text.replace(/@_user_(\d+)/g, (match, n) => {
+    const idx = Number(n) - 1;
+    const m = mentions[idx];
+    if (!m || !m.name) return match;
+    return `@${m.name}`;
+  });
 }
 
 type MessageHandler = (message: LarkMessage) => Promise<void>;
@@ -301,14 +327,26 @@ export class LarkChannel {
       }).catch(() => {});
     }
 
-    // Parse message text
-    const text = this.extractText(rawContent, messageType);
-
     // Parse mentions
-    const parsedMentions = (mentions ?? []).map((m: any) => ({
-      id: m.id?.open_id ?? m.id?.union_id ?? '',
-      name: m.name ?? '',
-    }));
+    const parsedMentions: Array<{ id: string; name: string }> = (mentions ?? []).map(
+      (m: any) => ({
+        id: m.id?.open_id ?? m.id?.union_id ?? '',
+        name: m.name ?? '',
+      }),
+    );
+
+    // Detect whether this bot was among the mentioned users — forwarded to
+    // Claude as meta.bot_mentioned so Claude has a text-independent signal
+    // when multiple users are @mentioned in the same message.
+    const botMentioned = this.botOpenId
+      ? parsedMentions.some((m) => m.id === this.botOpenId)
+      : parsedMentions.length > 0; // fallback: same heuristic as the group-filter
+
+    // Parse message text, resolving @_user_N placeholders to @<name>
+    const text = resolveMentionPlaceholders(
+      this.extractText(rawContent, messageType),
+      parsedMentions,
+    );
 
     // Parse attachments
     const attachments = this.extractAttachments(message);
@@ -367,6 +405,7 @@ export class LarkChannel {
       parentId,
       threadId,
       mentions: parsedMentions,
+      botMentioned,
       attachments,
       rawContent,
       imagePath,
@@ -379,10 +418,17 @@ export class LarkChannel {
         const parentMsg = await this.client.im.v1.message.get({
           path: { message_id: parentId },
         });
-        if (parentMsg?.data?.items?.[0]?.body?.content) {
-          larkMessage.parentContent = this.extractText(
-            parentMsg.data.items[0].body.content,
-            parentMsg.data.items[0].msg_type ?? 'text'
+        const parentItem = parentMsg?.data?.items?.[0];
+        if (parentItem?.body?.content) {
+          const parentMentions: Array<{ id: string; name: string }> = (
+            parentItem.mentions ?? []
+          ).map((m: any) => ({
+            id: m.id ?? '',
+            name: m.name ?? '',
+          }));
+          larkMessage.parentContent = resolveMentionPlaceholders(
+            this.extractText(parentItem.body.content, parentItem.msg_type ?? 'text'),
+            parentMentions,
           );
         }
       } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.0' },
+    { name: 'claude-lark-plugin', version: '1.0.2' },
     {
       capabilities: {
         logging: {},
@@ -139,6 +139,7 @@ async function main() {
             chat_type: message.chatType,
             ...(message.chatName ? { chat_name: message.chatName } : {}),
             ...(message.threadId ? { thread_id: message.threadId } : {}),
+            ...(message.botMentioned ? { bot_mentioned: 'true' } : {}),
             ts: new Date().toISOString(),
             ...(message.parentContent ? { parent_content: message.parentContent } : {}),
             ...(message.imagePath ? { image_path: message.imagePath } : {}),

--- a/src/memory/file.ts
+++ b/src/memory/file.ts
@@ -272,7 +272,11 @@ export class MemoryStore {
    * forget_memory tool) use the hash to identify a line without the file
    * needing a durable row id.
    *
-   * Blank lines are skipped. Leading/trailing whitespace is trimmed.
+   * Blank lines are skipped. Leading/trailing whitespace is trimmed. A leading
+   * `-`/`*` bullet marker is also stripped so `text` (and the derived hash) is
+   * storage-format-independent — a fact saved as "foo" by the distiller and
+   * later merged via append as "- foo" shares one hash and renders identically
+   * in `what_do_you_know`.
    */
   async listProfileLines(ownerId: string, tier: Tier): Promise<ProfileLine[]> {
     await this.migrateIfNeeded(ownerId);
@@ -281,7 +285,7 @@ export class MemoryStore {
     const content = await fs.readFile(p, 'utf-8');
     return content
       .split('\n')
-      .map((raw) => raw.trim())
+      .map((raw) => raw.trim().replace(/^[-*]\s+/, ''))
       .filter(Boolean)
       .map((text, index) => ({ index, hash: lineHash(text), text }));
   }
@@ -291,13 +295,17 @@ export class MemoryStore {
    * from the given tier file. Returns true if a line was removed, false if
    * nothing matched. Idempotent — removing the same hash twice returns false
    * on the second call.
+   *
+   * The rewritten file is bullet-normalized: every remaining line is written
+   * back with a `- ` prefix so the tier stays visually consistent with the
+   * append-mode storage convention.
    */
   async removeProfileLine(ownerId: string, tier: Tier, hash: string): Promise<boolean> {
     const lines = await this.listProfileLines(ownerId, tier);
     const kept = lines.filter((l) => l.hash !== hash);
     if (kept.length === lines.length) return false;
 
-    const next = kept.map((l) => l.text).join('\n') + (kept.length > 0 ? '\n' : '');
+    const next = kept.map((l) => `- ${l.text}`).join('\n') + (kept.length > 0 ? '\n' : '');
     await fs.writeFile(this.profileTierPath(ownerId, tier), next, 'utf-8');
     return true;
   }

--- a/src/memory/file.ts
+++ b/src/memory/file.ts
@@ -18,6 +18,65 @@ function lineHash(text: string): string {
   return createHash('sha1').update(text).digest('hex').slice(0, 8);
 }
 
+/** Normalize a profile line for deduplication (not for storage). */
+function normalizeProfileLine(line: string): string {
+  return line.trim().replace(/^[-*]\s+/, '').toLowerCase();
+}
+
+/**
+ * Merge new profile lines into an existing tier file body.
+ *
+ * Dedup rules:
+ * - Case-insensitive line match after trim + leading-bullet strip.
+ * - Punctuation is **not** normalized — "prefers tea" and "prefers tea."
+ *   are kept as distinct lines to avoid silent merges.
+ *
+ * Original capitalization and punctuation are preserved in the output.
+ *
+ * Incoming lines without a `-`/`*` bullet marker are normalized on write to
+ * `- <line>` so the tier file remains a well-formed markdown bullet list.
+ *
+ * Near-duplicates (prefix containment after normalization) are logged to
+ * stderr to help operators notice redundant writes, but are still preserved.
+ */
+export function mergeProfileLines(
+  existing: string,
+  incoming: string,
+  ctx?: { userId?: string; tier?: Tier },
+): string {
+  const existingLinesRaw = existing.split('\n').filter((l) => l.trim());
+  const existingKeys = new Set(existingLinesRaw.map(normalizeProfileLine));
+  const existingNormalized = existingLinesRaw.map(normalizeProfileLine);
+
+  const newLines: string[] = [];
+  for (const raw of incoming.split('\n')) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    const key = normalizeProfileLine(trimmed);
+    if (existingKeys.has(key)) continue; // exact match → skip
+    newLines.push(trimmed);
+
+    // Near-duplicate warning: prefix-containment either direction.
+    for (const other of existingNormalized) {
+      if (key !== other && (key.startsWith(other) || other.startsWith(key))) {
+        const where = ctx?.userId && ctx?.tier ? ` in ${ctx.userId}/${ctx.tier}.md` : '';
+        console.error(
+          `[memory] Possible near-duplicate${where}: incoming "${trimmed}" resembles existing entry "${existingLinesRaw[existingNormalized.indexOf(other)]}"`,
+        );
+        break;
+      }
+    }
+  }
+
+  if (newLines.length === 0) return existing;
+
+  const appended = newLines
+    .map((l) => (/^[-*]\s+/.test(l) ? l : `- ${l}`))
+    .join('\n');
+  const sep = existing.length === 0 || existing.endsWith('\n') ? '' : '\n';
+  return existing + sep + appended + '\n';
+}
+
 export interface Episode {
   id: string;
   content: string;
@@ -173,12 +232,37 @@ export class MemoryStore {
    * does not silently drop their legacy profile content. Without this call,
    * the order save → read would see dir-exists-early-return in migration and
    * throw away the legacy file without classifying it.
+   *
+   * Mode:
+   * - `'append'` (default, safe): read the existing tier, merge new lines
+   *   (exact-match deduped after `trim + strip-bullet + lowercase`), preserve
+   *   all original content. Used by one-off save_memory calls where `content`
+   *   is a single fact. Never destroys existing entries.
+   * - `'replace'`: overwrite the entire tier file. Reserved for the distiller
+   *   auto-flush path, which intentionally rewrites the full tier based on a
+   *   fresh read of recent history.
    */
-  async saveProfile(userId: string, content: string, tier: Tier): Promise<void> {
+  async saveProfile(
+    userId: string,
+    content: string,
+    tier: Tier,
+    mode: 'append' | 'replace' = 'append',
+  ): Promise<void> {
     await this.migrateIfNeeded(userId);
     const dir = this.profileDir(userId);
     await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(this.profileTierPath(userId, tier), content, 'utf-8');
+    const filePath = this.profileTierPath(userId, tier);
+
+    if (mode === 'replace') {
+      await fs.writeFile(filePath, content, 'utf-8');
+      return;
+    }
+
+    // append mode
+    const existing = existsSync(filePath) ? await fs.readFile(filePath, 'utf-8') : '';
+    const merged = mergeProfileLines(existing, content, { userId, tier });
+    if (merged === existing) return; // all incoming lines were duplicates — skip write
+    await fs.writeFile(filePath, merged, 'utf-8');
   }
 
   /**

--- a/src/memory/file.ts
+++ b/src/memory/file.ts
@@ -208,6 +208,12 @@ export class MemoryStore {
    * - caller !== ownerId → return public tier only
    *
    * Returns null if neither tier file has content.
+   *
+   * Output is the raw tier file bytes (bullets preserved). This is the
+   * representation the channel-side memory enricher feeds to Claude as
+   * conversational context. The display/edit representation in
+   * {@link listProfileLines} strips bullets — the two return formats are
+   * intentionally different, and their consumers are disjoint.
    */
   async getProfile(ownerId: string, caller: string): Promise<string | null> {
     await this.migrateIfNeeded(ownerId);

--- a/src/memory/file.ts
+++ b/src/memory/file.ts
@@ -55,6 +55,7 @@ export function mergeProfileLines(
     const key = normalizeProfileLine(trimmed);
     if (existingKeys.has(key)) continue; // exact match → skip
     newLines.push(trimmed);
+    existingKeys.add(key); // also dedupe within the incoming batch
 
     // Near-duplicate warning: prefix-containment either direction.
     for (const other of existingNormalized) {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -75,7 +75,7 @@ Classification rules (apply in order; higher priority wins):
    - chatType=p2p → unknown facts default to private (never voluntarily shared beyond 1:1).
 5. When truly uncertain: choose private.
 
-Return ONLY the JSON object, no prose or code fences. Then call save_memory(type="profile", content=<public-array-as-markdown-list>, reason=<why>, chat_id=<current>, tier="public") and again with tier="private" for the private array. Skip either call if its array is empty.`;
+Return ONLY the JSON object, no prose or code fences. Then call save_memory(type="profile", content=<public-array-as-markdown-list>, reason=<why>, chat_id=<current>, tier="public", mode="replace") and again with tier="private" for the private array. Skip either call if its array is empty. mode="replace" is required — this flush rewrites the full tier from a fresh read of history, so the existing file should be overwritten rather than appended to.`;
 }
 
 /**

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -507,7 +507,13 @@ export function registerTools(
       }),
     },
     async ({ type, content, reason, chat_id, thread_id, tier, mode }) => {
-      const auditArgs = { type, chat_id, thread_id, tier, mode };
+      // Only include profile-specific params in audit args when they're
+      // actually applied — keeps chat/thread audit lines clean and avoids
+      // implying a tier/mode was honored when type !== 'profile'.
+      const auditArgs =
+        type === 'profile'
+          ? { type, chat_id, thread_id, tier, mode }
+          : { type, chat_id, thread_id };
       const auth = resolveCaller('save_memory', chat_id, thread_id, auditArgs);
       if ('error' in auth) return auth.error;
       const { caller } = auth;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -498,21 +498,28 @@ export function registerTools(
           .describe(
             'Profile tier (type="profile" only). "public": safe for others to see when they @mention this user (job title, tech stack, team). "private": owner-only (preferences, ongoing work, emotional state, etc.). Defaults to "private" when omitted — err on the side of less exposure.'
           ),
+        mode: z
+          .enum(['append', 'replace'])
+          .optional()
+          .describe(
+            'Profile write mode (type="profile" only). Defaults to "append": new lines merged into the existing tier, deduped case-insensitively; existing entries are preserved. Use "replace" ONLY during distiller auto-flush when you are rewriting the full tier from a fresh read of the conversation — replace overwrites the entire file.'
+          ),
       }),
     },
-    async ({ type, content, reason, chat_id, thread_id, tier }) => {
-      const auditArgs = { type, chat_id, thread_id, tier };
+    async ({ type, content, reason, chat_id, thread_id, tier, mode }) => {
+      const auditArgs = { type, chat_id, thread_id, tier, mode };
       const auth = resolveCaller('save_memory', chat_id, thread_id, auditArgs);
       if ('error' in auth) return auth.error;
       const { caller } = auth;
 
       if (type === 'profile') {
         const effectiveTier = tier ?? 'private';
-        await memoryStore.saveProfile(caller, content, effectiveTier);
+        const effectiveMode = mode ?? 'append';
+        await memoryStore.saveProfile(caller, content, effectiveTier, effectiveMode);
         void audit('save_memory', caller, auditArgs, 'ok');
         return {
           content: [
-            { type: 'text' as const, text: `Saved ${effectiveTier} profile for ${caller}. Reason: ${reason}` },
+            { type: 'text' as const, text: `Saved ${effectiveTier} profile for ${caller} (mode: ${effectiveMode}). Reason: ${reason}` },
           ],
         };
       }


### PR DESCRIPTION
Closes #51, #52

## Summary

Two field-reported bugs.

### #51 — `save_memory` overwrote existing profile content
`saveProfile` did an unconditional `fs.writeFile`. A user telling the bot one new fact (e.g. "记住我不吃鱼") wiped the entire `private.md`.

**Fix:** `saveProfile` gains a `mode` parameter.
- `"append"` (new default, safe) — merge-by-line with case-insensitive dedup after trim + bullet-strip. Punctuation **not** normalized. Auto-bullets on write. Dedupes within the same incoming batch too. Near-duplicates logged to stderr.
- `"replace"` — old overwrite behavior; now explicitly requested by the distiller flush prompt.

`save_memory` tool schema gains a `mode` parameter (profile-only, default `"append"`). Profile-specific audit args are only recorded when `type='profile'`.

### #52 — Group @bot misrouted as @other-user
Feishu uses `@_user_N` placeholders in text; the identity mapping is in the `mentions` array. Plugin's group-mention **filter** matched by `open_id` correctly, but the text forwarded to Claude still had raw `@_user_1`. Claude read it, didn't recognize its own `user_<suffix>` alias, concluded it wasn't being addressed, and stayed silent.

**Fix, two parts:**
1. `resolveMentionPlaceholders(text, mentions)` post-processes `extractText` and `parentContent`. Each `@_user_N` → `@<name>` from `mentions[N-1]`. Masked/empty names and out-of-range indices keep the placeholder verbatim.
2. New `meta.bot_mentioned="true"` field on the MCP notification when this bot's `open_id` is among the mentions — text-independent signal that complements resolved names.

Permissions note: `mentions[].name` / `id.open_id` arrive with the message event. No extra contact permission needed.

### Ancillary storage cleanup (from audit rounds)
- `listProfileLines` / `removeProfileLine` now bullet-normalize the profile tier — hashes are storage-format independent so a fact saved via `replace` (no bullet) and one saved via `append` (bulleted) share an address in `forget_memory`. Fixes a double-bullet render artefact (`- [hash] - foo`) in `what_do_you_know`.
- Parent-reply mention parsing normalizes `id` to avoid `"[object Object]"` if the Feishu SDK returns the object shape.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes — profile-tier 25/25 (+7 new from pre-PR), mention-resolver 10/10 (new)
- [x] `npm start -- --dry-run` clean
- [x] 7 rounds of self-audit converged to ship-ready
- [x] Field verification: set a new fact in DM → previous entries survive
- [x] Field verification: @bot in group → bot replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)