### PR TITLE
fix: route follow-up messages into the source thread (v1.0.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.3] - 2026-04-24
+
+### Fixed
+- **Follow-up messages in a Feishu thread are now correctly routed into the thread** (#56). In a group thread (话题), when Claude replied with text + image (or long text split into multiple chunks, or a multi-card response), the first message stayed in the thread via `message.reply()` but every follow-up escaped to the chat's root timeline via `message.create()`. Now all follow-ups use `message.reply(source, reply_in_thread: true)` when the triggering notification carries a `thread_id`, which routes into the thread without rendering as a quote-reply. P2P and non-threaded group chats are unaffected — the gate falls through to `message.create()` in those cases (setting `reply_in_thread: true` on a non-threaded source would incorrectly start a new thread).
+
+Fix applies to three call sites in `src/tools.ts`:
+- Multi-chunk text replies (chunks 2..N)
+- Multi-card replies (cards 2..N)
+- Attachments (images, files)
+
+Cronjob-synthetic `thread_id` values (prefixed `job-`, used for IdentitySession isolation, not real Feishu threads) are excluded from thread-routing. Without this carve-out, a cronjob reply with an attachment could pull an unrelated earlier user message into a fabricated Feishu thread.
+
+New `scripts/reply-thread-smoke.ts` verifies the routing via a mock Feishu client across six scenarios (thread + image, P2P + image, thread + long text, missing `reply_to` fallback, thread + file, thread + multi-card).
+
+### Changed
+- **Attachment message IDs now tracked in `BotMessageTracker`.** Pre-1.0.3 the attachment path fire-and-forgot the send and never recorded the returned message_id. Reactions on bot-sent images/files were therefore silently filtered out by the reaction-forwarding gate (which only forwards reactions on known-bot messages). Because the thread-routing fix now captures the send response anyway, the plugin also calls `BotMessageTracker.add` on attachments — user reactions to bot-generated images/files will now correctly surface to Claude.
+
 ## [1.0.2] - 2026-04-22
 
 Two field-reported bug fixes on top of 1.0.1.
@@ -312,6 +329,7 @@ Precondition for the privacy redesign (#35). A pluggable abstraction made every 
 - Score-based filtering (`LARK_MIN_SEARCH_SCORE`)
 - HealthCheck for memory provider connectivity
 
+[1.0.3]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.3
 [1.0.2]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.2
 [1.0.1]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.1
 [1.0.0]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/reply-thread-smoke.ts
+++ b/scripts/reply-thread-smoke.ts
@@ -1,0 +1,326 @@
+/**
+ * Reply tool thread-routing smoke test — runs as part of `npm test`.
+ * Uses a mock Lark client to verify that follow-up messages (multi-chunk
+ * text, multi-card, attachments) correctly stay in the source message's
+ * thread when `thread_id` is present, and fall through to `message.create`
+ * otherwise.
+ */
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { registerTools } from '../src/tools.js';
+import type { MemoryStore } from '../src/memory/file.js';
+import { IdentitySession } from '../src/identity-session.js';
+import type { LarkChannel } from '../src/channel.js';
+import { JOB_THREAD_PREFIX } from '../src/scheduler.js';
+
+function fail(msg: string): never {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+let passed = 0;
+const apiCalls: { method: string; args: any }[] = [];
+
+function mockClient() {
+  return {
+    im: {
+      v1: {
+        message: {
+          create: async (args: any) => {
+            apiCalls.push({ method: 'message.create', args });
+            return { data: { message_id: `created_${apiCalls.length}` } };
+          },
+          reply: async (args: any) => {
+            apiCalls.push({ method: 'message.reply', args });
+            return { data: { message_id: `replied_${apiCalls.length}` } };
+          },
+        },
+        messageReaction: {
+          create: async () => {},
+          delete: async () => {},
+        },
+        image: {
+          create: async () => ({ data: { image_key: 'img_mock' } }),
+          get: async () => Buffer.from('fake'),
+        },
+        file: {
+          create: async () => ({ data: { file_key: 'file_mock' } }),
+        },
+        messageResource: {
+          get: async () => Buffer.from('fake'),
+        },
+      },
+    },
+  };
+}
+
+const noopMemory = {
+  healthCheck: async () => true,
+  getProfile: async () => null,
+  saveProfile: async () => {},
+  searchEpisodes: async () => [],
+  saveEpisode: async () => {},
+  listEpisodes: async () => [],
+  deleteEpisodes: async () => {},
+  searchSkills: async () => [],
+  saveSkill: async () => {},
+} as unknown as MemoryStore;
+
+function makeBuffer() {
+  return {
+    record() {},
+    flush: async () => {},
+    startAutoFlush: () => {},
+    stopAutoFlush: () => {},
+  };
+}
+
+const handlers = new Map<string, (args: any) => Promise<any>>();
+const fakeServer = {
+  registerTool(name: string, _config: any, handler: any) {
+    handlers.set(name, handler);
+  },
+};
+
+async function setup() {
+  apiCalls.length = 0;
+  const client = mockClient();
+  const botTracker = {
+    ids: new Set<string>(),
+    add(id: string) { this.ids.add(id); },
+    has(id: string) { return this.ids.has(id); },
+  };
+  const identitySession = new IdentitySession(() => null);
+  identitySession.setCaller('chat_grp', 'thread_abc', 'ou_caller');
+  identitySession.setCaller('chat_p2p', undefined, 'ou_caller');
+  const fakeChannel = { isPrivateChat: () => true } as unknown as LarkChannel;
+
+  registerTools(
+    fakeServer as any,
+    client as any,
+    noopMemory,
+    identitySession,
+    fakeChannel,
+    makeBuffer() as any,
+    new Map<string, string>(),
+    botTracker as any,
+    undefined,
+  );
+
+  const reply = handlers.get('reply');
+  if (!reply) fail('reply handler not registered');
+  return { reply };
+}
+
+// A fixture image on disk for attachment tests
+const fixDir = mkdtempSync(join(tmpdir(), 'reply-thread-fix-'));
+const imgPath = join(fixDir, 'fake.png');
+writeFileSync(imgPath, Buffer.from('fake-png-bytes'));
+
+// ── 1. Thread + image: image must go via reply(..., reply_in_thread=true) ──
+{
+  const { reply } = await setup();
+  await reply({
+    chat_id: 'chat_grp',
+    text: 'here is the image',
+    reply_to: 'om_user1',
+    thread_id: 'thread_abc',
+    files: [{ path: imgPath, type: 'image' }],
+  });
+  const replyCalls = apiCalls.filter((c) => c.method === 'message.reply');
+  const createCalls = apiCalls.filter((c) => c.method === 'message.create');
+  if (createCalls.length !== 0) {
+    fail(`1: expected 0 message.create in thread mode, got ${createCalls.length}`);
+  }
+  // 1 for text, 1 for image — both via reply
+  if (replyCalls.length !== 2) {
+    fail(`1: expected 2 message.reply, got ${replyCalls.length}`);
+  }
+  const imageCall = replyCalls[1];
+  if (imageCall.args.path.message_id !== 'om_user1') {
+    fail(`1: image reply path.message_id wrong: ${imageCall.args.path.message_id}`);
+  }
+  if (imageCall.args.data.reply_in_thread !== true) {
+    fail(`1: image reply missing reply_in_thread=true, got ${JSON.stringify(imageCall.args.data)}`);
+  }
+  if (imageCall.args.data.msg_type !== 'image') {
+    fail(`1: image reply msg_type wrong: ${imageCall.args.data.msg_type}`);
+  }
+  passed++;
+}
+
+// ── 2. P2P + image: image must still use message.create (no reply_in_thread) ──
+{
+  const { reply } = await setup();
+  await reply({
+    chat_id: 'chat_p2p',
+    text: 'here is the image',
+    reply_to: 'om_p2p1',
+    // no thread_id — P2P
+    files: [{ path: imgPath, type: 'image' }],
+  });
+  const createCalls = apiCalls.filter((c) => c.method === 'message.create');
+  const replyCalls = apiCalls.filter((c) => c.method === 'message.reply');
+  // text chunk 0 → reply; image → create (no thread)
+  if (replyCalls.length !== 1) fail(`2: expected 1 message.reply, got ${replyCalls.length}`);
+  if (createCalls.length !== 1) fail(`2: expected 1 message.create (image), got ${createCalls.length}`);
+  const imgCreate = createCalls[0];
+  if (imgCreate.args.data.msg_type !== 'image') {
+    fail(`2: image create msg_type wrong: ${imgCreate.args.data.msg_type}`);
+  }
+  if ('reply_in_thread' in imgCreate.args.data) {
+    fail(`2: P2P image create must NOT carry reply_in_thread`);
+  }
+  passed++;
+}
+
+// ── 3. Thread + long text (multi-chunk): chunks 2..N use reply_in_thread ──
+{
+  const { reply } = await setup();
+  // Force text path + multi-chunk (text > LARK_TEXT_CHUNK_LIMIT = 4000)
+  const big = 'a'.repeat(9000);
+  await reply({
+    chat_id: 'chat_grp',
+    text: big,
+    reply_to: 'om_user2',
+    thread_id: 'thread_abc',
+    format: 'text',
+  });
+  const replyCalls = apiCalls.filter((c) => c.method === 'message.reply');
+  const createCalls = apiCalls.filter((c) => c.method === 'message.create');
+  if (createCalls.length !== 0) {
+    fail(`3: expected 0 message.create in thread mode, got ${createCalls.length}`);
+  }
+  if (replyCalls.length < 2) {
+    fail(`3: expected multi-chunk replies (>=2), got ${replyCalls.length}`);
+  }
+  // First call is the bare quote-reply; subsequent must carry reply_in_thread
+  if ('reply_in_thread' in replyCalls[0].args.data) {
+    fail(`3: first chunk must not carry reply_in_thread`);
+  }
+  for (let i = 1; i < replyCalls.length; i++) {
+    if (replyCalls[i].args.data.reply_in_thread !== true) {
+      fail(`3: chunk ${i} missing reply_in_thread=true`);
+    }
+  }
+  passed++;
+}
+
+// ── 4. No reply_to + thread_id (shouldStayInThread guard) ─────────────
+// When effectiveReplyTo cannot be resolved (no reply_to, no tracker), the
+// follow-up must NOT try to call message.reply with an empty path — it
+// should fall through to message.create to avoid SDK errors.
+{
+  const { reply } = await setup();
+  await reply({
+    chat_id: 'chat_grp',
+    text: 'one line',
+    thread_id: 'thread_abc',
+    // no reply_to, no tracker configured in setup
+    files: [{ path: imgPath, type: 'image' }],
+  });
+  const replyCalls = apiCalls.filter((c) => c.method === 'message.reply');
+  const createCalls = apiCalls.filter((c) => c.method === 'message.create');
+  if (replyCalls.length !== 0) {
+    fail(`4: expected no reply calls without effectiveReplyTo, got ${replyCalls.length}`);
+  }
+  // 1 text + 1 image, both create
+  if (createCalls.length !== 2) {
+    fail(`4: expected 2 message.create, got ${createCalls.length}`);
+  }
+  passed++;
+}
+
+// ── 5. Thread + file attachment ──────────────────────────────────
+{
+  const { reply } = await setup();
+  const filePath = join(fixDir, 'doc.txt');
+  writeFileSync(filePath, 'hello');
+  await reply({
+    chat_id: 'chat_grp',
+    text: 'here is the file',
+    reply_to: 'om_user3',
+    thread_id: 'thread_abc',
+    files: [{ path: filePath, type: 'file' }],
+  });
+  const replyCalls = apiCalls.filter((c) => c.method === 'message.reply');
+  const fileReply = replyCalls.find((c) => c.args.data.msg_type === 'file');
+  if (!fileReply) fail('5: file attachment not sent via reply');
+  if (fileReply.args.data.reply_in_thread !== true) {
+    fail('5: file attachment missing reply_in_thread=true');
+  }
+  passed++;
+}
+
+// ── 6. Thread + multi-card (format=card): cards 2..N use reply_in_thread ──
+{
+  const { reply } = await setup();
+  // Force cards path via format='card'; exceed CARD_SIZE_LIMIT (25KB) with
+  // multiple markdown elements to actually trigger multi-card split.
+  // Use repeated markdown blocks so each becomes a separate element.
+  const block = '# heading\n\n' + 'x'.repeat(2000) + '\n\n';
+  const multiCardText = block.repeat(20); // ~40KB, forces >=2 cards
+  await reply({
+    chat_id: 'chat_grp',
+    text: multiCardText,
+    reply_to: 'om_user4',
+    thread_id: 'thread_abc',
+    format: 'card',
+  });
+  const replyCalls = apiCalls.filter((c) => c.method === 'message.reply');
+  const createCalls = apiCalls.filter((c) => c.method === 'message.create');
+  if (createCalls.length !== 0) {
+    fail(`6: expected 0 message.create in thread mode, got ${createCalls.length}`);
+  }
+  // At least 2 card chunks expected
+  if (replyCalls.length < 2) {
+    fail(`6: expected multi-card replies (>=2), got ${replyCalls.length}`);
+  }
+  if ('reply_in_thread' in replyCalls[0].args.data) {
+    fail(`6: first card must not carry reply_in_thread`);
+  }
+  for (let i = 1; i < replyCalls.length; i++) {
+    if (replyCalls[i].args.data.reply_in_thread !== true) {
+      fail(`6: card ${i} missing reply_in_thread=true`);
+    }
+    if (replyCalls[i].args.data.msg_type !== 'interactive') {
+      fail(`6: card ${i} msg_type wrong: ${replyCalls[i].args.data.msg_type}`);
+    }
+  }
+  passed++;
+}
+
+// ── 7. Synthetic cronjob thread_id must NOT trigger reply_in_thread ──
+// Regression guard: cronjob dispatches inject thread_id="job-<id>-<ts>"
+// as an IdentitySession isolation key. That value does not correspond to
+// a real Feishu thread. If the reply tool treated it like one and emitted
+// reply_in_thread:true against a real reply_to, Feishu would fabricate a
+// new thread around that earlier message — an unintended side effect.
+{
+  const { reply } = await setup();
+  await reply({
+    chat_id: 'chat_grp',
+    text: 'cron output',
+    reply_to: 'om_some_earlier_msg',
+    thread_id: `${JOB_THREAD_PREFIX}example-1700000000000`,
+    files: [{ path: imgPath, type: 'image' }],
+  });
+  const createCalls = apiCalls.filter((c) => c.method === 'message.create');
+  const replyCalls = apiCalls.filter((c) => c.method === 'message.reply');
+  // text chunk 0 quote-replies (reply without flag); image falls through to create
+  if (replyCalls.length !== 1) fail(`7: expected 1 reply (text chunk 0), got ${replyCalls.length}`);
+  if ('reply_in_thread' in replyCalls[0].args.data) {
+    fail(`7: first chunk must not carry reply_in_thread even for cronjob thread`);
+  }
+  if (createCalls.length !== 1) fail(`7: expected 1 create (image), got ${createCalls.length}`);
+  if ('reply_in_thread' in createCalls[0].args.data) {
+    fail(`7: create must not carry reply_in_thread`);
+  }
+  if (createCalls[0].args.data.msg_type !== 'image') {
+    fail(`7: create msg_type wrong: ${createCalls[0].args.data.msg_type}`);
+  }
+  passed++;
+}
+
+console.log(`reply-thread smoke: ${passed}/7 PASS`);

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -52,4 +52,8 @@ echo "=== Mention resolver unit checks ==="
 npx tsx scripts/mention-resolver-smoke.ts
 
 echo ""
+echo "=== Reply thread-routing unit checks ==="
+npx tsx scripts/reply-thread-smoke.ts
+
+echo ""
 echo "All tests passed."

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.2' },
+    { name: 'claude-lark-plugin', version: '1.0.3' },
     {
       capabilities: {
         logging: {},

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -17,6 +17,14 @@ import {
   type JobFile,
 } from './job-store.js';
 
+/**
+ * Prefix for synthetic `thread_id` values injected into cronjob channel
+ * notifications. Used only for IdentitySession isolation per cronjob run —
+ * NOT a real Feishu thread. Consumers that route messages to Feishu threads
+ * (e.g. the `reply` tool) must exclude thread_ids with this prefix.
+ */
+export const JOB_THREAD_PREFIX = 'job-';
+
 export interface SchedulerOptions {
   server: Server;
   client: Lark.Client;
@@ -250,7 +258,7 @@ export class JobScheduler {
    * does not clobber concurrent inbound human messages in the same chat.
    */
   private async executePromptJob(job: JobFile): Promise<void> {
-    const jobThreadId = `job-${job.meta.id}-${Date.now()}`;
+    const jobThreadId = `${JOB_THREAD_PREFIX}${job.meta.id}-${Date.now()}`;
 
     // Bind the job owner as caller so tools invoked from this Claude turn
     // (e.g. save_memory, list_jobs) resolve to the job creator, not to any

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -10,6 +10,7 @@ import type { BotMessageTracker, LatestMessageTracker, LarkChannel } from './cha
 import type { IdentitySession } from './identity-session.js';
 import { audit } from './audit-log.js';
 import { buildCards, shouldUseCard } from './feishu-card.js';
+import { JOB_THREAD_PREFIX } from './scheduler.js';
 import {
   sanitizeJobId,
   expandSchedule,
@@ -139,6 +140,44 @@ export function registerTools(
         }
       }
 
+      // Thread-aware routing: follow-up messages (text chunks 2..N, card
+      // 2..N, attachments) must stay in the same thread as the first reply.
+      // Using `message.reply(..., reply_in_thread: true)` routes into the
+      // source's thread WITHOUT rendering as a quote — unlike the bare
+      // `reply()` used for the first message which intentionally quotes.
+      //
+      // Gated on `thread_id` presence: on a non-threaded source message
+      // (P2P, non-threaded group) `reply_in_thread: true` would create a
+      // new thread — unwanted. Fall through to plain `message.create` in
+      // those cases, preserving pre-fix behavior.
+      //
+      // Also excluded: synthetic thread_ids from the cronjob dispatcher
+      // (prefix JOB_THREAD_PREFIX, see src/scheduler.ts). These values
+      // exist solely to isolate IdentitySession entries per cronjob run
+      // and do NOT correspond to a real Feishu thread. Using
+      // reply_in_thread:true against the effectiveReplyTo (which, if
+      // auto-filled or user-passed, points at a real earlier message)
+      // would incorrectly pull that message into a newly-created thread.
+      const isSyntheticThread = !!thread_id && thread_id.startsWith(JOB_THREAD_PREFIX);
+      const shouldStayInThread = !!thread_id && !isSyntheticThread && !!effectiveReplyTo;
+      async function sendFollowup(data: { content: string; msg_type: string }): Promise<any> {
+        if (shouldStayInThread) {
+          // `reply_in_thread: true` is a Feishu HTTP API field that routes the
+          // new message into the source's thread without rendering as a quote.
+          // The `@larksuiteoapi/node-sdk` type definitions currently omit it,
+          // hence the cast. Feishu docs:
+          //   https://open.feishu.cn/document/server-docs/im-v1/message/reply
+          return client.im.v1.message.reply({
+            path: { message_id: effectiveReplyTo! },
+            data: { ...data, reply_in_thread: true } as any,
+          });
+        }
+        return client.im.v1.message.create({
+          params: { receive_id_type: 'chat_id' },
+          data: { receive_id: chat_id, ...data },
+        });
+      }
+
       // Helper: record in buffer + revoke ack (shared by card & normal paths)
       function recordAndRevokeAck(replyText: string) {
         conversationBuffer?.record(chat_id, {
@@ -233,14 +272,7 @@ export function registerTools(
                 data: { content, msg_type: 'interactive' },
               });
             } else {
-              resp = await client.im.v1.message.create({
-                params: { receive_id_type: 'chat_id' },
-                data: {
-                  receive_id: chat_id,
-                  content,
-                  msg_type: 'interactive',
-                },
-              });
+              resp = await sendFollowup({ content, msg_type: 'interactive' });
             }
             const sentId = resp?.data?.message_id;
             if (sentId && botMessageTracker) botMessageTracker.add(sentId);
@@ -277,13 +309,9 @@ export function registerTools(
                 },
               });
             } else {
-              resp = await client.im.v1.message.create({
-                params: { receive_id_type: 'chat_id' },
-                data: {
-                  receive_id: chat_id,
-                  content: JSON.stringify({ text: chunks[i] }),
-                  msg_type: 'text',
-                },
+              resp = await sendFollowup({
+                content: JSON.stringify({ text: chunks[i] }),
+                msg_type: 'text',
               });
             }
             const sentId = resp?.data?.message_id;
@@ -321,14 +349,12 @@ export function registerTools(
               });
               const imageKey = (resp as any)?.data?.image_key ?? (resp as any)?.image_key;
               if (imageKey) {
-                await client.im.v1.message.create({
-                  params: { receive_id_type: 'chat_id' },
-                  data: {
-                    receive_id: chat_id,
-                    content: JSON.stringify({ image_key: imageKey }),
-                    msg_type: 'image',
-                  },
+                const sent = await sendFollowup({
+                  content: JSON.stringify({ image_key: imageKey }),
+                  msg_type: 'image',
                 });
+                const sentId = (sent as any)?.data?.message_id;
+                if (sentId && botMessageTracker) botMessageTracker.add(sentId);
               }
             } else {
               // For file uploads, use im.v1.file.create
@@ -341,17 +367,15 @@ export function registerTools(
               });
               const fileKey = (resp as any)?.data?.file_key ?? (resp as any)?.file_key;
               if (fileKey) {
-                await client.im.v1.message.create({
-                  params: { receive_id_type: 'chat_id' },
-                  data: {
-                    receive_id: chat_id,
-                    content: JSON.stringify({
-                      file_key: fileKey,
-                      file_name: path.basename(file.path),
-                    }),
-                    msg_type: 'file',
-                  },
+                const sent = await sendFollowup({
+                  content: JSON.stringify({
+                    file_key: fileKey,
+                    file_name: path.basename(file.path),
+                  }),
+                  msg_type: 'file',
                 });
+                const sentId = (sent as any)?.data?.message_id;
+                if (sentId && botMessageTracker) botMessageTracker.add(sentId);
               }
             }
           } catch (err) {


### PR DESCRIPTION
Closes #56

## Summary

In a Feishu group thread (话题), Claude's first reply lands in the thread but every follow-up message (image, long-text chunk, subsequent card) escapes to the chat's root timeline. This is because the reply handler's follow-up call sites used \`message.create(receive_id=chat_id)\`, which posts outside the thread regardless of the source message's thread context.

## Fix

New \`sendFollowup\` helper in the reply handler. When \`thread_id\` is in meta AND an effective \`reply_to\` exists AND the thread_id is not a cronjob-synthetic prefix (\`JOB_THREAD_PREFIX = "job-"\`) → route via \`message.reply(source, reply_in_thread: true)\` (posts into thread without quote-rendering). Otherwise → \`message.create\` (preserves current behavior for P2P and non-threaded group chats).

Applied to three call sites in \`src/tools.ts\`:
- Multi-chunk text path (chunks 2..N)
- Multi-card path (cards 2..N)
- Attachment upload path (images + files)

First chunk / card still quote-replies via bare \`message.reply\` — preserves the visual quote anchor and ack-reaction revocation flow.

### Ancillary behavior changes
- **Attachment message IDs now tracked in BotMessageTracker.** Pre-PR, bot-sent images/files weren't registered, so user reactions to them were silently filtered out of Claude's notifications. The refactor captures the send response and calls \`BotMessageTracker.add\` — reactions on bot images/files now surface to Claude.

### Why gate on \`thread_id\` and exclude cronjob-synthetic prefix
- Setting \`reply_in_thread: true\` on a **non-threaded** source would make Feishu **start a new thread** in the P2P DM or non-threaded group — worse UX than today.
- Cronjob dispatches inject \`thread_id="job-<id>-<ts>"\` for IdentitySession isolation — not a real Feishu thread. The carve-out prevents a cronjob reply with an attachment from pulling an unrelated earlier user message into a fabricated thread.

## Test plan
- [x] \`npm run typecheck\` passes
- [x] \`npm test\` passes (+ new reply-thread smoke: 7/7)
- [x] \`npm start -- --dry-run\` clean
- [x] 5 rounds of self-audit converged
- [ ] Field verification: in a Feishu group thread, ask bot to draw → text and image both stay in the thread
- [ ] Field verification: P2P image response — image appears as normal DM message (not suddenly threaded)
- [ ] Field verification: long-text reply in a thread — all chunks stay in the thread
- [ ] Field verification: cronjob-driven output in a group does NOT fabricate a thread around an unrelated user message

## Mock-based smoke test coverage
7 scenarios in \`scripts/reply-thread-smoke.ts\`:
1. thread + image → both via reply, image carries \`reply_in_thread=true\`
2. P2P + image → text via reply, image via create (no \`reply_in_thread\`)
3. thread + 9000-char text → multi-chunk; chunks 2..N carry the flag
4. no reply_to + thread_id → follow-up falls through to create (guard)
5. thread + file attachment → reply with flag
6. thread + multi-card (>25KB) → cards 2..N carry the flag
7. cronjob-synthetic thread_id (\`job-\` prefix) → no reply_in_thread even with real reply_to (regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)