### PR TITLE
fix: download_attachment handles all SDK shapes + preserves filename extension (v1.0.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": {
     "name": "IS908"
   },

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ docs/
 .DS_Store
 *.js.map
 *.tsbuildinfo
+
+# Local Claude Code state — not part of the plugin source
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.5] - 2026-05-12
+
+### Fixed
+- **`download_attachment` silently failed for PDF / file / audio / video** (#60). The tool's response-handling code only knew how to write a `Buffer` (or a Readable stream on newer Node). The Lark SDK returns binary resources wrapped as `{ writeFile(path): Promise<void> }` — passing that object to `fs.writeFile` either threw (caught by the outer try/catch, surfaced as the generic `"Failed to download attachment"`) or wrote `[object Object]` to disk. Images worked only because `channel.downloadImage` had separately implemented the three-shape dispatch.
+
+  Centralised the dispatch in a new `src/sdk-resource.ts` module with `writeSdkResource(data, filePath)` — handles `Buffer`, `{ writeFile }`, and `Readable` streams uniformly, and throws a descriptive error (with a shape descriptor) when the SDK returns something unexpected. Both `channel.downloadImage` and `tools.download_attachment` now route through this helper.
+
+- **Saved attachments now keep their original extension.** `download_attachment` previously saved every file as the opaque `file_key` (`file_v3_xxx`, no extension). Claude `Read` infers MIME from extension, so PDFs and text files weren't being parsed correctly even when the SDK bug above didn't bite. The tool now accepts an optional `file_name` parameter (the inbound notification's `meta.attachment_name`, e.g. `report.pdf`); saved file becomes `<file_key>-<sanitized_name>`. File names are sanitised (path-basename + non-`\w.-` replacement) to block traversal attempts.
+
+- **`download_attachment` error messages now include diagnostic context** — SDK error code + message, file_key, and routed resource type. Previous behavior collapsed all failures to the generic string `"Failed to download attachment"`, leaving Claude no signal to retry or escalate.
+
+### Added
+- `src/sdk-resource.ts` — shared module exporting `writeSdkResource(data, filePath)` and `describeSdkResource(data)` (the latter is used inside error messages so future SDK shape mismatches surface a clear "object{whatever}" descriptor).
+- `scripts/download-attachment-smoke.ts` — 15 mock-based assertions covering all three SDK response shapes, `img_*` vs `file_*` routing, file_name extension preservation, path-traversal sanitisation, SDK error diagnostic propagation, unknown-shape behaviour, and direct unit tests for the `capSanitizedFilename` helper (long stem, long extension, CJK chars stripped, leading-dot files, traversal). Wired into `npm test`.
+
 ## [1.0.4] - 2026-04-24
 
 ### Fixed
@@ -339,6 +354,7 @@ Precondition for the privacy redesign (#35). A pluggable abstraction made every 
 - Score-based filtering (`LARK_MIN_SEARCH_SCORE`)
 - HealthCheck for memory provider connectivity
 
+[1.0.5]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.5
 [1.0.4]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.4
 [1.0.3]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.3
 [1.0.2]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/download-attachment-smoke.ts
+++ b/scripts/download-attachment-smoke.ts
@@ -1,0 +1,325 @@
+/**
+ * download_attachment + writeSdkResource smoke test.
+ *
+ * Verifies:
+ *  - All three Lark SDK response shapes (Buffer / object.writeFile / Readable)
+ *    are correctly written to disk by `writeSdkResource`.
+ *  - The `download_attachment` tool routes resourceType by file_key prefix
+ *    (img_* -> image, else -> file).
+ *  - Saved filename preserves the original extension when `file_name` is
+ *    provided (regression guard for the PDF-Claude-Read bug).
+ *  - Error path returns a diagnostic message (not the old generic
+ *    "Failed to download attachment").
+ *  - Unknown SDK shape throws with a descriptive error (helps future
+ *    SDK-upgrade triage).
+ */
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { Readable } from 'node:stream';
+import { writeSdkResource, describeSdkResource } from '../src/sdk-resource.js';
+import { capSanitizedFilename } from '../src/tools.js';
+import { registerTools } from '../src/tools.js';
+import type { MemoryStore } from '../src/memory/file.js';
+import { IdentitySession } from '../src/identity-session.js';
+import type { LarkChannel } from '../src/channel.js';
+
+function fail(msg: string): never {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+let passed = 0;
+
+const tmpInbox = mkdtempSync(path.join(tmpdir(), 'download-attach-inbox-'));
+process.env.LARK_INBOX_DIR = tmpInbox;
+
+// 1. writeSdkResource: shape 1 (Buffer)
+{
+  const filePath = path.join(tmpInbox, 'shape1.bin');
+  await writeSdkResource(Buffer.from('buffer-content'), filePath);
+  const written = readFileSync(filePath, 'utf-8');
+  if (written !== 'buffer-content') fail(`1: buffer write mismatch: ${written}`);
+  passed++;
+}
+
+// 2. writeSdkResource: shape 2 (object with .writeFile method)
+{
+  const filePath = path.join(tmpInbox, 'shape2.bin');
+  const mockSdkResp = {
+    async writeFile(p: string): Promise<void> {
+      const fsp = await import('node:fs/promises');
+      await fsp.writeFile(p, 'sdk-writeFile-content');
+    },
+  };
+  await writeSdkResource(mockSdkResp, filePath);
+  const written = readFileSync(filePath, 'utf-8');
+  if (written !== 'sdk-writeFile-content') fail(`2: sdk writeFile mismatch: ${written}`);
+  passed++;
+}
+
+// 3. writeSdkResource: shape 3 (Readable stream)
+{
+  const filePath = path.join(tmpInbox, 'shape3.bin');
+  const stream = Readable.from([Buffer.from('chunk1-'), Buffer.from('chunk2')]);
+  await writeSdkResource(stream, filePath);
+  const written = readFileSync(filePath, 'utf-8');
+  if (written !== 'chunk1-chunk2') fail(`3: stream write mismatch: ${written}`);
+  passed++;
+}
+
+// 4. writeSdkResource: unknown shape throws descriptively
+{
+  try {
+    await writeSdkResource({ randomKey: 'no writeFile, no pipe' }, path.join(tmpInbox, 'nope.bin'));
+    fail('4: should have thrown on unknown shape');
+  } catch (err: any) {
+    if (!/unrecognised SDK response shape/.test(err.message)) {
+      fail(`4: error message lacks diagnostic: ${err.message}`);
+    }
+    if (!/object\{randomKey\}/.test(err.message)) {
+      fail(`4: error message lacks shape descriptor: ${err.message}`);
+    }
+  }
+  passed++;
+}
+
+// 5. writeSdkResource: null/undefined throws cleanly
+{
+  try {
+    await writeSdkResource(null, path.join(tmpInbox, 'null.bin'));
+    fail('5a: should have thrown on null');
+  } catch (err: any) {
+    if (!/null/.test(err.message)) fail(`5a: bad null error: ${err.message}`);
+  }
+  try {
+    await writeSdkResource(undefined, path.join(tmpInbox, 'undef.bin'));
+    fail('5b: should have thrown on undefined');
+  } catch (err: any) {
+    if (!/undefined/.test(err.message)) fail(`5b: bad undefined error: ${err.message}`);
+  }
+  passed++;
+}
+
+// 6. describeSdkResource: produces useful labels
+{
+  if (describeSdkResource(Buffer.from('x')) !== 'Buffer') fail('6: Buffer label');
+  if (describeSdkResource({ writeFile: () => {} }) !== 'object{writeFile()}') fail('6: writeFile label');
+  if (describeSdkResource(Readable.from([])) !== 'ReadableStream') fail('6: stream label');
+  if (describeSdkResource(null) !== 'null') fail('6: null label');
+  passed++;
+}
+
+const apiCalls: { method: string; args: any }[] = [];
+
+function mockClient(respFor: (fileKey: string, type: string) => unknown) {
+  return {
+    im: {
+      v1: {
+        message: { create: async () => ({}), reply: async () => ({}) },
+        messageReaction: { create: async () => {}, delete: async () => {} },
+        image: { create: async () => ({}), get: async () => Buffer.from('') },
+        file: { create: async () => ({}) },
+        messageResource: {
+          get: async (args: any) => {
+            apiCalls.push({ method: 'messageResource.get', args });
+            return respFor(args?.path?.file_key, args?.params?.type);
+          },
+        },
+      },
+    },
+  };
+}
+
+const noopMemory = {
+  healthCheck: async () => true,
+  getProfile: async () => null,
+  saveProfile: async () => {},
+  searchEpisodes: async () => [],
+  saveEpisode: async () => {},
+  listEpisodes: async () => [],
+  deleteEpisodes: async () => {},
+  searchSkills: async () => [],
+  saveSkill: async () => {},
+} as unknown as MemoryStore;
+
+const fakeChannel = { isPrivateChat: () => true } as unknown as LarkChannel;
+const handlers = new Map<string, (args: any) => Promise<any>>();
+const fakeServer = {
+  registerTool(name: string, _config: any, handler: any) {
+    handlers.set(name, handler);
+  },
+};
+
+function setup(respFor: (fileKey: string, type: string) => unknown) {
+  apiCalls.length = 0;
+  const client = mockClient(respFor);
+  const identitySession = new IdentitySession(() => null);
+  identitySession.setCaller('chat_001', undefined, 'ou_caller');
+  registerTools(
+    fakeServer as any,
+    client as any,
+    noopMemory,
+    identitySession,
+    fakeChannel,
+    { record() {}, flush: async () => {}, startAutoFlush: () => {}, stopAutoFlush: () => {} } as any,
+    new Map<string, string>(),
+    { ids: new Set(), add() {}, has: () => false } as any,
+    undefined,
+  );
+  const dl = handlers.get('download_attachment');
+  if (!dl) fail('download_attachment handler not registered');
+  return dl;
+}
+
+// 7. img_* file_key routes to type='image'
+{
+  const dl = setup(() => Buffer.from('img-bytes'));
+  const r = await dl({ message_id: 'om_x', file_key: 'img_abc' });
+  if (apiCalls[0]?.args?.params?.type !== 'image') {
+    fail(`7: expected type=image for img_* key, got ${apiCalls[0]?.args?.params?.type}`);
+  }
+  if (!/Downloaded to /.test(r.content[0].text)) fail(`7: success text wrong: ${r.content[0].text}`);
+  passed++;
+}
+
+// 8. file_v3_* file_key routes to type='file'
+{
+  const dl = setup(() => Buffer.from('pdf-bytes'));
+  await dl({ message_id: 'om_x', file_key: 'file_v3_xyz' });
+  if (apiCalls[0]?.args?.params?.type !== 'file') {
+    fail(`8: expected type=file for non-img key, got ${apiCalls[0]?.args?.params?.type}`);
+  }
+  passed++;
+}
+
+// 9. file_name preserves extension in saved path
+{
+  const dl = setup(() => Buffer.from('pdf-bytes'));
+  const r = await dl({
+    message_id: 'om_x',
+    file_key: 'file_v3_xyz',
+    file_name: 'report.pdf',
+  });
+  const txt = r.content[0].text as string;
+  if (!txt.endsWith('file_v3_xyz-report.pdf')) {
+    fail(`9: expected save path to end with file_v3_xyz-report.pdf, got: ${txt}`);
+  }
+  passed++;
+}
+
+// 10. file_name sanitization (path traversal / bad chars)
+{
+  const dl = setup(() => Buffer.from('x'));
+  const r = await dl({
+    message_id: 'om_x',
+    file_key: 'file_v3_xyz',
+    file_name: '../../../etc/passwd',
+  });
+  const txt = r.content[0].text as string;
+  if (/\.\.\//.test(txt) || /\/etc\//.test(txt)) {
+    fail(`10: path traversal not sanitized: ${txt}`);
+  }
+  if (!/passwd/.test(txt)) fail(`10: legitimate filename component lost: ${txt}`);
+  passed++;
+}
+
+// 11. Shape 2 (writeFile method) end-to-end through the tool
+{
+  const dl = setup(() => ({
+    async writeFile(p: string): Promise<void> {
+      const fsp = await import('node:fs/promises');
+      await fsp.writeFile(p, 'shape-2-end-to-end');
+    },
+  }));
+  const r = await dl({ message_id: 'om_x', file_key: 'file_v3_pdf', file_name: 'doc.pdf' });
+  const txt = r.content[0].text as string;
+  const match = /Downloaded to (.+)/.exec(txt);
+  if (!match) fail(`11: success text malformed: ${txt}`);
+  const saved = readFileSync(match![1], 'utf-8');
+  if (saved !== 'shape-2-end-to-end') fail(`11: file content wrong: ${saved}`);
+  passed++;
+}
+
+// 12. SDK API error -> diagnostic, not generic "Failed"
+{
+  const dl = setup(() => {
+    const err: any = new Error('boom');
+    err.response = { data: { code: 99991668, msg: 'invalid file_key' } };
+    throw err;
+  });
+  const r = await dl({ message_id: 'om_x', file_key: 'file_v3_bad' });
+  if (!r.isError) fail('12: should set isError');
+  const txt = r.content[0].text as string;
+  if (!/99991668/.test(txt)) fail(`12: error code missing: ${txt}`);
+  if (!/invalid file_key/.test(txt)) fail(`12: error msg missing: ${txt}`);
+  if (!/file_v3_bad/.test(txt)) fail(`12: file_key context missing: ${txt}`);
+  passed++;
+}
+
+// 13. Unknown SDK shape -> tool returns diagnostic isError
+{
+  const dl = setup(() => ({ unknownShape: true }));
+  const r = await dl({ message_id: 'om_x', file_key: 'file_v3_xyz' });
+  if (!r.isError) fail('13: should set isError for unknown shape');
+  const txt = r.content[0].text as string;
+  if (!/unrecognised SDK response shape/.test(txt)) {
+    fail(`13: diagnostic text missing: ${txt}`);
+  }
+  passed++;
+}
+
+// 10b. file_name length cap preserves extension (NAME_MAX defense)
+{
+  const dl = setup(() => Buffer.from('x'));
+  // 400-char filename; cap should kick in but .pdf must survive
+  const longName = 'a'.repeat(400) + '.pdf';
+  const r = await dl({
+    message_id: 'om_x',
+    file_key: 'file_v3_xyz',
+    file_name: longName,
+  });
+  const txt = r.content[0].text as string;
+  const match = /Downloaded to (.+)/.exec(txt);
+  if (!match) fail(`10b: tool did not succeed: ${txt}`);
+  const baseName = path.basename(match![1]);
+  const sanitizedPortion = baseName.slice(baseName.indexOf('-') + 1);
+  if (sanitizedPortion.length > 200) {
+    fail(`10b: sanitized portion not capped: ${sanitizedPortion.length} chars`);
+  }
+  if (!sanitizedPortion.endsWith('.pdf')) {
+    fail(`10b: extension lost during cap: ${sanitizedPortion}`);
+  }
+  passed++;
+}
+
+// 10c. capSanitizedFilename helper — direct unit tests
+{
+  // Short names pass through (sanitized)
+  if (capSanitizedFilename('report.pdf', 200) !== 'report.pdf') fail('10c.1');
+  // Long stem, extension preserved
+  const r2 = capSanitizedFilename('a'.repeat(300) + '.pdf', 200);
+  if (!r2.endsWith('.pdf')) fail(`10c.2: ext lost: ${r2}`);
+  if (r2.length > 200) fail(`10c.2: not capped: ${r2.length}`);
+  // No extension
+  const r3 = capSanitizedFilename('x'.repeat(300), 200);
+  if (r3.length !== 200) fail(`10c.3: no-ext cap: ${r3.length}`);
+  // Pathological long extension — capped at half maxLen so stem keeps space
+  const r4 = capSanitizedFilename('stem.' + 'e'.repeat(300), 200);
+  if (r4.length > 200) fail(`10c.4: long-ext not capped: ${r4.length}`);
+  if (!r4.startsWith('stem')) fail(`10c.4: stem lost: ${r4}`);
+  // Leading-dot file (e.g. ".env") — no extension to preserve
+  if (capSanitizedFilename('.env', 200) !== '.env') fail('10c.5');
+  // CJK chars stripped (sanitization preserved)
+  if (capSanitizedFilename('报告.pdf', 200) !== '__.pdf') fail('10c.6');
+  // path traversal stripped
+  const r7 = capSanitizedFilename('../../etc/passwd', 200);
+  if (r7.includes('/') || r7.includes('..')) fail(`10c.7: traversal: ${r7}`);
+  passed++;
+}
+
+rmSync(tmpInbox, { recursive: true, force: true });
+delete process.env.LARK_INBOX_DIR;
+
+console.log(`download-attachment smoke: ${passed}/15 PASS`);
+

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -66,4 +66,8 @@ echo "=== Reply thread-routing unit checks ==="
 npx tsx scripts/reply-thread-smoke.ts
 
 echo ""
+echo "=== Download attachment unit checks ==="
+npx tsx scripts/download-attachment-smoke.ts
+
+echo ""
 echo "All tests passed."

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -9,6 +9,7 @@ import type { MemoryStore } from './memory/file.js';
 import type { ConversationBuffer } from './memory/buffer.js';
 import type { IdentitySession } from './identity-session.js';
 import { TERMINAL_CHAT_ID } from './identity-session.js';
+import { writeSdkResource } from './sdk-resource.js';
 
 const DEBUG_LOG = path.join(os.homedir(), '.claude', 'channels', 'lark', 'debug.log');
 function debugLog(msg: string) {
@@ -586,33 +587,16 @@ export class LarkChannel {
         path: { message_id: messageId, file_key: imageKey },
         params: { type: 'image' },
       } as any);
-      if (resp) {
-        const filename = `${Date.now()}-${imageKey}.png`;
-        const filePath = path.join(appConfig.inboxDir, filename);
-        // The SDK returns a readable stream or buffer
-        const data = resp as any;
-        if (Buffer.isBuffer(data)) {
-          writeFileSync(filePath, data);
-        } else if (data?.writeFile) {
-          await data.writeFile(filePath);
-        } else if (typeof data?.pipe === 'function') {
-          // Readable stream — collect into buffer
-          const chunks: Buffer[] = [];
-          for await (const chunk of data) {
-            chunks.push(Buffer.from(chunk));
-          }
-          writeFileSync(filePath, Buffer.concat(chunks));
-        } else {
-          debugLog(`[channel] Unexpected image response type for ${imageKey}`);
-          return undefined;
-        }
-        debugLog(`[channel] Downloaded image ${imageKey} → ${filePath}`);
-        return filePath;
-      }
+      if (!resp) return undefined;
+      const filename = `${Date.now()}-${imageKey}.png`;
+      const filePath = path.join(appConfig.inboxDir, filename);
+      await writeSdkResource(resp, filePath);
+      debugLog(`[channel] Downloaded image ${imageKey} → ${filePath}`);
+      return filePath;
     } catch (err) {
       debugLog(`[channel] Failed to download image ${imageKey}: ${err}`);
+      return undefined;
     }
-    return undefined;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.4' },
+    { name: 'claude-lark-plugin', version: '1.0.5' },
     {
       capabilities: {
         logging: {},

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -92,7 +92,7 @@ Return ONLY the JSON object, no prose or code fences. Then call save_memory(type
 export const mcpServerInstructions: string = [
   'Users see Feishu, not this transcript. Interact via reply / edit_message / react.',
   'Each reply targets exactly one <channel> notification: pass its message_id as reply_to and its thread_id (if present) as thread_id. Do not cross fields between different notifications.',
-  'Meta image_path → Read that file. Meta attachment_file_id → call download_attachment(message_id, file_key) then Read the returned path.',
+  'Meta image_path → Read that file. Meta attachment_file_id → call download_attachment(message_id, file_key, file_name=meta.attachment_name) then Read the returned path. Always pass file_name so the saved file keeps its extension (.pdf, .txt, etc.) — Read infers MIME from the extension.',
   'CronJob notifications carry source=\'cronjob\'. Dispatch to a subagent so the main thread stays responsive to Feishu messages.',
   'Sensitive tools (save_memory, what_do_you_know, forget_memory, create_job, list_jobs, update_job, delete_job) authorize the caller server-side from chat_id + thread_id. Always pass BOTH verbatim from the current notification\'s metadata — never substitute sentinels like "__terminal__" for a real chat_id.',
 ].join('\n');

--- a/src/sdk-resource.ts
+++ b/src/sdk-resource.ts
@@ -1,0 +1,86 @@
+/**
+ * Helpers for writing Lark SDK binary-resource responses to disk.
+ *
+ * The `client.im.v1.messageResource.get` API can return one of three response
+ * shapes depending on the resource type and SDK version:
+ *
+ *  1. `Buffer` — raw bytes (rare)
+ *  2. Object with `.writeFile(path)` method — Lark SDK's typical convenience
+ *     wrapper for binary resources (this is what file/PDF responses look like
+ *     in @larksuiteoapi/node-sdk ≥1.60)
+ *  3. Readable stream — exposes `.pipe()`, iterable via `for await`
+ *
+ * Node's `fs.writeFile` only handles shape 1 natively (and streams in newer
+ * Node), so callers must inspect and dispatch. This module centralises the
+ * dispatch so we don't drift between `channel.downloadImage` and
+ * `tools.download_attachment` (a real v1.0.5 bug — see #60).
+ */
+import fsp from 'node:fs/promises';
+
+export type SdkResource =
+  | Buffer
+  | { writeFile: (path: string) => Promise<void> | void }
+  | NodeJS.ReadableStream
+  | unknown;
+
+/**
+ * Diagnostic shape descriptor — surfaced in error messages so callers can
+ * tell *why* the write failed (helpful when an SDK upgrade introduces a new
+ * shape we don't recognise).
+ */
+export function describeSdkResource(data: unknown): string {
+  if (data === null || data === undefined) return String(data);
+  if (Buffer.isBuffer(data)) return 'Buffer';
+  if (typeof data === 'object' && data !== null) {
+    const d = data as any;
+    if (typeof d.writeFile === 'function') return 'object{writeFile()}';
+    if (typeof d.pipe === 'function') return 'ReadableStream';
+    const keys = Object.keys(d).slice(0, 5).join(',');
+    return `object{${keys}}`;
+  }
+  return typeof data;
+}
+
+/**
+ * Write a Lark SDK binary-resource response to `filePath`. Handles the three
+ * known response shapes. Throws on unrecognised shape with a descriptor of
+ * what was actually received — much more useful than a silent
+ * `[object Object]` written to disk.
+ */
+export async function writeSdkResource(data: unknown, filePath: string): Promise<void> {
+  if (data === null || data === undefined) {
+    throw new Error('writeSdkResource: data is null/undefined');
+  }
+
+  if (Buffer.isBuffer(data)) {
+    await fsp.writeFile(filePath, data);
+    return;
+  }
+
+  const d = data as any;
+
+  if (typeof d.writeFile === 'function') {
+    await d.writeFile(filePath);
+    return;
+  }
+
+  if (typeof d.pipe === 'function' || typeof d[Symbol.asyncIterator] === 'function') {
+    // Collect the full payload in memory before writing — the Lark SDK's
+    // resource streams are small (≤ chat-message attachment size), and
+    // buffering keeps the API symmetric with the Buffer branch (both use
+    // async fsp.writeFile). If streaming-to-disk becomes a concern later,
+    // swap to fsp.writeFile(filePath, stream) — supported in Node ≥18.
+    const chunks: Buffer[] = [];
+    for await (const chunk of d as AsyncIterable<unknown>) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as any));
+    }
+    await fsp.writeFile(filePath, Buffer.concat(chunks));
+    return;
+  }
+
+  throw new Error(
+    `writeSdkResource: unrecognised SDK response shape (${describeSdkResource(data)}) — ` +
+      'the Lark SDK returned a value not matching Buffer / .writeFile() / Readable. ' +
+      'Likely an SDK upgrade introduced a new shape; extend writeSdkResource.',
+  );
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -11,6 +11,35 @@ import type { IdentitySession } from './identity-session.js';
 import { audit } from './audit-log.js';
 import { buildCards, shouldUseCard } from './feishu-card.js';
 import { JOB_THREAD_PREFIX } from './scheduler.js';
+import { writeSdkResource } from './sdk-resource.js';
+
+/**
+ * Sanitize and length-cap a Feishu attachment filename for safe local
+ * storage. Path-basename strips any directory prefix, regex replaces
+ * non-`\w.-` chars (including spaces, CJK, special punctuation) with
+ * underscore, then the stem is capped at `maxLen - extLength` so the
+ * extension always survives. Returns the sanitized + capped string.
+ *
+ * Exported for unit testing.
+ */
+export function capSanitizedFilename(raw: string, maxLen: number): string {
+  const sanitized = path.basename(raw).replace(/[^\w.\-]/g, '_');
+  if (sanitized.length <= maxLen) return sanitized;
+  // Find the last `.` separating stem from extension. If no dot or it's
+  // the leading char, treat the whole thing as a stem (no extension to
+  // preserve) and just truncate.
+  const dotIdx = sanitized.lastIndexOf('.');
+  if (dotIdx <= 0 || dotIdx === sanitized.length - 1) {
+    return sanitized.slice(0, maxLen);
+  }
+  const ext = sanitized.slice(dotIdx); // includes leading dot
+  // Cap extension itself to half of maxLen — pathological long extensions
+  // shouldn't crowd out the stem entirely.
+  const safeExt = ext.length > maxLen / 2 ? ext.slice(0, Math.floor(maxLen / 2)) : ext;
+  const stem = sanitized.slice(0, dotIdx);
+  const stemCap = maxLen - safeExt.length;
+  return stem.slice(0, stemCap) + safeExt;
+}
 import {
   sanitizeJobId,
   expandSchedule,
@@ -460,38 +489,90 @@ export function registerTools(
   server.registerTool(
     'download_attachment',
     {
-      description: 'Download an attachment (image, file, audio, video) from a message to local inbox.',
+      description:
+        'Download an attachment (image, file, audio, video) from a message to local inbox. Pass file_name from the inbound notification\'s meta.attachment_name so the saved file keeps its original extension — Claude Read needs the extension to infer MIME type for PDF/text.',
       inputSchema: z.object({
         message_id: z.string().describe('The message ID containing the attachment'),
         file_key: z.string().describe('The file key of the attachment'),
+        file_name: z
+          .string()
+          .optional()
+          .describe(
+            'Original filename from meta.attachment_name (e.g. "report.pdf"). When provided, the extension is preserved in the saved path so Claude Read can infer MIME. Falls back to file_key alone if omitted.',
+          ),
       }),
     },
-    async ({ message_id, file_key }) => {
+    async ({ message_id, file_key, file_name }) => {
       const inboxDir = appConfig.inboxDir;
       await fs.mkdir(inboxDir, { recursive: true });
+
+      // Route type by key prefix: img_* → image, otherwise → file.
+      // (Feishu's messageResource.get only accepts 'image' | 'file'; audio
+      //  and video are routed via 'file'.)
+      const resourceType = file_key.startsWith('img_') ? 'image' : 'file';
+
+      // Saved filename: prefer <file_key>-<original_name> when caller
+      // provides file_name — preserves the extension while keeping the
+      // file_key visible for traceability. Sanitize original name to
+      // avoid path traversal / unexpected separators, and cap length
+      // to leave room for the file_key prefix within NAME_MAX (255B on
+      // macOS/ext4). 200 bytes leaves slack for any future file_key
+      // format change without revisiting this cap.
+      //
+      // Extension preservation: cap the STEM, then reattach the ext.
+      // Required because the whole point of accepting file_name is to
+      // keep the extension so Claude `Read` can infer MIME — a naive
+      // slice(0, 200) would chop the ext off pathological-length names.
+      const sanitizedName = file_name ? capSanitizedFilename(file_name, 200) : '';
+      const savedName = sanitizedName ? `${file_key}-${sanitizedName}` : file_key;
+      const filePath = path.join(inboxDir, savedName);
+
       try {
         // Always use messageResource.get for user-uploaded resources.
         // image.get only works for images the bot itself uploaded.
-        // Route type by key prefix: img_* → image, otherwise → file.
-        const resourceType = file_key.startsWith('img_') ? 'image' : 'file';
-        const data: any = await client.im.v1.messageResource.get({
+        const data: unknown = await client.im.v1.messageResource.get({
           path: { message_id, file_key },
           params: { type: resourceType },
         });
-        if (data) {
-          const filePath = path.join(inboxDir, file_key);
-          await fs.writeFile(filePath, data as any);
-          return { content: [{ type: 'text' as const, text: `Downloaded to ${filePath}` }] };
+        if (!data) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Feishu returned empty response for file_key=${file_key} (type=${resourceType})`,
+              },
+            ],
+            isError: true,
+          };
         }
+        await writeSdkResource(data, filePath);
+        return { content: [{ type: 'text' as const, text: `Downloaded to ${filePath}` }] };
       } catch (err: any) {
         const apiError = err?.response?.data ?? err?.data;
         if (apiError?.code && apiError?.msg) {
           console.error(`[tools] download failed [${apiError.code}]: ${apiError.msg}`);
-          return { content: [{ type: 'text' as const, text: `Feishu API [${apiError.code}]: ${apiError.msg}` }], isError: true };
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Feishu API [${apiError.code}]: ${apiError.msg} (file_key=${file_key}, type=${resourceType})`,
+              },
+            ],
+            isError: true,
+          };
         }
-        console.error(`[tools] download failed:`, err?.message ?? String(err));
+        const msg = err?.message ?? String(err);
+        console.error(`[tools] download failed:`, msg);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Download failed for file_key=${file_key} (type=${resourceType}): ${msg}`,
+            },
+          ],
+          isError: true,
+        };
       }
-      return { content: [{ type: 'text' as const, text: 'Failed to download attachment' }], isError: true };
     }
   );
 


### PR DESCRIPTION
Closes #60

## Bug
\`download_attachment\` silently failed for PDF / file / audio / video. Images worked, masking the bug.

## Root cause
The tool only handled one Lark SDK response shape. The SDK returns binary resources as \`{ writeFile(path): Promise<void> }\` — \`fs.writeFile(filePath, sdkObject)\` either threw (caught silently, surfaced as the generic \`"Failed to download attachment"\`) or wrote \`[object Object]\` to disk. \`channel.downloadImage\` had its own three-shape dispatch implemented separately, which is why images worked.

## Fix — 5 components (one PR)

**A. New \`src/sdk-resource.ts\`** — \`writeSdkResource(data, filePath)\` centralises Buffer / \`{writeFile()}\` / Readable dispatch. Throws with a shape descriptor on unknown shapes so future SDK upgrades fail loudly rather than corrupt files.

**B. Both call sites** (\`channel.downloadImage\` + \`tools.download_attachment\`) route through the shared helper. Drift impossible.

**C. \`file_name\` param** preserves the original extension. Saved file is \`<file_key>-<sanitized_name>\` instead of bare opaque \`file_v3_xxx\`. Without an extension, Claude \`Read\` can't infer MIME — this was a second silent failure layered on top of the SDK bug. Sanitisation: path-basename + non-\`\\w.-\` replacement + extension-preserving 200-byte cap (the stem is truncated; the extension always survives so \`Read\` keeps working even on pathological long filenames).

**D. \`scripts/download-attachment-smoke.ts\`** — 15 mock-based assertions covering all three SDK shapes, img_*/file_* routing, extension preservation, path-traversal sanitisation, SDK error diagnostic propagation, unknown-shape behaviour, and the \`capSanitizedFilename\` helper edge cases (long stem, long extension, CJK stripping, leading-dot files, traversal). Wired into \`npm test\`.

**E. Better error messages** — SDK error code + message + file_key + routed type, instead of the old generic \`"Failed to download attachment"\`.

Also: mcpServerInstructions now reminds Claude to pass \`file_name=meta.attachment_name\` so the extension survives end-to-end.

## Housekeeping
- Added \`.claude/\` to .gitignore (local Claude Code state, not plugin source)
- Bumped version to 1.0.5

## Test plan
- [x] \`npm run typecheck\` passes
- [x] \`npm test\` — 15/15 new + all prior smoke suites green
- [x] \`npm start -- --dry-run\` clean
- [ ] Field verification: send a PDF in a Feishu DM, ask Claude to read it → Claude downloads with .pdf extension, \`Read\` returns content
- [ ] Field verification: image downloads still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)