### PR TITLE
fix(memory): forget_memory reports multi-delete count when hash collides (#88, v1.0.19)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
   Fix:
   - `MemoryStore.removeProfileLine(ownerId, tier, hash)` now returns `{ removed: number, sample: string | null, allTexts: string[] }` instead of a bare boolean.
-  - `forget_memory` tool reply branches on `removed`: singular `Removed "<text>" from ${tier} profile.` when 1, plural `Removed N lines sharing hash "${hash}" from ${tier} profile (sample: "<text>"). If only one of these was the intended target, run what_do_you_know and re-add the others with save_memory.` when ≥2.
-  - `promote_to_rule=true` uses the sample text for the L2 rule append (the colliding texts are normalized-equal so the sample is representative — operator is told the count and can manually add other variants if needed).
+  - `forget_memory` tool reply (via the new pure `formatForgetMemoryReply` helper) branches on `removed`: singular `Removed "<text>" from ${tier} profile.` when 1; plural lists every removed text inline as a numbered list followed by a `save_memory(type="profile", tier=..., mode="append", content=...)` recovery hint, so the operator can copy-paste any unintended losses back. R1 audit caught that the intermediate format (count + sample only) had a misleading recovery hint pointing at `what_do_you_know` — which can't show texts that were just deleted.
+  - `promote_to_rule=true` uses the sample text for the L2 rule append (the colliding texts are normalized-equal so the sample is representative); when `removed > 1`, the tail also warns "rule seeded from the sample text only; multiple lines were removed, so review whether other variants should also be added manually." If `addL2Rule` itself throws, the L2 warning takes precedence (single warning per reply).
+  - Audit log records the actual `removed` count so the trail shows the scope of every invocation, not just ok/denied.
 
 ### Added
 - 1 new transparency-smoke assertion (#5b) covering the multi-delete path: two normalized-equal lines pre-populated via `mode='replace'` (bypasses `mergeProfileLines` dedup), `removeProfileLine` reports `removed: 2`, file ends empty, `allTexts` carries both originals.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - 1 new transparency-smoke assertion (#5b) covering the multi-delete path: two normalized-equal lines pre-populated via `mode='replace'` (bypasses `mergeProfileLines` dedup), `removeProfileLine` reports `removed: 2`, file ends empty, `allTexts` carries both originals.
 - Existing transparency tests updated to assert the new return shape (`result.removed === N` instead of `if (!ok)`).
 - Existing profile-tier test 14 updated to the new shape.
-- Transparency suite total: 9 → 10.
+- Transparency suite total: 9 → 11.
+
+### R1-audit followups (closed in this PR)
+- **Plural reply now lists every removed text inline** with a numbered list, so the operator can copy-paste any unintended losses back via `save_memory(mode='append')`. Pre-followup the reply named the count + sample but the recovery hint ("run what_do_you_know and re-add the others") was misleading — `what_do_you_know` cannot show texts that were just deleted.
+- **`promote_to_rule=true` + multi-delete now emits a warning** in the tail: "rule seeded from the sample text only; multiple lines were removed, so review whether other variants should also be added manually." Prevents the operator from accidentally over-broadening L2 rules based on collision-driven multi-deletes.
+- **Audit log records `removed` count** in the args dict, so the audit trail shows the actual scope of each `forget_memory` invocation (not just ok/denied).
+- **Tool description updated** to surface the possible multi-delete and the recovery path. Claude reads tool descriptions; this lets it warn proactively rather than confronting an unexpected plural reply post-hoc.
+- **Extracted `formatForgetMemoryReply` as a pure exported function** so the singular/plural branch logic is unit-testable without standing up the MCP server. New transparency test #5a-tool covers the formatter directly.
 
 ### Operator notes
 - Existing on-disk profiles MAY contain hash collisions from past `save_memory` patterns. Calling `forget_memory` on a colliding hash now reports the count and a sample — if more than 1 was unintentionally swept, the operator can spot it in the reply text and recover via `save_memory(type='profile', tier, mode='append', content=...)` for the lost lines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.19] - 2026-05-25
+
+### Fixed
+- **`forget_memory` no longer silently deletes multiple lines that share an 8-char hash** (#88 — **MEDIUM, silent data loss**). Pre-v1.0.19 `MemoryStore.removeProfileLine` used `filter(l => l.hash !== hash)` which strips **every** matching line in one pass, but the tool reply was hardcoded singular `Removed "<text>" from <tier> profile.` — so a multi-delete was invisible to the operator. Collisions happen naturally (multiple `save_memory(profile, content="prefers tea", mode="append")` calls with mixed bullet formatting normalize to the same key after `listProfileLines`' bullet-strip) and could be triggered adversarially (8-char sha1 prefix is 32 bits — birthday paradox at ~77k lines, well above realistic profile size for an honest user but exploitable in principle).
+
+  Fix:
+  - `MemoryStore.removeProfileLine(ownerId, tier, hash)` now returns `{ removed: number, sample: string | null, allTexts: string[] }` instead of a bare boolean.
+  - `forget_memory` tool reply branches on `removed`: singular `Removed "<text>" from ${tier} profile.` when 1, plural `Removed N lines sharing hash "${hash}" from ${tier} profile (sample: "<text>"). If only one of these was the intended target, run what_do_you_know and re-add the others with save_memory.` when ≥2.
+  - `promote_to_rule=true` uses the sample text for the L2 rule append (the colliding texts are normalized-equal so the sample is representative — operator is told the count and can manually add other variants if needed).
+
+### Added
+- 1 new transparency-smoke assertion (#5b) covering the multi-delete path: two normalized-equal lines pre-populated via `mode='replace'` (bypasses `mergeProfileLines` dedup), `removeProfileLine` reports `removed: 2`, file ends empty, `allTexts` carries both originals.
+- Existing transparency tests updated to assert the new return shape (`result.removed === N` instead of `if (!ok)`).
+- Existing profile-tier test 14 updated to the new shape.
+- Transparency suite total: 9 → 10.
+
+### Operator notes
+- Existing on-disk profiles MAY contain hash collisions from past `save_memory` patterns. Calling `forget_memory` on a colliding hash now reports the count and a sample — if more than 1 was unintentionally swept, the operator can spot it in the reply text and recover via `save_memory(type='profile', tier, mode='append', content=...)` for the lost lines.
+- A future release may switch to per-line index-prefixed identifiers (e.g. `i17:abc12345`) to eliminate collisions entirely — would require updating `what_do_you_know`'s line-id rendering and `forget_memory`'s hash parameter semantics. Tracked separately if needed.
+
 ## [1.0.18] - 2026-05-25
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/profile-tier-smoke.ts
+++ b/scripts/profile-tier-smoke.ts
@@ -310,8 +310,8 @@ passed++;
   await s.saveProfile('ou_rm', '- first\nsecond\n- third', 'private', 'replace');
   const listed = await s.listProfileLines('ou_rm', 'private');
   const secondHash = listed.find((l) => l.text === 'second')!.hash;
-  const ok = await s.removeProfileLine('ou_rm', 'private', secondHash);
-  if (!ok) fail('14: removeProfileLine should report success');
+  const result = await s.removeProfileLine('ou_rm', 'private', secondHash);
+  if (result.removed !== 1) fail(`14: removeProfileLine should report removed=1, got ${result.removed}`);
   const body = readFileSync(join(r, 'profiles', 'ou_rm', 'private.md'), 'utf-8');
   // Remaining lines should both carry bullets now
   if (body !== '- first\n- third\n') fail(`14: expected bullet-normalized rewrite, got ${JSON.stringify(body)}`);

--- a/scripts/transparency-smoke.ts
+++ b/scripts/transparency-smoke.ts
@@ -94,6 +94,63 @@ let passed = 0;
   passed++;
 }
 
+// ── 5a-tool. formatForgetMemoryReply singular vs plural (#88 R1) ──
+//   Pure-function test of the reply-text branch logic the tool handler
+//   uses. Pre-extraction, the singular/plural split was inline in the
+//   handler and untested at unit level; a future regression flipping
+//   the branches would not have been caught by the storage-layer tests.
+{
+  const { formatForgetMemoryReply } = await import('../src/tools.js');
+
+  // Singular path: removed=1, no tail.
+  const singular = formatForgetMemoryReply(
+    { removed: 1, sample: 'likes Python', allTexts: ['likes Python'] },
+    'abc12345',
+    'public',
+    '',
+  );
+  if (!singular.startsWith('Removed "likes Python" from public profile.')) {
+    fail(`tool-fmt singular: got ${JSON.stringify(singular)}`);
+  }
+  if (singular.includes('lines sharing hash')) {
+    fail(`tool-fmt singular leaked plural wording: ${singular}`);
+  }
+
+  // Plural path: removed=3, all texts listed numbered, recovery hint
+  // names the tier and append mode.
+  const plural = formatForgetMemoryReply(
+    {
+      removed: 3,
+      sample: 'prefers tea',
+      allTexts: ['prefers tea', 'prefers tea', 'prefers tea'],
+    },
+    'deadbeef',
+    'private',
+    '',
+  );
+  if (!plural.includes('Removed 3 lines sharing hash "deadbeef" from private profile:')) {
+    fail(`tool-fmt plural header missing: ${plural}`);
+  }
+  if (!plural.includes('  1) "prefers tea"') || !plural.includes('  3) "prefers tea"')) {
+    fail(`tool-fmt plural numbered list missing: ${plural}`);
+  }
+  if (!plural.includes('save_memory(type="profile", tier="private", mode="append"')) {
+    fail(`tool-fmt plural recovery hint wrong tier/mode: ${plural}`);
+  }
+
+  // Tail append: singular + promote_to_rule tail.
+  const singularTail = formatForgetMemoryReply(
+    { removed: 1, sample: 'foo', allTexts: ['foo'] },
+    'h',
+    'private',
+    ' Also appended to privacy-rules.md.',
+  );
+  if (!singularTail.endsWith(' Also appended to privacy-rules.md.')) {
+    fail(`tool-fmt singular tail not preserved: ${singularTail}`);
+  }
+  passed++;
+}
+
 // ── 5b. removeProfileLine reports count when multiple lines share a hash (#88) ──
 //   Two lines with normalized-identical text ("prefers tea" with and
 //   without leading bullet, after listProfileLines strips bullets)
@@ -172,4 +229,4 @@ let passed = 0;
 }
 
 rmSync(tmp, { recursive: true, force: true });
-console.log(`transparency smoke: ${passed}/10 PASS`);
+console.log(`transparency smoke: ${passed}/11 PASS`);

--- a/scripts/transparency-smoke.ts
+++ b/scripts/transparency-smoke.ts
@@ -50,11 +50,16 @@ let passed = 0;
 }
 
 // ── 3. removeProfileLine by hash ──
+//   v1.0.19 (#88): return shape changed from boolean to
+//   { removed: number, sample: string|null, allTexts: string[] } so the
+//   tool reply can name the count when a hash collides across multiple
+//   lines. Single-match path returns { removed: 1, ... }.
 {
   const lines = await store.listProfileLines('ou_a', 'public');
   const target = lines[1]; // "- second"
-  const ok = await store.removeProfileLine('ou_a', 'public', target.hash);
-  if (!ok) fail('3: remove should succeed');
+  const result = await store.removeProfileLine('ou_a', 'public', target.hash);
+  if (result.removed !== 1) fail(`3: remove should report 1, got ${result.removed}`);
+  if (result.sample !== target.text) fail(`3: sample mismatch: ${result.sample}`);
 
   const after = await store.listProfileLines('ou_a', 'public');
   if (after.length !== 2) fail(`3: expected 2 lines after remove, got ${after.length}`);
@@ -66,8 +71,9 @@ let passed = 0;
 {
   const lines = await store.listProfileLines('ou_a', 'public');
   const removedHash = 'deadbeef'; // not present
-  const ok = await store.removeProfileLine('ou_a', 'public', removedHash);
-  if (ok) fail('4: removing a non-existent hash should return false');
+  const result = await store.removeProfileLine('ou_a', 'public', removedHash);
+  if (result.removed !== 0) fail(`4: non-existent hash should report removed=0, got ${result.removed}`);
+  if (result.sample !== null) fail(`4: non-existent hash should have null sample, got ${result.sample}`);
   const after = await store.listProfileLines('ou_a', 'public');
   if (after.length !== lines.length) fail('4: removing a non-existent hash should not mutate');
   passed++;
@@ -80,11 +86,35 @@ let passed = 0;
   const pubLines = await store.listProfileLines('ou_b', 'public');
   const privHash = (await store.listProfileLines('ou_b', 'private'))[0].hash;
 
-  const okCross = await store.removeProfileLine('ou_b', 'public', privHash);
-  if (okCross) fail('5: private-tier hash must not match against public tier');
+  const cross = await store.removeProfileLine('ou_b', 'public', privHash);
+  if (cross.removed !== 0) fail(`5: private-tier hash must not match against public tier, got removed=${cross.removed}`);
 
   const pubAfter = await store.listProfileLines('ou_b', 'public');
   if (pubAfter.length !== pubLines.length) fail('5: cross-tier call must not mutate public');
+  passed++;
+}
+
+// ── 5b. removeProfileLine reports count when multiple lines share a hash (#88) ──
+//   Two lines with normalized-identical text ("prefers tea" with and
+//   without leading bullet, after listProfileLines strips bullets)
+//   compute to the same 8-char hash. forget_memory pre-v1.0.19 returned
+//   `Removed "<text>"` — singular — hiding the multi-delete entirely.
+//   v1.0.19 returns count + sample so the tool can warn the user.
+{
+  // Construct file with two normalized-equal lines. Using replace mode
+  // bypasses mergeProfileLines' dedup, so both lines persist on disk.
+  await store.saveProfile('ou_dup', '- prefers tea\nprefers tea\n', 'private', 'replace');
+  const lines = await store.listProfileLines('ou_dup', 'private');
+  if (lines.length !== 2) fail(`5b: expected 2 lines pre-delete, got ${lines.length}`);
+  // Both lines must hash-equal.
+  if (lines[0].hash !== lines[1].hash) fail('5b: setup failed — duplicate lines should hash-equal');
+  const result = await store.removeProfileLine('ou_dup', 'private', lines[0].hash);
+  if (result.removed !== 2) fail(`5b: expected removed=2, got ${result.removed}`);
+  if (result.sample !== 'prefers tea') fail(`5b: sample wrong: ${result.sample}`);
+  if (result.allTexts.length !== 2) fail(`5b: allTexts should have 2 entries, got ${result.allTexts.length}`);
+  // File should be empty (both lines removed).
+  const after = await store.listProfileLines('ou_dup', 'private');
+  if (after.length !== 0) fail(`5b: file should be empty after multi-delete, got ${after.length}`);
   passed++;
 }
 
@@ -142,4 +172,4 @@ let passed = 0;
 }
 
 rmSync(tmp, { recursive: true, force: true });
-console.log(`transparency smoke: ${passed}/9 PASS`);
+console.log(`transparency smoke: ${passed}/10 PASS`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.18' },
+    { name: 'claude-lark-plugin', version: '1.0.19' },
     {
       capabilities: {
         logging: {},

--- a/src/memory/file.ts
+++ b/src/memory/file.ts
@@ -438,23 +438,40 @@ export class MemoryStore {
   }
 
   /**
-   * Remove a single line (identified by its hash from {@link listProfileLines})
-   * from the given tier file. Returns true if a line was removed, false if
-   * nothing matched. Idempotent — removing the same hash twice returns false
-   * on the second call.
+   * Remove every line whose 8-char hash matches `hash` from the given
+   * tier file (#88). Returns the count of removed lines AND a sample of
+   * the removed text so the caller can surface a faithful confirmation
+   * message: an 8-char sha1 prefix can collide across duplicates of the
+   * same fact ("prefers tea" written twice with different bullet
+   * formatting normalizes to the same key) OR via birthday paradox on
+   * adversarial input. Pre-v1.0.19 the tool reply hardcoded singular
+   * `Removed "<text>" from ...` regardless of how many lines vanished
+   * — silent multi-delete with no operator-visible signal.
    *
-   * The rewritten file is bullet-normalized: every remaining line is written
-   * back with a `- ` prefix so the tier stays visually consistent with the
-   * append-mode storage convention.
+   * Idempotent — removing the same hash twice returns `removed: 0` on
+   * the second call.
+   *
+   * The rewritten file is bullet-normalized: every remaining line is
+   * written back with a `- ` prefix so the tier stays visually
+   * consistent with the append-mode storage convention.
    */
-  async removeProfileLine(ownerId: string, tier: Tier, hash: string): Promise<boolean> {
+  async removeProfileLine(
+    ownerId: string,
+    tier: Tier,
+    hash: string,
+  ): Promise<{ removed: number; sample: string | null; allTexts: string[] }> {
     const lines = await this.listProfileLines(ownerId, tier);
+    const targets = lines.filter((l) => l.hash === hash);
+    if (targets.length === 0) return { removed: 0, sample: null, allTexts: [] };
     const kept = lines.filter((l) => l.hash !== hash);
-    if (kept.length === lines.length) return false;
 
     const next = kept.map((l) => `- ${l.text}`).join('\n') + (kept.length > 0 ? '\n' : '');
     await fs.writeFile(this.profileTierPath(ownerId, tier), next, 'utf-8');
-    return true;
+    return {
+      removed: targets.length,
+      sample: targets[0].text,
+      allTexts: targets.map((t) => t.text),
+    };
   }
 
   // ── Episodes ──

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1454,8 +1454,8 @@ export function registerTools(
         };
       }
 
-      const removed = await memoryStore.removeProfileLine(caller, tier, hash);
-      if (!removed) {
+      const result = await memoryStore.removeProfileLine(caller, tier, hash);
+      if (result.removed === 0) {
         return {
           isError: true,
           content: [{ type: 'text' as const, text: `Failed to remove line "${hash}".` }],
@@ -1465,11 +1465,18 @@ export function registerTools(
       // Line removal above is the primary effect; rule promotion is
       // a best-effort enhancement. If addL2Rule fails, don't undo the
       // removal — just report the partial outcome so the user knows.
+      //
+      // Rule-promotion text choice (#88 followup): when multiple lines
+      // shared the hash, we use the sample text (first match) as the
+      // rule seed. The texts are normalized-equal after bullet-strip
+      // (that's why their hashes collide), so the sample is
+      // representative — but the operator should see the count so they
+      // can decide whether to manually add other variants.
       let tail = '';
       if (promote_to_rule) {
         try {
           const { addL2Rule } = await import('./privacy-rules.js');
-          await addL2Rule(target.text, 'Always private');
+          await addL2Rule(result.sample ?? target.text, 'Always private');
           tail = ' Also appended to privacy-rules.md under "Always private" — future distillations will classify similar content accordingly.';
         } catch (err) {
           tail = ` (Warning: removal succeeded but failed to append rule to privacy-rules.md: ${err instanceof Error ? err.message : String(err)}. You can add the rule manually.)`;
@@ -1477,13 +1484,19 @@ export function registerTools(
       }
 
       void audit('forget_memory', caller, auditArgs, 'ok');
+
+      // #88 fix: faithful confirmation that names the count when more
+      // than one line was deleted (hash collision via duplicate or
+      // 32-bit birthday-paradox match). Pre-fix the singular wording
+      // hid multi-deletes from the operator entirely.
+      const replyText =
+        result.removed === 1
+          ? `Removed "${result.sample}" from ${tier} profile.${tail}`
+          : `Removed ${result.removed} lines sharing hash "${hash}" from ${tier} profile (sample: "${result.sample}"). ` +
+            `If only one of these was the intended target, run what_do_you_know and re-add the others with save_memory.${tail}`;
+
       return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Removed "${target.text}" from ${tier} profile.${tail}`,
-          },
-        ],
+        content: [{ type: 'text' as const, text: replyText }],
       };
     }
   );

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -117,6 +117,41 @@ export function sanitizeOutboundText(text: string): string {
  */
 export const LARK_ID_REGEX = /^[A-Za-z0-9_:-]{1,128}$/;
 
+/**
+ * Build the `forget_memory` tool-reply text. Pure function — extracted
+ * (#88 R1-audit followup) so the singular vs plural-with-allTexts
+ * branch logic is unit-testable without standing up the MCP server.
+ *
+ * Inputs:
+ * - `result`: shape from `MemoryStore.removeProfileLine`
+ *   (`{removed, sample, allTexts}`).
+ * - `hash`: the user-supplied 8-char hash.
+ * - `tier`: 'public' | 'private'.
+ * - `tail`: optional promote-to-rule outcome string (may include
+ *   a multi-rule warning when removed > 1).
+ *
+ * Contract:
+ * - `removed === 1`: singular `Removed "<text>" from <tier> profile.<tail>`
+ * - `removed >= 2`: plural with numbered list + recovery hint.
+ * - `removed === 0`: caller should NOT call this — it's reserved for
+ *   the success path.
+ */
+export function formatForgetMemoryReply(
+  result: { removed: number; sample: string | null; allTexts: string[] },
+  hash: string,
+  tier: 'public' | 'private',
+  tail: string,
+): string {
+  if (result.removed === 1) {
+    return `Removed "${result.sample}" from ${tier} profile.${tail}`;
+  }
+  const numbered = result.allTexts.map((t, i) => `  ${i + 1}) "${t}"`).join('\n');
+  return (
+    `Removed ${result.removed} lines sharing hash "${hash}" from ${tier} profile:\n${numbered}\n` +
+    `If only one of these was the intended target, re-add the others with save_memory(type="profile", tier="${tier}", mode="append", content=...).${tail}`
+  );
+}
+
 const larkIdSchema = (label: string) =>
   z
     .string()
@@ -1412,7 +1447,7 @@ export function registerTools(
     'forget_memory',
     {
       description:
-        "Remove a specific line from the caller's profile. Always caller-scoped — you can only forget things about yourself. Optionally promotes the removed line into a persistent L2 rule so future distillations classify similar content as private.",
+        "Remove profile lines by 8-char hash from caller's profile. Always caller-scoped. If multiple lines share the hash (duplicates or rare birthday-paradox collision), ALL of them are removed in one call — the tool reply lists every removed text by index so the operator can re-add unintended losses via save_memory(mode='append'). Optionally promotes the (sample) removed text to a persistent L2 rule.",
       inputSchema: z.object({
         chat_id: larkIdSchema('chat_id').describe('Chat ID where this call is acting from'),
         thread_id: larkIdSchema('thread_id')
@@ -1470,33 +1505,42 @@ export function registerTools(
       // shared the hash, we use the sample text (first match) as the
       // rule seed. The texts are normalized-equal after bullet-strip
       // (that's why their hashes collide), so the sample is
-      // representative — but the operator should see the count so they
-      // can decide whether to manually add other variants.
+      // representative — but the operator should see the count + the
+      // full list (below) so they can decide whether to manually add
+      // other variants. R1-audit followup: when removed>1+promote, also
+      // emit a "review whether you want all variants treated as
+      // private" warning so the operator catches the over-broad rule.
       let tail = '';
       if (promote_to_rule) {
         try {
           const { addL2Rule } = await import('./privacy-rules.js');
-          await addL2Rule(result.sample ?? target.text, 'Always private');
+          await addL2Rule(result.sample ?? '', 'Always private');
           tail = ' Also appended to privacy-rules.md under "Always private" — future distillations will classify similar content accordingly.';
+          if (result.removed > 1) {
+            tail +=
+              ' Note: rule seeded from the sample text only; multiple lines were removed, so review whether other variants should also be added manually.';
+          }
         } catch (err) {
           tail = ` (Warning: removal succeeded but failed to append rule to privacy-rules.md: ${err instanceof Error ? err.message : String(err)}. You can add the rule manually.)`;
         }
       }
 
-      void audit('forget_memory', caller, auditArgs, 'ok');
+      // Audit log includes the removed count for forensic visibility
+      // (R1-audit followup #12 — pre-fix only ok/denied was recorded,
+      // hiding that a multi-delete had happened from the audit trail).
+      void audit('forget_memory', caller, { ...auditArgs, removed: result.removed }, 'ok');
 
-      // #88 fix: faithful confirmation that names the count when more
-      // than one line was deleted (hash collision via duplicate or
-      // 32-bit birthday-paradox match). Pre-fix the singular wording
-      // hid multi-deletes from the operator entirely.
-      const replyText =
-        result.removed === 1
-          ? `Removed "${result.sample}" from ${tier} profile.${tail}`
-          : `Removed ${result.removed} lines sharing hash "${hash}" from ${tier} profile (sample: "${result.sample}"). ` +
-            `If only one of these was the intended target, run what_do_you_know and re-add the others with save_memory.${tail}`;
-
+      // #88 fix: faithful confirmation that names the count AND lists
+      // every removed text (so the operator can copy-paste back any
+      // unintended losses via save_memory). Pre-fix the singular wording
+      // hid multi-deletes entirely; intermediate fix named the count
+      // but the recovery hint ("re-add the others") was misleading
+      // because what_do_you_know wouldn't show the deleted texts to
+      // copy from. R1-audit followup #8 — surface allTexts inline via
+      // formatForgetMemoryReply (extracted as a pure function so the
+      // branch logic is unit-testable).
       return {
-        content: [{ type: 'text' as const, text: replyText }],
+        content: [{ type: 'text' as const, text: formatForgetMemoryReply(result, hash, tier, tail) }],
       };
     }
   );


### PR DESCRIPTION
## Summary
- Closes #88 (**MEDIUM — silent data loss**). \`removeProfileLine\` stripped every line sharing the 8-char hash but the tool reply was hardcoded singular, hiding multi-deletes. Hash collisions happen naturally (duplicate facts with mixed bullet formatting normalize to the same key) and adversarially (32-bit prefix → birthday paradox at ~77k lines).
- Return shape now \`{ removed, sample, allTexts }\`; tool reply branches singular vs plural-with-count-and-recovery-hint.

## Files
- \`src/memory/file.ts\` — \`removeProfileLine\` returns count + sample + allTexts.
- \`src/tools.ts\` — \`forget_memory\` handler reads the new shape; plural reply includes hash, count, sample, and a how-to-recover suggestion.
- \`scripts/transparency-smoke.ts\` — +1 new test (#5b multi-delete); 3 existing tests updated to new shape; total bumped 9→10.
- \`scripts/profile-tier-smoke.ts\` — test 14 updated to new shape.
- Version 1.0.19 across 5 locations; CHANGELOG entry.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 10/10 transparency, 30/30 profile-tier, 13/13 enrichment, 18/18 at-tag, 11/11 path-traversal, 19/19 skill ownership, 10/10 identity, all other suites unchanged
- [x] Reviewed: collisions hit by setup that bypasses mergeProfileLines dedup (replace-mode write of bullet-normalized duplicates); sample is representative since colliding lines are normalized-equal; promote_to_rule uses sample
- [ ] Operator-verified: a profile with no duplicates gets the unchanged singular reply; a manually-created duplicate gets the plural reply with sample

## Out of scope
A future release could switch to per-line index-prefixed identifiers (e.g. \`i17:abc12345\`) to eliminate collisions entirely. That would require updating \`what_do_you_know\` rendering and \`forget_memory\` parameter semantics — bigger surface change, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)