### PR TITLE
fix(security): reject path-traversal in Feishu IDs (#93, v1.0.15)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.15] - 2026-05-24
+
+### Security
+- **`chat_id` / `thread_id` / `message_id` / `target_chat_id` / `reply_to` / job `id` now reject path-traversal payloads** (#93 — **CRITICAL — arbitrary file write**). Pre-v1.0.15 these tool inputs were typed as plain `z.string()` and flowed verbatim into `path.join(baseDir, 'episodes', chatId, 'threads', threadId)` inside `MemoryStore.saveEpisode`. Because `path.join` *collapses* `..` segments rather than rejecting them, a Claude-supplied `thread_id='../../../../tmp/escape'` (delivered via prompt injection in a group chat, or via Claude misreading instructions) would write the episode markdown to `/tmp/escape/<timestamp>.md` — escaping the configured `baseDir`. Filename was fixed at `<timestamp>.md` so direct overwrite of named files (`~/.ssh/authorized_keys`, hook scripts) required pathological timing, but writing into any directory the process had access to was straightforward. `update_job` / `delete_job` accepted an analogous unsanitized `id`, allowing arbitrary `fs.unlink` outside `jobsDir`.
+
+  **Two-layer defense**:
+  1. **Tool boundary** — new `LARK_ID_REGEX = /^[A-Za-z0-9_:-]{1,128}$/` applied via `larkIdSchema(label)` to every `chat_id` / `thread_id` / `message_id` / `target_chat_id` / `reply_to` in `src/tools.ts` (all 12 tools that accept any of these). Real Feishu IDs (`oc_*`, `om_*`, `omt_*`, `ou_*`, `og_*`, `cli_msg_*`) match; anything containing `/`, `\`, `..`, `\0`, whitespace, or control characters rejects with a clear Zod error.
+  2. **Storage layer** — new `assertSafeKey` in `src/memory/file.ts` runs on `saveEpisode` / `searchEpisodes` / `listEpisodes` / `deleteEpisodes` / `profileDir` / `legacyProfilePath` *before* `path.join`, throwing a recognizable error if the key contains a traversal vector. New `assertSafeJobId` in `src/job-store.ts` does the same for `jobPath`. Read paths get the guard too — a traversal in `chatId` to `searchEpisodes` could otherwise leak file existence outside `baseDir`.
+
+  The two layers are independent: a future code path that bypasses Zod (e.g. internal cronjob plumbing) still cannot land bytes outside `baseDir`. Tests cover both layers.
+
+### Added
+- 9 smoke assertions in `scripts/path-traversal-smoke.ts` covering: `LARK_ID_REGEX` rejects every documented traversal vector + accepts realistic Feishu shapes; `saveEpisode` rejects bad `chatId` and bad `threadId` before any file write; happy-path `saveEpisode` still writes inside `baseDir`; `searchEpisodes` / `listEpisodes` / `deleteEpisodes` reject bad keys; `getProfile` rejects bad `userId`; `writeJob` throws on traversal id, `readJob` returns null, `deleteJob` returns false (catch-internal contract preserved).
+- `LARK_ID_REGEX` exported from `src/tools.ts` for downstream test reuse.
+
+### Operator notes
+- Legitimate IDs are unaffected — every observed Feishu ID shape (group chat, P2P chat, thread, message, user open_id, cronjob synthetic thread) matches the new regex.
+- The colon (`:`) is included in the character class to accommodate cronjob-synthetic thread IDs (`JOB_THREAD_PREFIX:<iso-timestamp>`) that contain colons in the timestamp segment.
+- If a custom integration was sending non-standard IDs (e.g. a script wrapping the tools manually), it may now hit `Invalid <field>: must be 1-128 chars of [A-Za-z0-9_:-]`. The fix is to pass the verbatim ID from the inbound Feishu notification.
+
 ## [1.0.14] - 2026-05-24
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   The two layers are independent: a future code path that bypasses Zod (e.g. internal cronjob plumbing) still cannot land bytes outside `baseDir`. Tests cover both layers.
 
 ### Added
-- 9 smoke assertions in `scripts/path-traversal-smoke.ts` covering: `LARK_ID_REGEX` rejects every documented traversal vector + accepts realistic Feishu shapes; `saveEpisode` rejects bad `chatId` and bad `threadId` before any file write; happy-path `saveEpisode` still writes inside `baseDir`; `searchEpisodes` / `listEpisodes` / `deleteEpisodes` reject bad keys; `getProfile` rejects bad `userId`; `writeJob` throws on traversal id, `readJob` returns null, `deleteJob` returns false (catch-internal contract preserved).
+- 11 smoke assertions in `scripts/path-traversal-smoke.ts` covering: `LARK_ID_REGEX` rejects every documented traversal vector + accepts realistic Feishu shapes; `saveEpisode` rejects bad `chatId` and bad `threadId` before any file write; happy-path `saveEpisode` still writes inside `baseDir`; `searchEpisodes` / `listEpisodes` / `deleteEpisodes` reject bad keys; `getProfile` rejects bad `userId`; `writeJob` throws on traversal id, `readJob` returns null, `deleteJob` returns false (catch-internal contract preserved); off-by-one boundary checks at 128 chars (Layer-1 regex) and 255 chars (Layer-2 storage cap = POSIX NAME_MAX).
 - `LARK_ID_REGEX` exported from `src/tools.ts` for downstream test reuse.
+
+### R1-audit followups (closed in this PR)
+- **`update_job.id` / `delete_job.id` / `download_attachment.file_key` now use `larkIdSchema`** — pre-R1-fix these were still plain `z.string()`. Layer 2 (`assertSafeJobId` / inbox-side defenses) already caught the traversal so the gap was design-inconsistency rather than a vulnerability, but a Layer-1 rejection produces a clear `Invalid <field>` error instead of a downstream Feishu-API failure or silent `false` return.
+- **`assertSafeKey` length cap lowered from 256 to 255** to match POSIX `NAME_MAX` / macOS HFS+/APFS per-component limit. Beyond 255 the syscalls would throw `ENAMETOOLONG`; clearer to reject upstream.
 
 ### Operator notes
 - Legitimate IDs are unaffected — every observed Feishu ID shape (group chat, P2P chat, thread, message, user open_id, cronjob synthetic thread) matches the new regex.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/path-traversal-smoke.ts
+++ b/scripts/path-traversal-smoke.ts
@@ -47,7 +47,7 @@ const BAD_IDS = [
   'foo\rbar',
   '\x01ctrl',
   '', // empty
-  'a'.repeat(257), // too long
+  'a'.repeat(129), // exceeds Layer-1 (tool boundary) cap of 128
 ];
 
 const GOOD_IDS = [
@@ -238,6 +238,39 @@ let testNum = 0;
 
   const del = await deleteJob('../../etc/passwd');
   if (del !== false) fail('deleteJob must return false on traversal id');
+}
+
+// 10. Boundary check: regex accepts exactly 128 chars, rejects 129.
+//     Catches off-by-one regressions on the upper cap.
+{
+  testNum++;
+  const exact128 = 'a'.repeat(128);
+  const exact129 = 'a'.repeat(129);
+  if (!LARK_ID_REGEX.test(exact128)) fail('LARK_ID_REGEX must accept exactly 128 chars');
+  if (LARK_ID_REGEX.test(exact129)) fail('LARK_ID_REGEX must reject 129 chars');
+}
+
+// 11. assertSafeKey storage-layer cap is NAME_MAX (255), looser than the
+//     Layer-1 cap (128). Catches a future regression that tightens the
+//     storage layer below Layer-1 (would break legitimate non-tool callers).
+{
+  testNum++;
+  const { store } = freshStore();
+  const exact255 = 'a'.repeat(255); // safe alphanumerics, no traversal
+  // saveEpisode internally calls assertSafeKey(chatId) which permits up to 255.
+  // We don't actually want to write a 255-char directory in /tmp on every
+  // test run — just verify the assertion path does NOT throw for 255 by
+  // invoking listEpisodes which calls assertSafeKey then fs.readdir (which
+  // returns [] for nonexistent paths, so no .md side effects either way).
+  let threw = false;
+  try { await store.listEpisodes(exact255); } catch { threw = true; }
+  if (threw) fail('assertSafeKey must accept exactly 255 chars');
+
+  // 256 chars must reject.
+  const exact256 = 'a'.repeat(256);
+  let rejected = false;
+  try { await store.listEpisodes(exact256); } catch { rejected = true; }
+  if (!rejected) fail('assertSafeKey must reject 256 chars');
 }
 
 console.log(`path-traversal smoke: ${testNum}/${testNum} PASS`);

--- a/scripts/path-traversal-smoke.ts
+++ b/scripts/path-traversal-smoke.ts
@@ -1,0 +1,243 @@
+/**
+ * Path-traversal defense smoke test (v1.0.15, #93).
+ *
+ * Verifies the two layers of defense against Claude-supplied chat / thread /
+ * message / job ids that contain `..` / `/` / `\` / NUL / control bytes:
+ *
+ *   Layer 1: `LARK_ID_REGEX` enforced at every tool input boundary in
+ *            src/tools.ts. Verified by parsing the exported regex.
+ *
+ *   Layer 2: `assertSafeKey` inside MemoryStore (saveEpisode /
+ *            searchEpisodes / listEpisodes / deleteEpisodes / profileDir /
+ *            legacyProfilePath) and `assertSafeJobId` inside job-store
+ *            (jobPath). Both throw a recognizable error before path.join
+ *            collapses `..` and lets a write/read escape the configured
+ *            baseDir.
+ *
+ * Tests cover the happy path (real Feishu id shapes pass) and the failure
+ * path (every traversal vector rejects).
+ */
+
+import fs from 'node:fs/promises';
+import { existsSync, mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { MemoryStore } from '../src/memory/file.js';
+import { LARK_ID_REGEX } from '../src/tools.js';
+
+function fail(msg: string): never {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+function freshStore(): { store: MemoryStore; baseDir: string } {
+  const baseDir = mkdtempSync(path.join(os.tmpdir(), 'lark-pathtrav-smoke-'));
+  return { store: new MemoryStore(baseDir), baseDir };
+}
+
+const BAD_IDS = [
+  '../escape',
+  '../../etc/passwd',
+  'foo/bar',
+  'foo\\bar',
+  '..',
+  '..\\..\\.ssh\\authorized_keys',
+  'oc_real\0null',
+  'foo\nbar',
+  'foo\rbar',
+  '\x01ctrl',
+  '', // empty
+  'a'.repeat(257), // too long
+];
+
+const GOOD_IDS = [
+  'oc_e9b5b07c890b4c80b9a2eb234a1234ab',
+  'om_xxx_yyy_zzz-123',
+  'omt_long_thread_id_2025',
+  'ou_user_open_id_alphanumeric',
+  'og_group_chat_5fa3b1',
+  'cli_msg_12345',
+  // synthetic cronjob thread ids use colon — accept under LARK_ID_REGEX (Tier-1 in tools.ts allows : explicitly)
+  'job-name-12345',
+];
+
+let testNum = 0;
+
+// 1. LARK_ID_REGEX rejects every traversal vector
+{
+  testNum++;
+  for (const id of BAD_IDS) {
+    if (LARK_ID_REGEX.test(id)) {
+      fail(`LARK_ID_REGEX should REJECT bad id "${id.slice(0, 40)}"`);
+    }
+  }
+}
+
+// 2. LARK_ID_REGEX accepts realistic Feishu id shapes
+{
+  testNum++;
+  for (const id of GOOD_IDS) {
+    if (!LARK_ID_REGEX.test(id)) {
+      fail(`LARK_ID_REGEX should ACCEPT good id "${id}"`);
+    }
+  }
+}
+
+// 3. saveEpisode rejects bad chatId — and the rejection happens BEFORE
+//    any file is written / dir is created. Pre-fix, the write succeeded
+//    at a path collapsed outside baseDir; post-fix, the throw happens
+//    first and the unsafe absolute path is never touched.
+{
+  testNum++;
+  const { store, baseDir } = freshStore();
+  let threw = false;
+  try {
+    await store.saveEpisode('chat', 'oops', { chatId: '../../tmp/escape' });
+  } catch (err) {
+    threw = true;
+    if (!String(err).match(/Invalid chatId/)) {
+      fail(`saveEpisode bad chatId: wrong error: ${String(err)}`);
+    }
+  }
+  if (!threw) fail('saveEpisode must throw on traversal chatId');
+
+  // No traversed file should exist anywhere outside baseDir.
+  // Spot-check the would-have-been target directory (resolved relative to
+  // baseDir to mimic Node's path.join collapse): under /tmp/escape we
+  // expect nothing because the throw fired first.
+  const wouldHaveTarget = path.resolve(baseDir, 'episodes', '../../tmp/escape');
+  if (existsSync(wouldHaveTarget)) {
+    // Defensive: tmp may already have unrelated content; only fail if a
+    // FRESH .md is there with our timestamp shape.
+    const files = await fs.readdir(wouldHaveTarget).catch(() => [] as string[]);
+    if (files.some((f) => f.endsWith('.md'))) {
+      fail(`saveEpisode wrote a file at ${wouldHaveTarget} despite the throw`);
+    }
+  }
+}
+
+// 4. saveEpisode rejects bad threadId (thread-typed path)
+{
+  testNum++;
+  const { store } = freshStore();
+  let threw = false;
+  try {
+    await store.saveEpisode('thread', 'oops', {
+      chatId: 'oc_safe_chat_id',
+      threadId: '../../../etc/cron.daily',
+    });
+  } catch (err) {
+    threw = true;
+    if (!String(err).match(/Invalid threadId/)) {
+      fail(`saveEpisode bad threadId: wrong error: ${String(err)}`);
+    }
+  }
+  if (!threw) fail('saveEpisode must throw on traversal threadId');
+}
+
+// 5. saveEpisode accepts realistic IDs and writes inside baseDir
+{
+  testNum++;
+  const { store, baseDir } = freshStore();
+  await store.saveEpisode('thread', 'hello', {
+    chatId: 'oc_real_chat',
+    threadId: 'omt_real_thread',
+  });
+  const targetDir = path.join(baseDir, 'episodes', 'oc_real_chat', 'threads', 'omt_real_thread');
+  if (!existsSync(targetDir)) fail('saveEpisode happy path did not create target dir');
+  const files = await fs.readdir(targetDir);
+  if (!files.some((f) => f.endsWith('.md'))) fail('saveEpisode happy path did not write any .md');
+}
+
+// 6. searchEpisodes rejects bad chatId (read-side defense)
+{
+  testNum++;
+  const { store } = freshStore();
+  let threw = false;
+  try {
+    await store.searchEpisodes('hello', { chatId: '../../etc' });
+  } catch (err) {
+    threw = true;
+    if (!String(err).match(/Invalid chatId/)) {
+      fail(`searchEpisodes bad chatId: wrong error: ${String(err)}`);
+    }
+  }
+  if (!threw) fail('searchEpisodes must throw on traversal chatId');
+}
+
+// 7. listEpisodes / deleteEpisodes reject bad ids
+{
+  testNum++;
+  const { store } = freshStore();
+  let listThrew = false;
+  try { await store.listEpisodes('../escape'); } catch { listThrew = true; }
+  if (!listThrew) fail('listEpisodes must throw on traversal chatId');
+
+  let delThrew = false;
+  try { await store.deleteEpisodes('../escape', ['x.md']); } catch { delThrew = true; }
+  if (!delThrew) fail('deleteEpisodes must throw on traversal chatId');
+
+  let delIdThrew = false;
+  try { await store.deleteEpisodes('oc_real', ['../../escape.md']); } catch { delIdThrew = true; }
+  if (!delIdThrew) fail('deleteEpisodes must throw on traversal episode id');
+}
+
+// 8. profileDir / getProfile reject bad userId (defense in depth — userId
+//    is server-derived, so this normally can't happen, but the storage
+//    contract should reject regardless).
+{
+  testNum++;
+  const { store } = freshStore();
+  let threw = false;
+  try {
+    await store.getProfile('../../etc/passwd', '../../etc/passwd');
+  } catch (err) {
+    threw = true;
+    if (!String(err).match(/Invalid userId/)) {
+      fail(`getProfile bad userId: wrong error: ${String(err)}`);
+    }
+  }
+  if (!threw) fail('getProfile must throw on traversal userId');
+}
+
+// 9. Job store: writeJob / deleteJob / readJob reject bad job ids
+{
+  testNum++;
+  const { writeJob, deleteJob, readJob } = await import('../src/job-store.js');
+
+  let writeThrew = false;
+  try {
+    await writeJob({
+      meta: {
+        id: '../../etc/cron.daily/payload',
+        name: 'evil',
+        type: 'message',
+        schedule: '* * * * *',
+        schedule_human: 'every min',
+        content: 'x',
+        msg_type: 'text',
+        target_chat_id: 'oc_x',
+        origin_chat_id: 'oc_x',
+        status: 'active',
+        created_by: 'ou_x',
+        created_at: '2026-01-01T00:00:00.000Z',
+      },
+      runtime: { last_run_at: null, next_run_at: '2026-01-01T00:01:00.000Z', run_count: 0, last_error: null },
+    });
+  } catch (err) {
+    writeThrew = true;
+    if (!String(err).match(/Invalid job id/)) fail(`writeJob: wrong error: ${err}`);
+  }
+  if (!writeThrew) fail('writeJob must throw on traversal id');
+
+  // readJob and deleteJob catch internally and return null/false rather
+  // than propagating; the path traversal STILL never executes a real
+  // fs.readFile / fs.unlink on the traversed path.
+  const bad = await readJob('../../etc/passwd');
+  if (bad !== null) fail('readJob must return null on traversal id');
+
+  const del = await deleteJob('../../etc/passwd');
+  if (del !== false) fail('deleteJob must return false on traversal id');
+}
+
+console.log(`path-traversal smoke: ${testNum}/${testNum} PASS`);

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -82,4 +82,8 @@ echo "=== Skill ownership unit checks ==="
 npx tsx scripts/skill-ownership-smoke.ts
 
 echo ""
+echo "=== Path-traversal defense unit checks ==="
+npx tsx scripts/path-traversal-smoke.ts
+
+echo ""
 echo "All tests passed."

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.14' },
+    { name: 'claude-lark-plugin', version: '1.0.15' },
     {
       capabilities: {
         logging: {},

--- a/src/job-store.ts
+++ b/src/job-store.ts
@@ -151,7 +151,33 @@ async function ensureJobsDir(): Promise<string> {
   return dir;
 }
 
+/**
+ * Defense layer 2 for #93 (path traversal). `create_job` derives `id`
+ * via {@link sanitizeJobId} so newly-created jobs are inherently safe,
+ * but `update_job` / `delete_job` accept an `id` from Claude directly
+ * (e.g. `z.string()` at the tool boundary — the Zod layer there caps
+ * the shape per `LARK_ID_REGEX` but this defense is the storage-layer
+ * contract). Without this, a stray `'../../etc/cron.daily/payload'`
+ * could become a `jobPath` outside `jobsDir` and the subsequent
+ * `fs.unlink` / `fs.writeFile` would escape the sandbox.
+ */
+function assertSafeJobId(id: string): void {
+  if (
+    !id ||
+    typeof id !== 'string' ||
+    id.length === 0 ||
+    id.length > 128 ||
+    id.includes('/') ||
+    id.includes('\\') ||
+    id.includes('..') ||
+    id.includes('\0')
+  ) {
+    throw new Error(`Invalid job id: "${String(id).slice(0, 64)}" — must be 1-128 chars without '/', '\\', '..', null.`);
+  }
+}
+
 function jobPath(id: string): string {
+  assertSafeJobId(id);
   return path.join(appConfig.jobsDir, `${id}.json`);
 }
 

--- a/src/memory/file.ts
+++ b/src/memory/file.ts
@@ -18,6 +18,41 @@ function lineHash(text: string): string {
   return createHash('sha1').update(text).digest('hex').slice(0, 8);
 }
 
+/**
+ * Defense layer 2 for #93 (path traversal via Claude-supplied chat/thread IDs).
+ *
+ * Zod regex at the tool boundary (`larkIdSchema` in tools.ts) is the
+ * primary defense — but anything that calls into `MemoryStore` from a
+ * non-tool path (cronjob runtime, dry-run, future code) bypasses Zod.
+ * This helper makes the constraint a property of the storage layer
+ * itself: any key destined to become a path component is rejected here
+ * if it contains a separator, parent-traversal, NUL, or control byte
+ * BEFORE it reaches `path.join` (which silently *collapses* `..`
+ * rather than rejecting it — the precise hazard #93 exploits).
+ *
+ * Note: separately from path safety, callers like `saveEpisode` that
+ * accept `chatId` from authenticated identity context don't NEED this
+ * check (the value already came from a Feishu webhook payload), but
+ * apply it anyway to keep the storage layer's contract self-defending.
+ */
+function assertSafeKey(key: string, field: string): void {
+  if (
+    !key ||
+    typeof key !== 'string' ||
+    key.length > 256 ||
+    key.includes('/') ||
+    key.includes('\\') ||
+    key.includes('..') ||
+    key.includes('\0') ||
+    // eslint-disable-next-line no-control-regex
+    /[\x00-\x1f]/.test(key)
+  ) {
+    throw new Error(
+      `Invalid ${field}: "${key.slice(0, 64)}${key.length > 64 ? '…' : ''}" — must not contain '/', '\\', '..', null/control bytes, and must be 1-256 chars.`,
+    );
+  }
+}
+
 /** Normalize a profile line for deduplication (not for storage). */
 function normalizeProfileLine(line: string): string {
   return line.trim().replace(/^[-*]\s+/, '').toLowerCase();
@@ -136,6 +171,10 @@ export class MemoryStore {
   // ── User Profile (tiered, v0.10.0+) ──
 
   private profileDir(userId: string): string {
+    // userId is server-derived (caller open_id from authenticated Feishu
+    // session) so it should never carry separators, but #93 motivates
+    // defense-in-depth on every path-building site.
+    assertSafeKey(userId, 'userId');
     return path.join(this.baseDir, 'profiles', userId);
   }
 
@@ -144,6 +183,7 @@ export class MemoryStore {
   }
 
   private legacyProfilePath(userId: string): string {
+    assertSafeKey(userId, 'userId');
     return path.join(this.baseDir, 'profiles', `${userId}.md`);
   }
 
@@ -419,6 +459,14 @@ export class MemoryStore {
   ): Promise<Episode[]> {
     if (!scope?.chatId) return [];
 
+    // Defense layer 2 against #93 path traversal — assert before path.join.
+    // Read paths must guard too: even though listing/reading malformed
+    // paths can't *write* outside baseDir, a traversal in `chatId` could
+    // exfiltrate the *existence* of files elsewhere (return their contents
+    // if they happen to look like episodes), leaking server info.
+    assertSafeKey(scope.chatId, 'chatId');
+    if (scope.threadId) assertSafeKey(scope.threadId, 'threadId');
+
     const dir = scope.threadId
       ? path.join(this.baseDir, 'episodes', scope.chatId, 'threads', scope.threadId)
       : path.join(this.baseDir, 'episodes', scope.chatId);
@@ -481,6 +529,10 @@ export class MemoryStore {
     content: string,
     meta: EpisodeMeta
   ): Promise<void> {
+    // Defense layer 2 against #93 path traversal — assert before path.join.
+    assertSafeKey(meta.chatId, 'chatId');
+    if (meta.threadId) assertSafeKey(meta.threadId, 'threadId');
+
     const dir =
       type === 'thread' && meta.threadId
         ? path.join(this.baseDir, 'episodes', meta.chatId, 'threads', meta.threadId)
@@ -494,6 +546,7 @@ export class MemoryStore {
   }
 
   async listEpisodes(chatId: string): Promise<Episode[]> {
+    assertSafeKey(chatId, 'chatId');
     const dir = path.join(this.baseDir, 'episodes', chatId);
     try {
       const files = await fs.readdir(dir);
@@ -519,8 +572,13 @@ export class MemoryStore {
   }
 
   async deleteEpisodes(chatId: string, ids: string[]): Promise<void> {
+    assertSafeKey(chatId, 'chatId');
     const dir = path.join(this.baseDir, 'episodes', chatId);
     for (const id of ids) {
+      // Episode IDs are server-generated filenames (timestamp.md) but the
+      // delete API takes them as opaque strings, so apply the same guard —
+      // a caller could pass `../../etc/passwd.md` and otherwise unlink it.
+      assertSafeKey(id, 'episode id');
       try {
         await fs.unlink(path.join(dir, id));
       } catch {

--- a/src/memory/file.ts
+++ b/src/memory/file.ts
@@ -36,10 +36,16 @@ function lineHash(text: string): string {
  * apply it anyway to keep the storage layer's contract self-defending.
  */
 function assertSafeKey(key: string, field: string): void {
+  // Length cap 255 matches POSIX NAME_MAX / macOS HFS+/APFS per-component
+  // limit. Beyond that, `fs.mkdir`/`writeFile` would throw ENAMETOOLONG —
+  // we'd rather surface a clear "Invalid <field>" upstream than a syscall
+  // error. Tool-boundary `LARK_ID_REGEX` caps at 128 (well within NAME_MAX),
+  // so the larger 255 here is reachable only from non-tool callers and
+  // serves as a final storage-layer guard.
   if (
     !key ||
     typeof key !== 'string' ||
-    key.length > 256 ||
+    key.length > 255 ||
     key.includes('/') ||
     key.includes('\\') ||
     key.includes('..') ||
@@ -48,7 +54,7 @@ function assertSafeKey(key: string, field: string): void {
     /[\x00-\x1f]/.test(key)
   ) {
     throw new Error(
-      `Invalid ${field}: "${key.slice(0, 64)}${key.length > 64 ? '…' : ''}" — must not contain '/', '\\', '..', null/control bytes, and must be 1-256 chars.`,
+      `Invalid ${field}: "${key.slice(0, 64)}${key.length > 64 ? '…' : ''}" — must not contain '/', '\\', '..', null/control bytes, and must be 1-255 chars.`,
     );
   }
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -15,6 +15,43 @@ import { JOB_THREAD_PREFIX } from './scheduler.js';
 import { writeSdkResource } from './sdk-resource.js';
 
 /**
+ * Format regex for Feishu chat / thread / message / user IDs.
+ *
+ * Feishu IDs are short ASCII tokens with a prefix (`oc_`, `om_`, `omt_`,
+ * `ou_`, `og_`, `cli_msg_`, etc.) followed by alphanumerics. This regex
+ * permits the union of all currently-observed shapes plus a generous
+ * upper bound, and **rejects** anything containing path separators,
+ * dot-dot, null bytes, whitespace, or any other character that would let
+ * a Claude-supplied ID escape the storage hierarchy when joined into a
+ * filesystem path (`saveEpisode` etc., see #93).
+ *
+ * Defense layer 1 of 2 — Zod-level rejection at the tool boundary.
+ * Layer 2 lives inside `MemoryStore.assertSafeKey` so a future
+ * code path that bypasses the schema (or a deserialization quirk)
+ * still cannot land bytes outside `baseDir`.
+ *
+ * Two special-case exemptions on top of the base regex:
+ * - cronjob-synthetic `thread_id`s prefixed `JOB_THREAD_PREFIX` (see
+ *   src/scheduler.ts) — they contain colons in the iso-ish timestamp.
+ *   We exempt them by accepting `:` as well; they never reach the file
+ *   layer because cronjob notifications don't trigger save_memory's
+ *   thread path (the flush handler uses chat_type='system' which the
+ *   distillation prompt also restricts to type=chat|thread, not profile).
+ * - the reserved sentinel `__terminal__` (`TERMINAL_CHAT_ID`) used by
+ *   terminal-side skills — exempt because it never lands as a directory
+ *   name (`resolveCaller` short-circuits to OWNER, and OWNER's userId
+ *   is the path component, not the sentinel chat_id).
+ *
+ * The final form: alphanumeric + `_` + `-` + `:`, 1..128 chars.
+ */
+export const LARK_ID_REGEX = /^[A-Za-z0-9_:-]{1,128}$/;
+
+const larkIdSchema = (label: string) =>
+  z
+    .string()
+    .regex(LARK_ID_REGEX, `Invalid ${label}: must be 1-128 chars of [A-Za-z0-9_:-]`);
+
+/**
  * Sanitize and length-cap a Feishu attachment filename for safe local
  * storage. Path-basename strips any directory prefix, regex replaces
  * non-`\w.-` chars (including spaces, CJK, special punctuation) with
@@ -144,7 +181,7 @@ export function registerTools(
       description:
         'Send a reply to a Feishu chat. Plain text by default; long or markdown-rich content auto-renders as a Feishu card. Pass "card" param with raw Schema 2.0 JSON to send a pre-built card directly.',
       inputSchema: z.object({
-        chat_id: z.string().describe('The chat ID to reply in'),
+        chat_id: larkIdSchema('chat_id').describe('The chat ID to reply in'),
         text: z.string().describe('The text content to send (ignored when card is provided)'),
         card: z
           .string()
@@ -152,9 +189,8 @@ export function registerTools(
           .describe(
             'Raw Feishu Schema 2.0 card JSON string. When provided, sends the card directly without buildCards conversion. Use this for pre-built cards from scripts/skills.'
           ),
-        reply_to: z.string().optional().describe('Message ID to reply to (quoted reply)'),
-        thread_id: z
-          .string()
+        reply_to: larkIdSchema('reply_to').optional().describe('Message ID to reply to (quoted reply)'),
+        thread_id: larkIdSchema('thread_id')
           .optional()
           .describe(
             'Thread ID from the <channel> meta. Pass this when replying to a threaded message — the plugin will auto-fill reply_to if you omit it, ensuring the reply lands in the correct thread.'
@@ -455,7 +491,7 @@ export function registerTools(
     {
       description: 'Edit a previously sent bot message (text or card_markdown).',
       inputSchema: z.object({
-        message_id: z.string().describe('The message ID to edit'),
+        message_id: larkIdSchema('message_id').describe('The message ID to edit'),
         text: z.string().describe('New content'),
         format: z
           .enum(['text', 'card_markdown'])
@@ -495,7 +531,7 @@ export function registerTools(
     {
       description: 'Add an emoji reaction to a message.',
       inputSchema: z.object({
-        message_id: z.string().describe('The message ID to react to'),
+        message_id: larkIdSchema('message_id').describe('The message ID to react to'),
         emoji: z.string().describe('Emoji type (e.g., "THUMBSUP", "SMILE", "HEART")'),
       }),
     },
@@ -520,7 +556,7 @@ export function registerTools(
       description:
         'Download an attachment (image, file, audio, video) from a message to local inbox. Pass file_name from the inbound notification\'s meta.attachment_name so the saved file keeps its original extension — Claude Read needs the extension to infer MIME type for PDF/text.',
       inputSchema: z.object({
-        message_id: z.string().describe('The message ID containing the attachment'),
+        message_id: larkIdSchema('message_id').describe('The message ID containing the attachment'),
         file_key: z.string().describe('The file key of the attachment'),
         file_name: z
           .string()
@@ -618,9 +654,8 @@ export function registerTools(
           ),
         content: z.string().describe('The memory content to save (concise, factual)'),
         reason: z.string().describe('Why this is worth remembering'),
-        chat_id: z.string().describe('Chat ID — required; also used to resolve caller identity'),
-        thread_id: z
-          .string()
+        chat_id: larkIdSchema('chat_id').describe('Chat ID — required; also used to resolve caller identity'),
+        thread_id: larkIdSchema('thread_id')
           .optional()
           .describe(
             'Thread ID from the current notification\'s metadata. Required whenever present — both for server-side caller resolution (omitting it silently attributes the call to the wrong user in cronjob turns) and when type="thread".'
@@ -714,8 +749,8 @@ export function registerTools(
         name: z.string().describe('Short skill name (e.g., "deploy-service"). Normalized to a slug (lowercase, non-alphanumeric → "-"). Must contain at least one alphanumeric character.'),
         description: z.string().describe('One-line description of what this skill does'),
         content: z.string().describe('The full procedure/instructions'),
-        chat_id: z.string().describe('Chat ID from the inbound notification — required for caller authorization'),
-        thread_id: z.string().optional().describe('Thread ID from the inbound notification — pass verbatim when present'),
+        chat_id: larkIdSchema('chat_id').describe('Chat ID from the inbound notification — required for caller authorization'),
+        thread_id: larkIdSchema('thread_id').optional().describe('Thread ID from the inbound notification — pass verbatim when present'),
       }),
     },
     async ({ name, description, content, chat_id, thread_id }) => {
@@ -769,18 +804,15 @@ export function registerTools(
           .string()
           .optional()
           .describe('Fixed message content (type=message)'),
-        target_chat_id: z
-          .string()
+        target_chat_id: larkIdSchema('target_chat_id')
           .describe('Chat ID that receives job output. Used by scheduler delivery and list_jobs visibility filter.'),
         model: z
           .string()
           .optional()
           .describe('Model override for prompt-type jobs (e.g. "sonnet", "haiku", "opus"). When set, the subagent executing this job uses the specified model instead of the default.'),
-        chat_id: z
-          .string()
+        chat_id: larkIdSchema('chat_id')
           .describe('Chat ID where this create_job call was triggered — used to resolve caller identity and to populate origin_chat_id'),
-        thread_id: z
-          .string()
+        thread_id: larkIdSchema('thread_id')
           .optional()
           .describe(
             'Thread ID from the current notification\'s metadata. Required whenever present — the server resolves caller identity from (chat_id, thread_id); omitting it falls back to chat-level and will silently attribute the call to the wrong user in cronjob turns.'
@@ -888,9 +920,8 @@ export function registerTools(
           .optional()
           .default('all')
           .describe('Filter by status'),
-        chat_id: z.string().describe('Chat ID where this list call is acting from'),
-        thread_id: z
-          .string()
+        chat_id: larkIdSchema('chat_id').describe('Chat ID where this list call is acting from'),
+        thread_id: larkIdSchema('thread_id')
           .optional()
           .describe(
             'Thread ID from the current notification\'s metadata. Required whenever present — the server resolves caller identity from (chat_id, thread_id); omitting it falls back to chat-level and will silently attribute the call to the wrong user in cronjob turns.'
@@ -965,9 +996,8 @@ export function registerTools(
           .string()
           .optional()
           .describe('Model override for prompt-type jobs (e.g. "sonnet", "haiku", "opus"). Pass empty string to clear.'),
-        chat_id: z.string().describe('Chat ID where this update call is acting from'),
-        thread_id: z
-          .string()
+        chat_id: larkIdSchema('chat_id').describe('Chat ID where this update call is acting from'),
+        thread_id: larkIdSchema('thread_id')
           .optional()
           .describe(
             'Thread ID from the current notification\'s metadata. Required whenever present — the server resolves caller identity from (chat_id, thread_id); omitting it falls back to chat-level and will silently attribute the call to the wrong user in cronjob turns.'
@@ -1058,9 +1088,8 @@ export function registerTools(
       description: 'Delete a cronjob permanently. Only the job owner can delete.',
       inputSchema: z.object({
         id: z.string().describe('Job ID to delete'),
-        chat_id: z.string().describe('Chat ID where this delete call is acting from'),
-        thread_id: z
-          .string()
+        chat_id: larkIdSchema('chat_id').describe('Chat ID where this delete call is acting from'),
+        thread_id: larkIdSchema('thread_id')
           .optional()
           .describe(
             'Thread ID from the current notification\'s metadata. Required whenever present — the server resolves caller identity from (chat_id, thread_id); omitting it falls back to chat-level and will silently attribute the call to the wrong user in cronjob turns.'
@@ -1114,9 +1143,8 @@ export function registerTools(
       description:
         "List what the bot has stored in the caller's profile. Output is filtered by current-chat rendering visibility (path B): in a private chat both public and private tiers are rendered; in a group chat only the public tier — because the reply is visible to the whole group. Each returned line has a short hash that forget_memory uses to target the exact line.",
       inputSchema: z.object({
-        chat_id: z.string().describe('Chat ID where this call is acting from'),
-        thread_id: z
-          .string()
+        chat_id: larkIdSchema('chat_id').describe('Chat ID where this call is acting from'),
+        thread_id: larkIdSchema('thread_id')
           .optional()
           .describe(
             'Thread ID from the current notification\'s metadata. Required whenever present — the server resolves caller identity from (chat_id, thread_id); omitting it falls back to chat-level and will silently attribute the call to the wrong user in cronjob turns.'
@@ -1164,9 +1192,8 @@ export function registerTools(
       description:
         "Remove a specific line from the caller's profile. Always caller-scoped — you can only forget things about yourself. Optionally promotes the removed line into a persistent L2 rule so future distillations classify similar content as private.",
       inputSchema: z.object({
-        chat_id: z.string().describe('Chat ID where this call is acting from'),
-        thread_id: z
-          .string()
+        chat_id: larkIdSchema('chat_id').describe('Chat ID where this call is acting from'),
+        thread_id: larkIdSchema('thread_id')
           .optional()
           .describe(
             'Thread ID from the current notification\'s metadata. Required whenever present — the server resolves caller identity from (chat_id, thread_id); omitting it falls back to chat-level and will silently attribute the call to the wrong user in cronjob turns.'

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -557,7 +557,7 @@ export function registerTools(
         'Download an attachment (image, file, audio, video) from a message to local inbox. Pass file_name from the inbound notification\'s meta.attachment_name so the saved file keeps its original extension — Claude Read needs the extension to infer MIME type for PDF/text.',
       inputSchema: z.object({
         message_id: larkIdSchema('message_id').describe('The message ID containing the attachment'),
-        file_key: z.string().describe('The file key of the attachment'),
+        file_key: larkIdSchema('file_key').describe('The file key of the attachment'),
         file_name: z
           .string()
           .optional()
@@ -986,7 +986,7 @@ export function registerTools(
       description:
         'Update a cronjob — change schedule, content, pause, or resume. Only the job owner can mutate a job.',
       inputSchema: z.object({
-        id: z.string().describe('Job ID'),
+        id: larkIdSchema('id').describe('Job ID'),
         status: z.enum(['active', 'paused']).optional().describe('Set status'),
         schedule: z.string().optional().describe('New cron expression or alias'),
         prompt: z.string().optional().describe('New prompt (type=prompt)'),
@@ -1087,7 +1087,7 @@ export function registerTools(
     {
       description: 'Delete a cronjob permanently. Only the job owner can delete.',
       inputSchema: z.object({
-        id: z.string().describe('Job ID to delete'),
+        id: larkIdSchema('id').describe('Job ID to delete'),
         chat_id: larkIdSchema('chat_id').describe('Chat ID where this delete call is acting from'),
         thread_id: larkIdSchema('thread_id')
           .optional()


### PR DESCRIPTION
## Summary
- Closes #93 (**CRITICAL — arbitrary file write**). Plain `z.string()` on `chat_id` / `thread_id` / `message_id` / `target_chat_id` / `reply_to` / job `id` let Claude-supplied `..` payloads escape `baseDir` via `path.join` collapse. A `thread_id='../../../../tmp/escape'` to `save_memory(type='thread')` wrote `/tmp/escape/<timestamp>.md`. `update_job` / `delete_job` had the analogous arbitrary-`fs.unlink` issue outside `jobsDir`.
- Two independent layers added: tool-boundary regex (\`LARK_ID_REGEX = /^[A-Za-z0-9_:-]{1,128}$/\`) and storage-layer assertions (\`assertSafeKey\` in MemoryStore, \`assertSafeJobId\` in job-store) before any \`path.join\`.

## Files
- \`src/tools.ts\` — new \`LARK_ID_REGEX\` + \`larkIdSchema()\` helper; applied to every \`chat_id\` / \`thread_id\` / \`message_id\` / \`target_chat_id\` / \`reply_to\` in all 12 tools.
- \`src/memory/file.ts\` — new \`assertSafeKey\` (control bytes + traversal + length + NUL); wired into \`saveEpisode\`, \`searchEpisodes\`, \`listEpisodes\`, \`deleteEpisodes\`, \`profileDir\`, \`legacyProfilePath\`.
- \`src/job-store.ts\` — new \`assertSafeJobId\`; wired into \`jobPath\`.
- \`scripts/path-traversal-smoke.ts\` — 9 new assertions (regex shape, every traversal vector rejected, happy-path Feishu IDs pass, both layers verified on all entry points).
- Version 1.0.15 across 5 files; CHANGELOG entry.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 9/9 path-traversal, 19/19 skill ownership, 10/10 identity, 30/30 profile-tier, all other suites unchanged
- [x] Reviewed: real Feishu IDs (\`oc_*\`, \`om_*\`, \`omt_*\`, \`ou_*\`, \`og_*\`, \`cli_msg_*\`, cronjob-synthetic \`job-...:<iso>\`) all match \`LARK_ID_REGEX\`; the colon exemption is documented inline.
- [ ] Operator-verified: bot continues handling real inbound messages after upgrade (regex doesn't false-positive on production Feishu IDs).

## Threat model
Pre-fix exploit chain: any user in a group → @bot with prompt-inject text → Claude calls \`save_memory(type='thread', thread_id='../../tmp/x', content=...)\` → file written under \`/tmp/x/<timestamp>.md\`. Combined with #94 (vulnerable transitive deps including SSRF), this was a viable horizontal-movement footprint. Closed by the storage-layer guard regardless of tool-boundary regex (defense in depth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)