### PR TITLE
fix: cronjob duplicate execution from filename/meta.id mismatch (v1.0.6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": {
     "name": "IS908"
   },

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ docs/
 
 # Local Claude Code state — not part of the plugin source
 .claude/
+
+# Local agent config files used by other AI tooling (Codex, etc.) — not
+# part of the plugin source. CLAUDE.md is checked in; AGENTS.md is not.
+AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.6] - 2026-05-18
+
+### Fixed
+- **Cronjob duplicate execution from filename / `meta.id` mismatch** (#62). `listAllJobs()` previously trusted whatever `meta.id` each file carried, completely independent of the on-disk filename. When the two diverged — typically via hand-edits, `cp foo.json bar.json` for testing, or stale files from a prior release whose `sanitizeJobId` rules changed — the scheduler would surface multiple `JobFile` entries with the same id at every tick and execute the job once per file. `type=message` jobs sent the notification 2×/N× per cycle; `type=prompt` jobs dispatched 2×/N× subagents with all the API-call duplication that implied. Meanwhile `update_job` / `delete_job` (which locate files via `{id}.json`) silently failed for any job whose on-disk file had been renamed.
+
+  `listAllJobs()` now skips and logs a clear stderr warning when `file !== \`${meta.id}.json\``. Defensive (skip + warn) rather than auto-reconcile: operators may have deliberately renamed files, and silently mutating their on-disk state would be worse than surfacing the mismatch. The warning text points at the corrective action (rename file OR edit `meta.id`).
+
+  New smoke assertions (30/31) in `scripts/job-smoke.ts` exercise both the happy path (matched files load) and the mismatch defense (mismatched files skipped + warning emitted) by writing two fixture files into a tmp `jobsDir`.
+
 ## [1.0.5] - 2026-05-12
 
 ### Fixed
@@ -354,6 +363,7 @@ Precondition for the privacy redesign (#35). A pluggable abstraction made every 
 - Score-based filtering (`LARK_MIN_SEARCH_SCORE`)
 - HealthCheck for memory provider connectivity
 
+[1.0.6]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.6
 [1.0.5]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.5
 [1.0.4]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.4
 [1.0.3]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/job-smoke.ts
+++ b/scripts/job-smoke.ts
@@ -7,8 +7,13 @@ import {
   expandSchedule,
   computeNextRun,
   backfillJob,
+  listAllJobs,
   type JobFile,
 } from '../src/job-store.js';
+import { appConfig } from '../src/config.js';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 function fail(msg: string): never {
   console.error(`FAIL: ${msg}`);
@@ -244,5 +249,98 @@ if (typeof b3.meta.created_by !== 'string') fail(`created_by must be string: got
 // 29. backfill: non-empty created_by is preserved
 const b4 = backfillJob(makeLegacyJob({ created_by: 'ou_alice' }));
 if (b4.meta.created_by !== 'ou_alice') fail(`backfill must preserve created_by: got "${b4.meta.created_by}"`);
+
+// ── listAllJobs: filename/meta.id mismatch defense (#62) ──
+//
+// Defends against the duplicate-execution bug: if a job file's on-disk
+// name doesn't match its internal meta.id, listAllJobs must skip it
+// (rather than yield a JobFile that no readJob/deleteJob can address),
+// otherwise the scheduler would happily execute orphan files at every
+// tick. See issue #62 for the full failure path.
+
+const tmpJobsDir = mkdtempSync(join(tmpdir(), 'job-mismatch-smoke-'));
+const originalJobsDir = appConfig.jobsDir;
+// `appConfig` is declared `as const`, so TypeScript blocks direct
+// reassignment. At runtime the object is still mutable — cast-and-set
+// for the test, restore in the cleanup block below.
+(appConfig as { jobsDir: string }).jobsDir = tmpJobsDir;
+
+// Cleanup-aware fail helper: restore env + remove tmp dir before exiting.
+// fail() calls process.exit, which BYPASSES try/finally — so any assertion
+// failure inside the try block would otherwise leak the tmp dir and leave
+// appConfig pointing at a deleted path. Going through this helper makes
+// failures as tidy as success.
+function failClean(msg: string): never {
+  (appConfig as { jobsDir: string }).jobsDir = originalJobsDir;
+  try { rmSync(tmpJobsDir, { recursive: true, force: true }); } catch {}
+  fail(msg);
+}
+
+// Hoisted outside the try so the finally block can restore stderr even
+// if listAllJobs() throws before we get to the explicit restore line.
+// Without this, an uncaught rejection mid-test would leave stderr
+// overridden for any future code in the same process (harmless today
+// because npm test exits, but cheap belt-and-suspenders).
+const origStderr = process.stderr.write.bind(process.stderr);
+let stderrCapture = '';
+
+try {
+  process.stderr.write = ((chunk: any) => {
+    stderrCapture += typeof chunk === 'string' ? chunk : chunk.toString();
+    return true;
+  }) as any;
+
+  // The console.error path used by job-store goes through process.stderr,
+  // but we wrap conservatively — flush console first.
+
+  // 30. good-file: filename matches meta.id → loaded normally
+  const goodJob: JobFile = {
+    meta: {
+      id: 'job-good',
+      name: 'Good Job',
+      type: 'message',
+      schedule: '* * * * *',
+      schedule_human: 'every 1m',
+      target_chat_id: 'oc_x',
+      origin_chat_id: 'oc_x',
+      status: 'active',
+      created_by: 'ou_x',
+      created_at: '2026-01-01T00:00:00Z',
+      content: 'hi',
+      msg_type: 'text',
+    } as JobFile['meta'],
+    runtime: { last_run_at: null, next_run_at: '2099-01-01T00:00:00Z', run_count: 0, last_error: null },
+  };
+  writeFileSync(join(tmpJobsDir, 'job-good.json'), JSON.stringify(goodJob, null, 2));
+
+  // 31. bad-file: filename does NOT match meta.id → skipped + warning
+  // Simulates `cp job-good.json renamed.json` or a hand-edit gone wrong.
+  const badJob: JobFile = { ...goodJob, meta: { ...goodJob.meta, id: 'job-original' } };
+  writeFileSync(join(tmpJobsDir, 'renamed.json'), JSON.stringify(badJob, null, 2));
+
+  const listed = await listAllJobs();
+
+  // Restore stderr before assertions so failures print normally.
+  process.stderr.write = origStderr;
+
+  if (listed.length !== 1) {
+    failClean(`30/31: expected 1 job (mismatched file skipped), got ${listed.length}: ${listed.map((j) => j.meta.id).join(',')}`);
+  }
+  if (listed[0].meta.id !== 'job-good') {
+    failClean(`30: expected job-good, got ${listed[0].meta.id}`);
+  }
+  if (!stderrCapture.includes('Skipping renamed.json')) {
+    failClean(`31: warning not emitted for mismatched filename. Captured stderr:\n${stderrCapture}`);
+  }
+  if (!stderrCapture.includes('meta.id="job-original"')) {
+    failClean(`31: warning missing meta.id detail. Captured stderr:\n${stderrCapture}`);
+  }
+} finally {
+  // Restore even on failure so later tests / processes don't inherit
+  // overridden stderr, a deleted tmp dir, or a stale appConfig pointer.
+  process.stderr.write = origStderr;
+  (appConfig as { jobsDir: string }).jobsDir = originalJobsDir;
+  rmSync(tmpJobsDir, { recursive: true, force: true });
+}
 
 console.log('PASS');

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.5' },
+    { name: 'claude-lark-plugin', version: '1.0.6' },
     {
       capabilities: {
         logging: {},

--- a/src/job-store.ts
+++ b/src/job-store.ts
@@ -226,7 +226,29 @@ export async function listAllJobs(): Promise<JobFile[]> {
     for (const file of files.filter(f => f.endsWith('.json'))) {
       try {
         const data = await fs.readFile(path.join(dir, file), 'utf-8');
-        jobs.push(backfillJob(JSON.parse(data) as JobFile));
+        const job = backfillJob(JSON.parse(data) as JobFile);
+        // Defensive: the rest of the job-store (readJob/writeJob/deleteJob)
+        // locates files via `{meta.id}.json`. If the on-disk filename
+        // diverges from meta.id, two failure modes follow:
+        //   (a) update_job / delete_job by id silently fail (the looked-up
+        //       file doesn't exist), and
+        //   (b) if a second file later lands at `{meta.id}.json`, BOTH
+        //       files surface from listAllJobs with the same meta.id and
+        //       the scheduler executes the job once per file (duplicate
+        //       message sends / duplicate prompt subagent dispatches).
+        // See #62 for the full failure analysis. Skip-and-warn rather than
+        // auto-reconcile: operators may have deliberately renamed files,
+        // and silently mutating their on-disk state would be worse than
+        // surfacing the mismatch.
+        if (file !== `${job.meta.id}.json`) {
+          console.error(
+            `[job-store] Skipping ${file}: meta.id="${job.meta.id}" doesn't match filename. ` +
+            `Either rename the file to ${job.meta.id}.json or edit meta.id to match. ` +
+            `Skipping prevents duplicate execution if a matching ${job.meta.id}.json also exists.`,
+          );
+          continue;
+        }
+        jobs.push(job);
       } catch (err) {
         console.error(`[job-store] Skipping corrupt job file ${file}:`, err);
       }


### PR DESCRIPTION
Closes #62

## Bug
\`JobScheduler.tick()\` invoked the same cronjob N times per cycle when the jobs directory contained multiple files with the same \`meta.id\`. Two cleanest paths into that state:

1. Operator hand-edits a job file and renames it (\`vi\`, \`cp foo.json bar.json\`), leaving \`meta.id\` unchanged. \`listAllJobs\` reads BOTH files, returning two \`JobFile\` entries with the same id. \`update_job\`/\`delete_job\` by id silently fail for the renamed file (they look up \`{id}.json\` which is now elsewhere).
2. An older release's \`sanitizeJobId\` allowed characters the current release doesn't — a job file written under the old name keeps its old id internally, but any new \`writeJob\` for that id creates a second file at the new sanitised name. Same dual-file state.

**User-visible impact:** \`type=message\` jobs send the notification 2× per cycle; \`type=prompt\` jobs dispatch 2× subagents with all the API duplication that implies.

## Fix (Option B from the issue)
\`listAllJobs()\` now validates \`file === \${meta.id}.json\` before yielding. Mismatched files are skipped with a clear stderr warning pointing at the corrective action (rename file OR edit \`meta.id\`). Defensive (skip + warn) rather than auto-reconcile — operators may have deliberately renamed files, and silently mutating their on-disk state would be worse than surfacing the mismatch.

Diff is 1 file, ~15 lines including the explanatory comment.

## Tests
Two new assertions in \`scripts/job-smoke.ts\` (30/31):
- Happy path: matched filename → loaded
- Defense: mismatched filename → skipped, warning emitted containing both the filename and the offending \`meta.id\`

Test captures \`process.stderr.write\` to verify the warning fires, restores in a \`finally\` block, uses a tmp \`jobsDir\` (runtime cast since \`appConfig\` is \`as const\`).

## Test plan
- [x] \`npm run typecheck\` passes
- [x] \`npm test\` — new 30/31 + all prior smoke suites green
- [x] \`npm start -- --dry-run\` clean
- [ ] Field verification: rename a real cronjob file, observe stderr warning + the job no longer executing
- [ ] Field verification: pre-existing operators have no orphan files (clean upgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)