### PR TITLE
fix: redirect Lark EventDispatcher logger to stderr (v1.0.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.4] - 2026-04-24
+
+### Fixed
+- **Plugin startup crash from EventDispatcher stdout pollution.** `src/channel.ts` wired a custom stderr logger onto `Lark.Client` and `Lark.WSClient` but missed `Lark.EventDispatcher`, which therefore used the SDK's default logger. On every startup the EventDispatcher wrote `[info]: [ 'event-dispatch is ready' ]` to stdout — which the MCP stdio transport reserves for JSON-RPC framing. The non-JSON bytes corrupted the handshake and Claude Code killed the plugin subprocess. Added the same stderr-redirecting logger to the EventDispatcher constructor.
+
+  This was not caught by `scripts/test.sh`'s existing "MCP stdout clean" assertion because dry-run exits before `channel.start()`, which is where the EventDispatcher is actually constructed.
+
+### Added
+- **Static lint: `scripts/check-sdk-loggers.ts`.** Parses `src/channel.ts` and verifies every `new Lark.<Client|EventDispatcher|WSClient>(` has a `logger:` option within its argument block (paren-balanced scope, not fixed-line window). Runs as part of `npm test` — future omissions fail CI rather than manifest as a mysterious production crash.
+
 ## [1.0.3] - 2026-04-24
 
 ### Fixed
@@ -329,6 +339,7 @@ Precondition for the privacy redesign (#35). A pluggable abstraction made every 
 - Score-based filtering (`LARK_MIN_SEARCH_SCORE`)
 - HealthCheck for memory provider connectivity
 
+[1.0.4]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.4
 [1.0.3]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.3
 [1.0.2]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.2
 [1.0.1]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/check-sdk-loggers.ts
+++ b/scripts/check-sdk-loggers.ts
@@ -1,0 +1,91 @@
+/**
+ * Static check: every `new Lark.<Client|EventDispatcher|WSClient>(` call in
+ * `src/channel.ts` must include a `logger:` option in its argument block.
+ *
+ * Why this matters: the Lark SDK's default logger uses `console.log`, which
+ * writes to stdout. The MCP server uses stdout for JSON-RPC framing, so any
+ * non-JSON-RPC bytes on stdout corrupt the protocol and Claude Code kills
+ * the plugin. Every SDK object that can log must redirect to stderr.
+ *
+ * Why static (not runtime): dry-run exits before `channel.start()`, which
+ * is where EventDispatcher and WSClient are actually constructed. So
+ * `scripts/test.sh`'s "MCP stdout clean" assertion can't catch a missing
+ * logger on those — this check closes the gap.
+ *
+ * Scope limits (by design):
+ *   - Only verifies the *presence* of `logger:` in the options block. A
+ *     literal `logger: undefined`, `logger: null`, or `logger: somevar`
+ *     (where the variable is later reassigned) all pass this check.
+ *     Human review covers the "is the value actually stderr-routing?"
+ *     question — the lint catches the far more common mistake of
+ *     omitting the option entirely.
+ *   - Only scans `src/channel.ts`. No other file in the project constructs
+ *     Lark SDK objects today; a `grep -r "new Lark\\." src/` run during
+ *     review confirms this remains true.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const src = readFileSync(join(process.cwd(), 'src/channel.ts'), 'utf-8');
+
+const ctors = ['Client', 'EventDispatcher', 'WSClient'] as const;
+const problems: string[] = [];
+let totalMatches = 0;
+
+/**
+ * Given a source position at `(`, walk forward tracking paren depth and
+ * return the substring spanning the constructor's argument list up to the
+ * matching close-paren. This scopes the `logger:` search to THIS
+ * constructor's options — not a later unrelated block.
+ */
+function extractArgBlock(source: string, openParenIdx: number): string | null {
+  let depth = 0;
+  for (let i = openParenIdx; i < source.length; i++) {
+    const c = source[i];
+    if (c === '(') depth++;
+    else if (c === ')') {
+      depth--;
+      if (depth === 0) return source.slice(openParenIdx, i + 1);
+    }
+  }
+  return null; // unbalanced
+}
+
+for (const ctor of ctors) {
+  const pattern = new RegExp(`new Lark\\.${ctor}\\(`, 'g');
+  let found: RegExpExecArray | null;
+  while ((found = pattern.exec(src)) !== null) {
+    totalMatches++;
+    const parenIdx = found.index + found[0].length - 1;
+    const block = extractArgBlock(src, parenIdx);
+    if (block === null) {
+      problems.push(
+        `src/channel.ts — new Lark.${ctor}( at char ${parenIdx} has unbalanced parens (cannot verify)`,
+      );
+      continue;
+    }
+    if (!/\blogger:/.test(block)) {
+      const lineNo = src.slice(0, found.index).split('\n').length;
+      problems.push(
+        `src/channel.ts:${lineNo} — new Lark.${ctor}( has no 'logger:' option in its argument block (would corrupt MCP stdout)`,
+      );
+    }
+  }
+}
+
+if (totalMatches === 0) {
+  // The plugin relies on channel.ts constructing at least one Lark SDK
+  // object — if none are found, either the source moved (and this check
+  // is stale) or the file really lacks them (which is a bug). Fail loudly
+  // rather than silently pass.
+  console.error('FAIL: no Lark SDK constructors found in src/channel.ts');
+  process.exit(1);
+}
+
+if (problems.length > 0) {
+  console.error('FAIL: SDK constructor(s) missing stderr logger:');
+  for (const p of problems) console.error(`  ${p}`);
+  process.exit(1);
+}
+
+console.log(`check-sdk-loggers: ${totalMatches}/${totalMatches} SDK constructors have logger`);

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,6 +20,16 @@ fi
 echo "PASS"
 
 echo ""
+echo "=== SDK constructors have stderr logger ==="
+# Dry-run cannot catch stdout pollution from SDK constructors that only run
+# inside channel.start() (e.g. EventDispatcher). Their default logger writes
+# to stdout and would corrupt MCP JSON-RPC framing. Enforce statically that
+# each `new Lark.<Client|EventDispatcher|WSClient>(` in src/channel.ts has a
+# `logger:` option within the parens of its arg block (depth-tracked scope).
+npx tsx scripts/check-sdk-loggers.ts
+echo "PASS"
+
+echo ""
 echo "=== Card builder unit checks ==="
 npx tsx scripts/card-smoke.ts
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -18,6 +18,28 @@ function debugLog(msg: string) {
 }
 
 /**
+ * Build a Lark SDK logger that routes every level to stderr. The SDK's default
+ * logger writes to stdout via `console.log`, which would corrupt MCP JSON-RPC
+ * framing on the stdio transport. Every `new Lark.<Client|EventDispatcher|WSClient>(...)`
+ * MUST be constructed with this logger — enforced statically by
+ * `scripts/check-sdk-loggers.ts`.
+ *
+ * Levels implemented: info / warn / error / debug / trace — the canonical
+ * Lark SDK set. If a future SDK version introduces a new level (e.g.
+ * verbose, fatal), this factory will need to be extended; otherwise the
+ * SDK would throw a TypeError on the missing method.
+ */
+function makeSdkLogger(prefix: string) {
+  return {
+    info: (...args: any[]) => console.error(`[${prefix}]`, ...args),
+    warn: (...args: any[]) => console.error(`[${prefix}][warn]`, ...args),
+    error: (...args: any[]) => console.error(`[${prefix}][error]`, ...args),
+    debug: (...args: any[]) => console.error(`[${prefix}][debug]`, ...args),
+    trace: (...args: any[]) => console.error(`[${prefix}][trace]`, ...args),
+  };
+}
+
+/**
  * Whitelist check with OR semantics:
  * - Neither list configured → allow all
  * - Only user list → gate on user only
@@ -159,20 +181,12 @@ export class LarkChannel {
   private latestMessageTracker = new LatestMessageTracker();
 
   constructor() {
-    // Custom logger to redirect all SDK output to stderr (stdout is reserved for MCP JSON-RPC)
-    const sdkLogger = {
-      info: (...args: any[]) => console.error('[lark-sdk]', ...args),
-      warn: (...args: any[]) => console.error('[lark-sdk][warn]', ...args),
-      error: (...args: any[]) => console.error('[lark-sdk][error]', ...args),
-      debug: (...args: any[]) => console.error('[lark-sdk][debug]', ...args),
-      trace: (...args: any[]) => console.error('[lark-sdk][trace]', ...args),
-    };
     this.client = new Lark.Client({
       appId: appConfig.appId,
       appSecret: appConfig.appSecret,
       appType: Lark.AppType.SelfBuild,
       domain: Lark.Domain.Feishu,
-      logger: sdkLogger,
+      logger: makeSdkLogger('lark-sdk'),
     });
   }
 
@@ -227,7 +241,13 @@ export class LarkChannel {
     await this.fetchBotOpenId();
 
     debugLog('[channel] Registering event dispatcher...');
-    const eventDispatcher = new Lark.EventDispatcher({}).register({
+    // EventDispatcher's default logger writes to stdout, which would corrupt
+    // MCP JSON-RPC framing the moment it logs "event-dispatch is ready".
+    // Redirect to stderr like Client and WSClient.
+    const eventDispatcher = new Lark.EventDispatcher({
+      loggerLevel: Lark.LoggerLevel.info,
+      logger: makeSdkLogger('lark-events'),
+    }).register({
       'im.message.receive_v1': async (data: any) => {
         debugLog(`[channel] Event received: im.message.receive_v1`);
         try {
@@ -251,13 +271,7 @@ export class LarkChannel {
       appId: appConfig.appId,
       appSecret: appConfig.appSecret,
       loggerLevel: Lark.LoggerLevel.info,
-      logger: {
-        info: (...args: any[]) => console.error('[lark-ws]', ...args),
-        warn: (...args: any[]) => console.error('[lark-ws][warn]', ...args),
-        error: (...args: any[]) => console.error('[lark-ws][error]', ...args),
-        debug: (...args: any[]) => console.error('[lark-ws][debug]', ...args),
-        trace: (...args: any[]) => console.error('[lark-ws][trace]', ...args),
-      },
+      logger: makeSdkLogger('lark-ws'),
     });
 
     this.wsClient.start({ eventDispatcher });

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.3' },
+    { name: 'claude-lark-plugin', version: '1.0.4' },
     {
       capabilities: {
         logging: {},


### PR DESCRIPTION
Closes #58

## Critical startup bug

The plugin didn't actually start cleanly in production. \`Lark.EventDispatcher\` was constructed without a logger, so it used the SDK's stdout-bound default. The \`[info]: [ 'event-dispatch is ready' ]\` line corrupted MCP JSON-RPC framing and Claude Code killed the subprocess.

\`Lark.Client\` and \`Lark.WSClient\` had stderr loggers since forever — \`Lark.EventDispatcher\` was simply missed.

## Why tests didn't catch it
\`scripts/test.sh\`'s "MCP stdout clean" assertion runs on \`npm start -- --dry-run\`, which exits before \`channel.start()\`. EventDispatcher is constructed inside \`start()\`, so dry-run never exercises the code path that emits the problematic log.

## Fix
1. Pass the stderr-redirecting logger to \`new Lark.EventDispatcher({...})\` — mirrors the pattern already used for Client and WSClient.
2. Add \`scripts/check-sdk-loggers.ts\` — a static lint. Parses \`src/channel.ts\` and verifies every \`new Lark.<Client|EventDispatcher|WSClient>(\` has a \`logger:\` option in its argument block. Paren-depth tracking correctly scopes to each constructor's options (not a line window that could accidentally see a later unrelated block). Runs as part of \`npm test\`.

Verified the lint catches regression: temporarily removing the logger from any of the three constructors makes the check fail with a precise file:line pointer.

## Test plan
- [x] \`npm run typecheck\` passes
- [x] \`npm test\` passes (including new \`check-sdk-loggers.ts\`, 3/3 constructors have logger)
- [x] Lint fails loudly when any constructor's logger is removed
- [ ] Field verification: plugin boots through MCP handshake without getting killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)