### PR TITLE
fix: job-store hygiene — parallel reads + ENOENT distinction + writeJob invariant (v1.0.7)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.7] - 2026-05-19
+
+Three small `job-store` hygiene improvements from #64. No behaviour change for operators whose jobs directory is healthy.
+
+### Changed
+- **`listAllJobs` reads job files in parallel.** Was sequential `await fs.readFile` in a for-loop — O(N × per-file latency). Switched to `Promise.all`. Negligible at typical operator scale (<10 jobs), linear-bad once cronjob counts grow.
+- **`listAllJobs` distinguishes ENOENT / corrupt / unreadable.** Pre-1.0.7 lumped all read failures under `Skipping corrupt job file <file>: <err>`. Three real failure modes now route differently:
+  - **ENOENT** (file vanished between `readdir` and `readFile` — a benign race with concurrent `deleteJob`) → silent skip. The file is legitimately gone, which is the desired state.
+  - **SyntaxError** (JSON parse failed) → `Skipping corrupt job file <file> (invalid JSON): <msg>`.
+  - **Other** (EACCES, EISDIR, ...) → `Skipping unreadable job file <file>: <msg>`. Operator should investigate.
+
+### Fixed
+- **`writeJob` invariant documented.** v1.0.6 fixed the read-side dual-file orphan path (#62). v1.0.7 documents the symmetric write-side invariant in the `writeJob` JSDoc — if a future feature ever lets users rename a job, the caller MUST `deleteJob(oldId)` first. No code change today; every current caller (create_job / update_job / scheduler) keeps `meta.id` stable.
+
+### Added
+- Smoke tests 32–34 in `scripts/job-smoke.ts`: corrupt JSON file labelled correctly (not "unreadable"); a corrupt sibling doesn't break loading of valid jobs alongside; 20 valid jobs all load via the parallel path.
+
+Closes #64
+
 ## [1.0.6] - 2026-05-18
 
 ### Fixed
@@ -363,6 +382,7 @@ Precondition for the privacy redesign (#35). A pluggable abstraction made every 
 - Score-based filtering (`LARK_MIN_SEARCH_SCORE`)
 - HealthCheck for memory provider connectivity
 
+[1.0.7]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.7
 [1.0.6]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.6
 [1.0.5]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.5
 [1.0.4]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/job-smoke.ts
+++ b/scripts/job-smoke.ts
@@ -343,4 +343,127 @@ try {
   rmSync(tmpJobsDir, { recursive: true, force: true });
 }
 
+// ── listAllJobs: corrupt vs unreadable vs ENOENT distinction (#64) ──
+//
+// v1.0.6 lumped all read failures under "Skipping corrupt job file".
+// v1.0.7 distinguishes: ENOENT (silent — benign delete race), SyntaxError
+// (truly corrupt), other (unreadable).
+
+const tmpJobsDir2 = mkdtempSync(join(tmpdir(), 'job-errkind-smoke-'));
+const originalJobsDir2 = appConfig.jobsDir;
+(appConfig as { jobsDir: string }).jobsDir = tmpJobsDir2;
+
+const origStderr2 = process.stderr.write.bind(process.stderr);
+let stderrCapture2 = '';
+
+function failClean2(msg: string): never {
+  process.stderr.write = origStderr2;
+  (appConfig as { jobsDir: string }).jobsDir = originalJobsDir2;
+  try { rmSync(tmpJobsDir2, { recursive: true, force: true }); } catch {}
+  fail(msg);
+}
+
+try {
+  process.stderr.write = ((chunk: any) => {
+    stderrCapture2 += typeof chunk === 'string' ? chunk : chunk.toString();
+    return true;
+  }) as any;
+
+  // 32. corrupt-JSON file is labelled "corrupt", not "unreadable"
+  writeFileSync(join(tmpJobsDir2, 'broken.json'), 'not-valid-json{');
+  // 33. one good job alongside the broken one — should still load
+  const goodJob: JobFile = {
+    meta: {
+      id: 'job-alongside',
+      name: 'Alongside Good',
+      type: 'message',
+      schedule: '* * * * *',
+      schedule_human: 'every 1m',
+      target_chat_id: 'oc_x',
+      origin_chat_id: 'oc_x',
+      status: 'active',
+      created_by: 'ou_x',
+      created_at: '2026-01-01T00:00:00Z',
+      content: 'hi',
+      msg_type: 'text',
+    } as JobFile['meta'],
+    runtime: { last_run_at: null, next_run_at: '2099-01-01T00:00:00Z', run_count: 0, last_error: null },
+  };
+  writeFileSync(join(tmpJobsDir2, 'job-alongside.json'), JSON.stringify(goodJob, null, 2));
+
+  const listed = await listAllJobs();
+
+  process.stderr.write = origStderr2;
+
+  // 32a. corrupt file warning fires with the correct label
+  if (!stderrCapture2.includes('corrupt job file broken.json')) {
+    failClean2(`32: expected "corrupt job file broken.json" in stderr. Got:\n${stderrCapture2}`);
+  }
+  // 32b. corrupt file warning does NOT use the unreadable label.
+  // Intentionally tautological with 32a today: job-store emits exactly
+  // ONE log line per file via either branch, so once 32a passes, 32b
+  // cannot fail. Kept as regression scaffolding — if a future refactor
+  // reorders the `instanceof SyntaxError` check below the generic `else`
+  // (and the same file got mis-routed through both), this would fire.
+  // Do not "clean up" this check.
+  if (stderrCapture2.includes('unreadable job file broken.json')) {
+    failClean2(`32: corrupt file shouldn't be labelled "unreadable". Got:\n${stderrCapture2}`);
+  }
+  // 33. good job survives the corrupt sibling
+  if (listed.length !== 1 || listed[0].meta.id !== 'job-alongside') {
+    failClean2(`33: expected only job-alongside, got ${listed.map((j) => j.meta.id).join(',')}`);
+  }
+} finally {
+  process.stderr.write = origStderr2;
+  (appConfig as { jobsDir: string }).jobsDir = originalJobsDir2;
+  rmSync(tmpJobsDir2, { recursive: true, force: true });
+}
+
+// ── listAllJobs: parallel reads complete (smoke for #64 perf change) ──
+// 34. 20 valid jobs all load via the parallel Promise.all path
+{
+  const tmp = mkdtempSync(join(tmpdir(), 'job-parallel-smoke-'));
+  const origDir = appConfig.jobsDir;
+  (appConfig as { jobsDir: string }).jobsDir = tmp;
+
+  // Cleanup-aware fail mirrors failClean / failClean2 — fail() calls
+  // process.exit which bypasses the finally below.
+  function failClean3(msg: string): never {
+    (appConfig as { jobsDir: string }).jobsDir = origDir;
+    try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+    fail(msg);
+  }
+
+  try {
+    for (let i = 0; i < 20; i++) {
+      const id = `parallel-${String(i).padStart(2, '0')}`;
+      const job: JobFile = {
+        meta: {
+          id,
+          name: `Parallel ${i}`,
+          type: 'message',
+          schedule: '* * * * *',
+          schedule_human: 'every 1m',
+          target_chat_id: 'oc_x',
+          origin_chat_id: 'oc_x',
+          status: 'active',
+          created_by: 'ou_x',
+          created_at: '2026-01-01T00:00:00Z',
+          content: 'hi',
+          msg_type: 'text',
+        } as JobFile['meta'],
+        runtime: { last_run_at: null, next_run_at: '2099-01-01T00:00:00Z', run_count: 0, last_error: null },
+      };
+      writeFileSync(join(tmp, `${id}.json`), JSON.stringify(job, null, 2));
+    }
+    const listed = await listAllJobs();
+    if (listed.length !== 20) {
+      failClean3(`34: parallel read missed jobs. expected 20, got ${listed.length}`);
+    }
+  } finally {
+    (appConfig as { jobsDir: string }).jobsDir = origDir;
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
 console.log('PASS');

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.6' },
+    { name: 'claude-lark-plugin', version: '1.0.7' },
     {
       capabilities: {
         logging: {},

--- a/src/job-store.ts
+++ b/src/job-store.ts
@@ -204,6 +204,20 @@ export async function readJob(id: string): Promise<JobFile | null> {
   }
 }
 
+/**
+ * Persist a JobFile to disk under `{jobsDir}/{job.meta.id}.json`.
+ *
+ * **Invariant for callers**: a job's `meta.id` is stable across its
+ * lifetime. If a future feature ever lets users rename a job, the caller
+ * MUST call `deleteJob(oldId)` BEFORE this with the new id — otherwise
+ * the old file is orphaned. listAllJobs (since v1.0.6, #62) will skip
+ * the orphan with a filename/meta.id-mismatch warning so duplicate
+ * execution won't happen, but the orphan still wastes inode + appears
+ * confusingly in `ls`. Track at #64.
+ *
+ * Today every caller (create_job / update_job / scheduler runtime
+ * persistence) keeps the id stable, so writeJob is a pure overwrite.
+ */
 export async function writeJob(job: JobFile): Promise<void> {
   await ensureJobsDir();
   await fs.writeFile(jobPath(job.meta.id), JSON.stringify(job, null, 2), 'utf-8');
@@ -220,10 +234,22 @@ export async function deleteJob(id: string): Promise<boolean> {
 
 export async function listAllJobs(): Promise<JobFile[]> {
   const dir = appConfig.jobsDir;
+  let files: string[];
   try {
-    const files = await fs.readdir(dir);
-    const jobs: JobFile[] = [];
-    for (const file of files.filter(f => f.endsWith('.json'))) {
+    files = await fs.readdir(dir);
+  } catch {
+    return [];
+  }
+  const jsonFiles = files.filter(f => f.endsWith('.json'));
+
+  // Read all files in parallel — was sequential awaits in v1.0.6 and
+  // earlier, which made list_jobs / scheduler tick O(N × per-file latency).
+  // Negligible at typical scale (<10 jobs) but linear-bad once cronjob
+  // counts grow. Promise.all with Promise.allSettled-style per-file
+  // error handling preserves the "one bad file doesn't break the rest"
+  // semantics of the original loop. See #64.
+  const results = await Promise.all(
+    jsonFiles.map(async (file): Promise<JobFile | null> => {
       try {
         const data = await fs.readFile(path.join(dir, file), 'utf-8');
         const job = backfillJob(JSON.parse(data) as JobFile);
@@ -246,17 +272,30 @@ export async function listAllJobs(): Promise<JobFile[]> {
             `Either rename the file to ${job.meta.id}.json or edit meta.id to match. ` +
             `Skipping prevents duplicate execution if a matching ${job.meta.id}.json also exists.`,
           );
-          continue;
+          return null;
         }
-        jobs.push(job);
-      } catch (err) {
-        console.error(`[job-store] Skipping corrupt job file ${file}:`, err);
+        return job;
+      } catch (err: any) {
+        // Distinguish three failure modes so the operator's log signal
+        // matches the actual cause (#64):
+        //   - ENOENT: file vanished between readdir and readFile (benign
+        //     race with concurrent deleteJob). Silent skip — the file is
+        //     legitimately gone, which is the desired state.
+        //   - SyntaxError: JSON parse failed. Genuinely corrupt.
+        //   - Other (EACCES, EISDIR, etc.): unreadable for an unexpected
+        //     reason. Operator should investigate.
+        if (err?.code === 'ENOENT') return null;
+        if (err instanceof SyntaxError) {
+          console.error(`[job-store] Skipping corrupt job file ${file} (invalid JSON):`, err.message);
+        } else {
+          console.error(`[job-store] Skipping unreadable job file ${file}:`, err?.message ?? err);
+        }
+        return null;
       }
-    }
-    return jobs;
-  } catch {
-    return [];
-  }
+    }),
+  );
+
+  return results.filter((j): j is JobFile => j !== null);
 }
 
 export async function jobExists(id: string): Promise<boolean> {


### PR DESCRIPTION
Closes #64

## Three independent hygiene improvements

All from the v1.0.6 (#62) audit-round 4 follow-ups. None affect correctness today; together they tighten the job-store boundary the v1.0.6 read-side check opened up.

### 1. \`listAllJobs\` reads in parallel
Was sequential \`await fs.readFile\` in a for-loop. \`Promise.all\` parallelises. Negligible at typical operator scale (<10 jobs), linear-bad once cronjob counts grow.

### 2. ENOENT / corrupt / unreadable distinction
Pre-1.0.7 lumped all read failures under \`Skipping corrupt job file\`. For an operator watching scheduler stderr, a benign delete race showed up as a scary "corrupt" warning. Now:
- **ENOENT** (concurrent \`deleteJob\` race) → silent skip
- **SyntaxError** (genuine corruption) → \`Skipping corrupt job file ... (invalid JSON)\`
- **Other** (EACCES, EISDIR, ...) → \`Skipping unreadable job file ...\`

### 3. \`writeJob\` invariant documented
v1.0.6 fixed the read-side dual-file orphan path. v1.0.7 documents the symmetric write-side invariant in \`writeJob\`'s JSDoc: \`meta.id\` is stable across a job's lifetime; a future id-rename feature MUST \`deleteJob(oldId)\` first to avoid orphans. **No code change today** — no current caller renames. Pure documentation guard for future contributors.

## Tests
Three new smoke assertions (32-34) in \`scripts/job-smoke.ts\`:
- 32: corrupt JSON file labelled "corrupt", not "unreadable"
- 33: a corrupt sibling doesn't block valid jobs alongside it
- 34: 20 valid jobs all load via the parallel \`Promise.all\` path

## Test plan
- [x] \`npm run typecheck\` passes
- [x] \`npm test\` — new 32/33/34 + all prior smoke suites green
- [x] \`npm start -- --dry-run\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)