### PR TITLE
fix: bind system caller for auto-flush so save_memory(type=chat) persists (v1.0.8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.8] - 2026-05-19
+
+### Fixed
+- **Auto-flush `save_memory` was silently denied in threaded group chats** (#66). After the inactivity-triggered buffer flush, Claude tried to call `save_memory(type="chat", chat_id=X)` to persist the distilled summary, but `resolveCaller(X, undefined)` returned null and the call was denied — Claude printed a "no caller, giving up" diagnostic to stderr and the episode was lost. Pre-1.0.8 the `CLAUDE.md` note called this "flaky"; the actual cause is structural, not transient:
+
+  Identity binding uses key `(chatId, threadId)`. In a threaded group chat, user messages bind under `(chat, thread)`. The flush notification carries `chatId` only (the buffer is chat-scoped, no thread). `getCaller(chat, undefined)` falls back to chat-level entries — which exist only for non-threaded chats. **Threaded group chats failed every flush.**
+
+  Fix: in `buffer.setFlushHandler`, bind a sentinel caller `SYSTEM_FLUSH_CALLER = '__system_flush__'` before notifying Claude — mirrors `scheduler.executePromptJob`'s pattern of binding `job.meta.created_by` before a cronjob notification. Chat episodes are stored by `(chatId, threadId?)` only (not by caller), so the sentinel only affects audit-log attribution — the data itself goes to the same `episodes/<chatId>/` directory it always did. Audit log entries for system-flush writes carry `caller=__system_flush__`, making system-distilled episodes greppable.
+
+### Added
+- `SYSTEM_FLUSH_CALLER` constant exported from `src/identity-session.ts`.
+- Server-side guard in `resolveCaller`: when caller resolves to `SYSTEM_FLUSH_CALLER`, only `save_memory` is authorized — all other sensitive tools (`create_job`, `update_job`, `delete_job`, `list_jobs`, `what_do_you_know`, `forget_memory`) are denied. Reason: the sentinel exists solely to let buffer flushes persist chat episodes without a real user. A sentinel-attributed `create_job` would produce a job no real operator could later update/delete (owner mismatch); a sentinel-attributed `forget_memory` couldn't address any user's profile. The guard is also defense for the sticky-binding window: `IdentitySession` entries outlive the flush turn until the next real user message overwrites them.
+- Server-side guard in `save_memory`: when caller is `SYSTEM_FLUSH_CALLER`, `type="profile"` is rejected with an explanatory error. Profile writes are user-scoped (`saveProfile` writes to `profiles/<callerId>/`), and the sentinel has no user identity to legitimately own private-tier data.
+- `scripts/auto-flush-smoke.ts` — 8 assertions covering: sentinel value; `setCaller`/`getCaller` roundtrip; end-to-end `save_memory(type=chat)` success with episode file written to disk; `save_memory(type=profile)` rejection; audit log records both `denied` and `ok` with the sentinel caller (operator-greppable); `create_job` denied for the sentinel; `forget_memory` denied for the sentinel.
+
+### Changed
+- The auto-flush prompt (`src/prompts.ts`) now explicitly tells Claude the turn is system-initiated, that the plugin has bound a system caller, and that profile writes will be rejected server-side. Stops Claude from second-guessing and emitting the "no caller, giving up" diagnostic on threaded chats.
+
+Closes #66
+
 ## [1.0.7] - 2026-05-19
 
 Three small `job-store` hygiene improvements from #64. No behaviour change for operators whose jobs directory is healthy.
@@ -382,6 +402,7 @@ Precondition for the privacy redesign (#35). A pluggable abstraction made every 
 - Score-based filtering (`LARK_MIN_SEARCH_SCORE`)
 - HealthCheck for memory provider connectivity
 
+[1.0.8]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.8
 [1.0.7]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.7
 [1.0.6]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.6
 [1.0.5]: https://github.com/IS908/claude-lark-plugin/releases/tag/v1.0.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/auto-flush-smoke.ts
+++ b/scripts/auto-flush-smoke.ts
@@ -1,0 +1,229 @@
+/**
+ * Auto-flush caller-binding smoke test — runs as part of `npm test`.
+ *
+ * Verifies the v1.0.8 fix for #66:
+ *   - SYSTEM_FLUSH_CALLER sentinel is exported with the documented value.
+ *   - setCaller(chatId, undefined, SYSTEM_FLUSH_CALLER) followed by
+ *     save_memory(type='chat') succeeds end-to-end (the bug being fixed:
+ *     pre-1.0.8 this denied because resolveCaller returned null in
+ *     threaded contexts).
+ *   - The server-side guard rejects save_memory(type='profile') when the
+ *     caller is the sentinel, even though resolveCaller succeeds — system
+ *     has no user identity to attribute private-tier data to.
+ */
+import { mkdtempSync, rmSync, existsSync, readdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+
+function fail(msg: string): never {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+// Route audit log to a tmpdir BEFORE importing audit-log.js (it reads env at import).
+const tmp = mkdtempSync(join(tmpdir(), 'auto-flush-smoke-'));
+process.env.LARK_AUDIT_LOG = join(tmp, 'audit.log');
+process.env.LARK_PRIVACY_RULES_FILE = join(tmp, 'privacy-rules.md');
+
+const { IdentitySession, SYSTEM_FLUSH_CALLER } = await import('../src/identity-session.js');
+const { MemoryStore } = await import('../src/memory/file.js');
+const { registerTools } = await import('../src/tools.js');
+import type { LarkChannel } from '../src/channel.js';
+
+let passed = 0;
+
+// ── 1. SYSTEM_FLUSH_CALLER constant value ──
+if (SYSTEM_FLUSH_CALLER !== '__system_flush__') {
+  fail(`1: SYSTEM_FLUSH_CALLER should be "__system_flush__", got "${SYSTEM_FLUSH_CALLER}"`);
+}
+passed++;
+
+// ── 2. setCaller + getCaller roundtrips the sentinel ──
+{
+  const s = new IdentitySession(() => null);
+  s.setCaller('oc_x', undefined, SYSTEM_FLUSH_CALLER);
+  if (s.getCaller('oc_x') !== SYSTEM_FLUSH_CALLER) {
+    fail(`2: roundtrip failed, got ${s.getCaller('oc_x')}`);
+  }
+  passed++;
+}
+
+// ── Setup for tool-integration tests ──
+
+const memRoot = join(tmp, 'memory');
+const memoryStore = new MemoryStore(memRoot);
+
+const handlers = new Map<string, (args: any) => Promise<any>>();
+const fakeServer = {
+  registerTool(name: string, _config: any, handler: any) {
+    handlers.set(name, handler);
+  },
+};
+
+const identitySession = new IdentitySession(() => null);
+const fakeChannel = { isPrivateChat: () => false } as unknown as LarkChannel;
+
+// Minimal mock Lark client — save_memory doesn't actually use it but
+// registerTools signature requires one.
+const mockClient = {
+  im: {
+    v1: {
+      message: { create: async () => ({}), reply: async () => ({}) },
+      messageReaction: { create: async () => {}, delete: async () => {} },
+      image: { create: async () => ({}), get: async () => Buffer.from('') },
+      file: { create: async () => ({}) },
+      messageResource: { get: async () => Readable.from([]) },
+    },
+  },
+};
+
+registerTools(
+  fakeServer as any,
+  mockClient as any,
+  memoryStore,
+  identitySession,
+  fakeChannel,
+  { record() {}, flush: async () => {}, startAutoFlush: () => {}, stopAutoFlush: () => {} } as any,
+  new Map<string, string>(),
+  { ids: new Set(), add() {}, has: () => false } as any,
+  undefined,
+);
+
+const saveMemory = handlers.get('save_memory');
+if (!saveMemory) fail('save_memory handler not registered');
+
+// ── 3. save_memory(type=chat) succeeds with SYSTEM_FLUSH_CALLER ──
+// This is the actual #66 bug: pre-1.0.8, resolveCaller returned null for
+// (chat, no threadId) when user's entry was at (chat, threadId), and the
+// call was denied. With v1.0.8's flush-handler setCaller, the call now
+// resolves to the sentinel and the episode persists.
+{
+  identitySession.setCaller('oc_thread_chat', undefined, SYSTEM_FLUSH_CALLER);
+  const r = await saveMemory!({
+    type: 'chat',
+    content: 'distilled summary of the conversation',
+    reason: 'auto-flush after inactivity',
+    chat_id: 'oc_thread_chat',
+    // no thread_id — mirrors what the flush notification provides
+  });
+  if (r.isError) {
+    fail(`3: save_memory(type=chat) should succeed with system caller, got error: ${JSON.stringify(r.content)}`);
+  }
+  // Episode file actually written?
+  const episodesDir = join(memRoot, 'episodes', 'oc_thread_chat');
+  if (!existsSync(episodesDir)) {
+    fail(`3: episode directory not created at ${episodesDir}`);
+  }
+  const files = readdirSync(episodesDir).filter((f) => f.endsWith('.md'));
+  if (files.length !== 1) fail(`3: expected 1 episode file, got ${files.length}`);
+  const content = readFileSync(join(episodesDir, files[0]), 'utf-8');
+  if (!content.includes('distilled summary')) fail(`3: episode content lost`);
+  passed++;
+}
+
+// ── 4. save_memory(type=profile) DENIED with SYSTEM_FLUSH_CALLER ──
+// Defense in depth: even if Claude goes off-script and tries to write a
+// profile during a flush turn, the server rejects.
+{
+  identitySession.setCaller('oc_thread_chat', undefined, SYSTEM_FLUSH_CALLER);
+  const r = await saveMemory!({
+    type: 'profile',
+    content: 'user likes tea',
+    reason: 'inferred during flush',
+    chat_id: 'oc_thread_chat',
+    tier: 'private',
+  });
+  if (!r.isError) fail(`4: save_memory(type=profile) must be denied for system caller`);
+  const txt = r.content[0].text as string;
+  if (!/system-flush sentinel/.test(txt)) {
+    fail(`4: error must mention sentinel, got: ${txt}`);
+  }
+  // No profile written to disk for the sentinel "user"
+  const sentinelProfileDir = join(memRoot, 'profiles', SYSTEM_FLUSH_CALLER);
+  if (existsSync(sentinelProfileDir)) {
+    fail(`4: sentinel must not have a profile directory`);
+  }
+  passed++;
+}
+
+// Audit log writes are fire-and-forget (`void audit(...)` inside tools.ts).
+// Wait briefly for the queued appendFile calls to land before reading.
+// Retry-loop up to 1s — should land in <50ms on a healthy disk.
+async function waitForAuditLog(): Promise<string> {
+  const auditPath = process.env.LARK_AUDIT_LOG!;
+  for (let i = 0; i < 20; i++) {
+    if (existsSync(auditPath)) {
+      const contents = readFileSync(auditPath, 'utf-8');
+      if (contents.includes('denied') && contents.includes('ok')) return contents;
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  const final = existsSync(auditPath) ? readFileSync(auditPath, 'utf-8') : '(file missing)';
+  fail(`audit log never reached expected state. Last contents:\n${final}`);
+}
+
+const auditLog = await waitForAuditLog();
+
+// ── 5. Audit log records the denial ──
+{
+  if (!auditLog.includes('denied')) fail(`5: audit log should record denial`);
+  if (!auditLog.includes(SYSTEM_FLUSH_CALLER)) {
+    fail(`5: audit log should record the sentinel caller`);
+  }
+  passed++;
+}
+
+// ── 6. save_memory(type=chat) audit shows sentinel as caller (operator can grep) ──
+{
+  const okLine = auditLog.split('\n').find((l) => l.includes('ok') && l.includes(SYSTEM_FLUSH_CALLER));
+  if (!okLine) fail(`6: audit log should record ok save with sentinel caller. Got:\n${auditLog}`);
+  passed++;
+}
+
+// ── 7. Other sensitive tools are denied for SYSTEM_FLUSH_CALLER ──
+// Defense: the sentinel is bound only to let save_memory persist chat
+// episodes during a flush. It must not authorize create_job /
+// forget_memory / etc. — any such call would produce records owned by
+// or addressing the sentinel, which no real user can later
+// update/delete/inspect. resolveCaller centralises this guard.
+{
+  const createJob = handlers.get('create_job');
+  if (!createJob) fail('7: create_job handler not registered');
+
+  identitySession.setCaller('oc_thread_chat', undefined, SYSTEM_FLUSH_CALLER);
+  const r = await createJob!({
+    name: 'rogue-job',
+    type: 'message',
+    schedule: 'every 5m',
+    content: 'hi',
+    target_chat_id: 'oc_thread_chat',
+    chat_id: 'oc_thread_chat',
+    // no thread_id — mirrors what a flush turn would have
+  });
+  if (!r.isError) fail(`7: create_job must be denied for system caller, got: ${JSON.stringify(r.content)}`);
+  const txt = r.content[0].text as string;
+  if (!/system-flush caller|sentinel/i.test(txt)) {
+    fail(`7: error should explain sentinel restriction, got: ${txt}`);
+  }
+  passed++;
+}
+
+// ── 8. forget_memory also denied for SYSTEM_FLUSH_CALLER ──
+{
+  const forgetMemory = handlers.get('forget_memory');
+  if (!forgetMemory) fail('8: forget_memory handler not registered');
+
+  identitySession.setCaller('oc_thread_chat', undefined, SYSTEM_FLUSH_CALLER);
+  const r = await forgetMemory!({
+    hash: 'deadbeef',
+    tier: 'private',
+    chat_id: 'oc_thread_chat',
+  });
+  if (!r.isError) fail(`8: forget_memory must be denied for system caller, got: ${JSON.stringify(r.content)}`);
+  passed++;
+}
+
+rmSync(tmp, { recursive: true, force: true });
+
+console.log(`auto-flush smoke: ${passed}/8 PASS`);

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -70,4 +70,8 @@ echo "=== Download attachment unit checks ==="
 npx tsx scripts/download-attachment-smoke.ts
 
 echo ""
+echo "=== Auto-flush caller binding unit checks ==="
+npx tsx scripts/auto-flush-smoke.ts
+
+echo ""
 echo "All tests passed."

--- a/src/identity-session.ts
+++ b/src/identity-session.ts
@@ -25,6 +25,35 @@
 
 export const TERMINAL_CHAT_ID = '__terminal__';
 
+/**
+ * Sentinel caller for buffer auto-flush turns (#66). The flush is a
+ * system-initiated, chat-level distillation — no user triggered it. We
+ * bind this synthetic caller before the flush notification so the
+ * server-side `resolveCaller` gate passes and `save_memory(type=chat|thread)`
+ * can persist.
+ *
+ * NOT a valid profile owner — `save_memory(type=profile)` rejects this
+ * sentinel server-side (system has no user identity to attribute private
+ * data to). The flush prompt also instructs Claude not to attempt profile
+ * writes during flush turns; this constant is the second line of defense.
+ *
+ * `resolveCaller` in tools.ts further restricts the sentinel to only
+ * `save_memory` — any other sensitive tool (`create_job`, `forget_memory`,
+ * etc.) is denied to prevent sentinel-attributed records that no real
+ * user could later address.
+ *
+ * Audit log entries for system-flush writes carry caller=`__system_flush__`,
+ * making the data lineage greppable.
+ *
+ * Operator constraint: `LARK_OWNER_OPEN_ID` MUST NOT equal this value.
+ * If it did, terminal invocations would resolve through `ownerFallback()`
+ * to the sentinel and inherit the sentinel's restrictive guard — the
+ * operator would be locked out of every sensitive tool except save_memory.
+ * Realistic risk near zero (Feishu open_ids are `ou_*`), but documented
+ * for completeness.
+ */
+export const SYSTEM_FLUSH_CALLER = '__system_flush__';
+
 interface SessionEntry {
   userId: string;
   updatedAt: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { registerTools } from './tools.js';
 import { ConversationBuffer } from './memory/buffer.js';
 import { buildFlushPrompt } from './memory/distiller.js';
 import { MemoryStore } from './memory/file.js';
-import { IdentitySession } from './identity-session.js';
+import { IdentitySession, SYSTEM_FLUSH_CALLER } from './identity-session.js';
 import { JobScheduler } from './scheduler.js';
 import { mcpServerInstructions } from './prompts.js';
 
@@ -63,7 +63,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.7' },
+    { name: 'claude-lark-plugin', version: '1.0.8' },
     {
       capabilities: {
         logging: {},
@@ -87,6 +87,22 @@ async function main() {
     // In auto-flush, we inject the prompt as if it were a message
     // The channel's message handler will forward it to Claude
     console.error(`[distiller] Auto-flush for chat ${chatId}: ${messages.length} messages`);
+
+    // Bind a system-flush caller BEFORE notifying Claude (#66). Without
+    // this, save_memory(type=chat) inside the flush turn fails caller
+    // resolution because:
+    //   - User entries are stored by IdentitySession under (chatId, threadId).
+    //   - The flush notification carries chatId only (no threadId, since the
+    //     buffer is chat-scoped, not thread-scoped).
+    //   - getCaller(chatId, undefined) falls back to a chat-level entry,
+    //     which is only present in non-threaded chats. Threaded chats miss.
+    //
+    // Chat episodes are stored by (chatId, threadId?), NOT by caller, so a
+    // sentinel caller doesn't change WHERE the data goes — only WHAT the
+    // audit log records. Mirrors scheduler.executePromptJob's pattern of
+    // binding job.meta.created_by before the cronjob notification.
+    identitySession.setCaller(chatId, undefined, SYSTEM_FLUSH_CALLER);
+
     // Forward flush prompt through the normal message handler
     if (channel['messageHandler']) {
       await channel['messageHandler']({

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -13,13 +13,15 @@
  * profileDistillationPrompt path where the target user is unambiguous.
  */
 export function flushPrompt(chatId: string, conversation: string, messageCount: number): string {
-  return `[Auto-memory-flush]
+  return `[Auto-memory-flush — system-initiated]
+This is a buffer flush triggered by inactivity, not a user message. The plugin has bound a system caller for this turn, so save_memory(type="chat", ...) will succeed even though no real user invoked it.
+
 The following is a conversation from chat ${chatId} (${messageCount} messages).
 Please:
 1. Write a 3-5 sentence summary focusing on: what was discussed, what was decided, what was resolved, and any open items.
-2. Call save_memory(type="chat", content=<summary>, reason=<why>, chat_id="${chatId}") to persist it.
+2. Call save_memory(type="chat", content=<summary>, reason=<why>, chat_id="${chatId}") to persist it. Do not output a reply — this is system, not user.
 
-Do NOT call save_memory(type="profile", ...) in this turn — profile writes require a specific caller identity, which an auto-flush does not have. Individual profile updates are handled by a separate distillation stage.
+Do NOT call save_memory(type="profile", ...) in this turn — profile writes are user-scoped (they persist into a specific user's profile directory), and a system caller has no user identity to attribute private-tier data to. The server-side gate will reject any profile write attempt here. Individual profile updates are handled by a separate distillation stage.
 
 --- Conversation ---
 ${conversation}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -8,6 +8,7 @@ import type { MemoryStore } from './memory/file.js';
 import type { ConversationBuffer } from './memory/buffer.js';
 import type { BotMessageTracker, LatestMessageTracker, LarkChannel } from './channel.js';
 import type { IdentitySession } from './identity-session.js';
+import { SYSTEM_FLUSH_CALLER } from './identity-session.js';
 import { audit } from './audit-log.js';
 import { buildCards, shouldUseCard } from './feishu-card.js';
 import { JOB_THREAD_PREFIX } from './scheduler.js';
@@ -102,6 +103,33 @@ export function registerTools(
             {
               type: 'text' as const,
               text: `No active identity session for chat ${chat_id}. This tool requires an inbound Feishu message to establish caller identity, or a terminal invocation with LARK_OWNER_OPEN_ID set.`,
+            },
+          ],
+        },
+      };
+    }
+    // SYSTEM_FLUSH_CALLER is bound by buffer.setFlushHandler (#66) to let
+    // save_memory persist chat-level distillations without a real user
+    // identity. It must NOT authorize anything else — a sentinel-attributed
+    // `create_job` would produce a job with `created_by=__system_flush__`
+    // that no real operator could update/delete (owner mismatch); a
+    // sentinel-attributed `forget_memory` couldn't address any user's
+    // profile. The save_memory handler itself further restricts the
+    // sentinel to type=chat|thread (rejecting type=profile).
+    //
+    // The sentinel binding can outlive the flush turn (sticky in
+    // IdentitySession until the next real user message overwrites it),
+    // so this guard is also defense against any later tool call that
+    // happens to land on the leftover entry.
+    if (caller === SYSTEM_FLUSH_CALLER && toolName !== 'save_memory') {
+      void audit(toolName, caller, args, 'denied');
+      return {
+        error: {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: `${toolName} is not authorized for the system-flush caller. Only save_memory can authorize under this caller (and save_memory itself further restricts to type=chat|thread). The sentinel exists to let buffer flushes persist chat episodes without a real user — not to act on behalf of one.`,
             },
           ],
         },
@@ -622,6 +650,30 @@ export function registerTools(
       const auth = resolveCaller('save_memory', chat_id, thread_id, auditArgs);
       if ('error' in auth) return auth.error;
       const { caller } = auth;
+
+      // Defense in depth (#66): the auto-flush turn binds SYSTEM_FLUSH_CALLER
+      // as the caller so save_memory(type=chat|thread) can persist
+      // chat-level distillations without a real user identity. That sentinel
+      // MUST NOT be allowed to write profile tiers — profiles are
+      // user-scoped (saveProfile writes to profiles/<callerId>/...), and a
+      // sentinel "writer" has no user identity to legitimately own
+      // private-tier data. The flush prompt already forbids type=profile,
+      // this is the server-side guard against Claude going off-script.
+      if (type === 'profile' && caller === SYSTEM_FLUSH_CALLER) {
+        void audit('save_memory', caller, auditArgs, 'denied');
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text:
+                'save_memory(type=profile) denied: caller is the system-flush sentinel. ' +
+                'Profile writes need a real user identity. If you reached this in an ' +
+                'auto-flush turn, restrict to type=chat or type=thread.',
+            },
+          ],
+          isError: true,
+        };
+      }
 
       if (type === 'profile') {
         const effectiveTier = tier ?? 'private';


### PR DESCRIPTION
Closes #66

## Symptom
After inactivity-triggered buffer flush, Claude tried \`save_memory(type=\"chat\")\` to persist the distilled summary. \`resolveCaller\` returned null, the call was denied, and Claude printed a diagnostic to stderr saying it was giving up. The episode was lost.

## Root cause
Identity binding uses key \`(chatId, threadId)\`. In a threaded group chat, user messages bind under \`(chat, thread)\`. The flush notification carries \`chatId\` only (the buffer is chat-scoped). \`getCaller(chat, undefined)\` falls back to chat-level entries — which exist only for non-threaded chats. **Threaded group chats failed every flush.** P2P happened to work because both set/get used the same plain chatId key.

## Fix — Option A (system sentinel caller)
\`buffer.setFlushHandler\` binds \`SYSTEM_FLUSH_CALLER = '__system_flush__'\` before notifying Claude. Mirrors \`scheduler.executePromptJob\`'s pattern of binding \`job.meta.created_by\` before a cronjob notification.

**Storage is unchanged.** \`saveEpisode\` keys by \`(chatId, threadId?)\` only — caller doesn't enter the storage path or content. The sentinel only affects audit-log attribution. Data lands in the same \`episodes/<chatId>/\` directory it always did.

### Why not the alternatives
- **B: getCaller cross-thread fallback** — would scan \`<chatId>#*\` keys but risks cross-thread attribution leak when multiple threads are active.
- **C: per-(chat,thread) buffer** — large refactor, loses whole-chat distillation.
- **D: re-bind last user as caller** — misleads audit (the user didn't trigger this; buffer timer did).

### Defense in depth (two layers)
1. **\`resolveCaller\` (centralized, all sensitive tools)** — when caller resolves to \`SYSTEM_FLUSH_CALLER\`, **only \`save_memory\` is authorized**. \`create_job\`/\`update_job\`/\`delete_job\`/\`list_jobs\`/\`what_do_you_know\`/\`forget_memory\` all deny. Reason: sentinel-attributed records (e.g. a job with \`created_by=__system_flush__\`) couldn't be addressed by any real user. The guard also handles the sticky-binding window — \`IdentitySession\` entries outlive the flush turn until the next real user message overwrites them.
2. **\`save_memory\` (type-specific)** — even within save_memory, sentinel callers are restricted to \`type=chat|thread\`. \`type=profile\` is rejected because profile writes are user-scoped (\`saveProfile\` writes to \`profiles/<callerId>/\`).

## Test plan
- [x] \`npm run typecheck\` passes
- [x] \`npm test\` — new auto-flush smoke **8/8** + all prior suites green
- [x] \`npm start -- --dry-run\` clean
- [x] Self-loop review converged after 3 rounds
- [ ] Field verification: in a Feishu thread, message the bot, wait inactivity_hours, observe stderr show \"[distiller] Auto-flush\" and the episode .md appears under \`~/.claude/channels/lark/memories/episodes/<chatId>/\`

## Audit-round summary
- R1 — broadened sentinel guard from save_memory-only to centralized in \`resolveCaller\` (only save_memory authorized; others deny). Smoke 6 → 8.
- R2 — error-message phrasing + operator constraint docstring (\`LARK_OWNER_OPEN_ID != '__system_flush__'\`).
- R3 — clean, ship-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)