### PR TITLE
fix(channel): fail-safe bot @-mention detection when botOpenId unknown (#86 + #55, v1.0.25)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - 10 smoke assertions in new `scripts/bot-mention-failsafe-smoke.ts`: happy path for both helpers, deny-by-default on empty botOpenId, no-mentions / null / undefined handling, `union_id` fallback when `open_id` missing, combined startup-race reproducer (#86's exact scenario).
 - New exports from `src/channel.ts`: `shouldAcceptGroupMention`, `computeBotMentioned`.
 
+### R1-audit followups (closed in this PR)
+- **Background-refetch `setTimeout`s are `.unref()`-ed** so they don't keep the event loop alive at shutdown. Cosmetic — `process.exit()` on signals already tore down the loop forcibly, but `.unref()` lets an otherwise-idle process exit naturally too.
+- PR description updated to use GitHub's `Closes #X, closes #Y` form so both #86 AND #55 auto-close on merge.
+
 ### Operator notes
 - After upgrade, expect a brief startup window (up to ~10s for 5 retries × 2s) where group @-mentions are silently ignored before `botOpenId` resolves. This is correct fail-safe behavior. P2P chats are unaffected.
 - If you see `[channel] WARNING: botOpenId not resolved after 5 startup attempts` in stderr after upgrade, check Feishu app permissions (`im:bot` scope) — the background re-fetch will keep trying every 5 minutes for up to an hour but the bot will be silent in groups during that window.
+- **Known limitation**: if bot permission is revoked at RUNTIME (post-successful-startup), the cached `botOpenId` becomes stale. No spam regression (filter correctly rejects messages that don't mention the now-stale id), but no automatic recovery either — operator restart is needed. The background re-fetch only fires from the startup-exhaustion path.
 - This release also closes #55 (same root cause — both group filter and bot_mentioned flag now share the fail-safe `shouldAcceptGroupMention` / `computeBotMentioned` helpers).
 
 ## [1.0.24] - 2026-05-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.25] - 2026-05-25
+
+### Fixed
+- **Bot `@`-mention detection fails safely when `botOpenId` is unknown** (#86, #55 — **HIGH — spammy unsolicited replies in every group during startup race / fetch failure**). Pre-v1.0.25 two fallback paths in `src/channel.ts` accepted ANY mention as if it addressed the bot when `botOpenId` was empty (transient `fetchBotOpenId` failure, network blip, or startup race window):
+  - Group filter (`handleMessageEvent`, line 313 area): fell through to "no filter — accept any group mention" → every `@User B 请评审` was forwarded to Claude.
+  - `bot_mentioned` meta flag (line 357 area): fell through to `mentions.length > 0` → biased Claude toward replying even when bot wasn't actually addressed.
+
+  Combined effect: in any group with active @mentions during the startup window, the bot would inject unsolicited replies into unrelated conversations. The user's documented operating principle ("if a group message reaches you, the user expects a reply") amplified the noise.
+
+  Fix: both decisions extracted as pure helpers (`shouldAcceptGroupMention`, `computeBotMentioned`) with deny-by-default semantics when `botOpenId === ''`. Better silent during startup than spammy.
+
+- **`fetchBotOpenId` now retries on startup AND re-fetches in background on persistent failure** (#86 hardening). Pre-v1.0.25 a single attempt that failed (network blip, Feishu 5xx, transient permission issue) silenced group @-mentions until next process restart. Now: 5 startup attempts with 2s linear backoff, then a background re-fetch every 5 minutes for up to 1 hour. Logs at the right level — last startup attempt and background retries log at ERROR, intermediates at debug. Caps at 1 hour total so a permanently-broken setup doesn't burn quota indefinitely.
+
+### Added
+- 10 smoke assertions in new `scripts/bot-mention-failsafe-smoke.ts`: happy path for both helpers, deny-by-default on empty botOpenId, no-mentions / null / undefined handling, `union_id` fallback when `open_id` missing, combined startup-race reproducer (#86's exact scenario).
+- New exports from `src/channel.ts`: `shouldAcceptGroupMention`, `computeBotMentioned`.
+
+### Operator notes
+- After upgrade, expect a brief startup window (up to ~10s for 5 retries × 2s) where group @-mentions are silently ignored before `botOpenId` resolves. This is correct fail-safe behavior. P2P chats are unaffected.
+- If you see `[channel] WARNING: botOpenId not resolved after 5 startup attempts` in stderr after upgrade, check Feishu app permissions (`im:bot` scope) — the background re-fetch will keep trying every 5 minutes for up to an hour but the bot will be silent in groups during that window.
+- This release also closes #55 (same root cause — both group filter and bot_mentioned flag now share the fail-safe `shouldAcceptGroupMention` / `computeBotMentioned` helpers).
+
 ## [1.0.24] - 2026-05-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/bot-mention-failsafe-smoke.ts
+++ b/scripts/bot-mention-failsafe-smoke.ts
@@ -1,0 +1,150 @@
+/**
+ * Bot @-mention fail-safe smoke test (v1.0.25, closes #86 + #55).
+ *
+ * Exercises the pure helpers `shouldAcceptGroupMention` and
+ * `computeBotMentioned` extracted from `LarkChannel.handleMessageEvent`.
+ *
+ * The bug pre-v1.0.25:
+ *   - `fetchBotOpenId` could fail silently during startup race /
+ *     network blip / transient permission revoke. `this.botOpenId`
+ *     stayed empty string.
+ *   - Group-filter logic FELL THROUGH on empty botOpenId → accepted
+ *     ANY mention as if @bot was addressed (#55).
+ *   - `bot_mentioned` meta field FELL THROUGH to `mentions.length > 0`
+ *     — so User A's `@User B 请评审` was forwarded with
+ *     `bot_mentioned=true`, biasing Claude toward replying (#86).
+ *
+ * Fix: both helpers return `false` (deny / not-mentioned) when
+ * botOpenId is empty. Better silent during startup than spammy
+ * unsolicited replies in every group.
+ */
+
+import {
+  shouldAcceptGroupMention,
+  computeBotMentioned,
+} from '../src/channel.js';
+
+function fail(msg: string): never {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+let testNum = 0;
+
+// 1. shouldAcceptGroupMention — happy path: known bot + bot in mentions
+{
+  testNum++;
+  const out = shouldAcceptGroupMention(
+    [
+      { id: { open_id: 'ou_user_a' } },
+      { id: { open_id: 'ou_bot' } },
+    ],
+    'ou_bot',
+  );
+  if (out !== true) fail(`1: bot present + known id → true; got ${out}`);
+}
+
+// 2. shouldAcceptGroupMention — known bot, bot NOT in mentions
+{
+  testNum++;
+  const out = shouldAcceptGroupMention(
+    [
+      { id: { open_id: 'ou_user_a' } },
+      { id: { open_id: 'ou_user_b' } },
+    ],
+    'ou_bot',
+  );
+  if (out !== false) fail(`2: bot absent + known id → false; got ${out}`);
+}
+
+// 3. shouldAcceptGroupMention — botOpenId empty, mentions present → REJECT
+//    Pre-v1.0.25 returned true (accept any mention). This is the #55/#86 fix.
+{
+  testNum++;
+  const out = shouldAcceptGroupMention(
+    [
+      { id: { open_id: 'ou_user_a' } },
+      { id: { open_id: 'ou_user_b' } },
+    ],
+    '',
+  );
+  if (out !== false) {
+    fail(`3: REGRESSION — botOpenId='' must REJECT group mention (was accepting any); got ${out}`);
+  }
+}
+
+// 4. shouldAcceptGroupMention — no mentions
+{
+  testNum++;
+  if (shouldAcceptGroupMention([], 'ou_bot') !== false) fail('4: empty mentions → false');
+  if (shouldAcceptGroupMention(null, 'ou_bot') !== false) fail('4: null mentions → false');
+  if (shouldAcceptGroupMention(undefined, 'ou_bot') !== false) fail('4: undefined mentions → false');
+}
+
+// 5. shouldAcceptGroupMention — union_id fallback when open_id missing
+//    Feishu sometimes returns only one of the two id forms.
+{
+  testNum++;
+  const out = shouldAcceptGroupMention(
+    [{ id: { union_id: 'ou_bot' } }],
+    'ou_bot',
+  );
+  if (out !== true) fail(`5: union_id match should accept; got ${out}`);
+}
+
+// 6. computeBotMentioned — happy path
+{
+  testNum++;
+  const out = computeBotMentioned(
+    [
+      { id: 'ou_user_a' },
+      { id: 'ou_bot' },
+    ],
+    'ou_bot',
+  );
+  if (out !== true) fail(`6: bot present → true; got ${out}`);
+}
+
+// 7. computeBotMentioned — bot NOT in mentions
+{
+  testNum++;
+  const out = computeBotMentioned([{ id: 'ou_user_a' }], 'ou_bot');
+  if (out !== false) fail(`7: bot absent → false; got ${out}`);
+}
+
+// 8. computeBotMentioned — botOpenId empty, mentions present → false
+//    Pre-v1.0.25 returned true (length > 0). This is the #86 fix.
+{
+  testNum++;
+  const out = computeBotMentioned([{ id: 'ou_user_a' }, { id: 'ou_user_b' }], '');
+  if (out !== false) {
+    fail(`8: REGRESSION — botOpenId='' must NOT mark bot_mentioned=true; got ${out}`);
+  }
+}
+
+// 9. computeBotMentioned — empty parsedMentions
+{
+  testNum++;
+  if (computeBotMentioned([], 'ou_bot') !== false) fail('9: empty parsedMentions → false');
+  if (computeBotMentioned([], '') !== false) fail('9: empty + unknown bot → false');
+}
+
+// 10. Combined scenario (the #86 production reproducer): startup race
+//     where botOpenId is still empty and User A mentions User B. Both
+//     helpers must reject — group message not forwarded, meta not
+//     polluted with bot_mentioned=true.
+{
+  testNum++;
+  const mentions = [{ id: { open_id: 'ou_user_b' } }];
+  const parsedMentions = [{ id: 'ou_user_b', name: 'B' }];
+  const botOpenId = ''; // startup race state
+
+  if (shouldAcceptGroupMention(mentions, botOpenId) !== false) {
+    fail('10: startup race — group mention must be REJECTED');
+  }
+  if (computeBotMentioned(parsedMentions, botOpenId) !== false) {
+    fail('10: startup race — bot_mentioned meta must be false');
+  }
+}
+
+console.log(`bot-mention failsafe smoke: ${testNum}/${testNum} PASS`);

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -90,6 +90,10 @@ echo "=== Single-instance lock unit checks ==="
 npx tsx scripts/lock-smoke.ts
 
 echo ""
+echo "=== Bot @-mention fail-safe unit checks ==="
+npx tsx scripts/bot-mention-failsafe-smoke.ts
+
+echo ""
 echo "=== Path-traversal defense unit checks ==="
 npx tsx scripts/path-traversal-smoke.ts
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -898,9 +898,12 @@ export class LarkChannel {
         );
         return;
       }
-      setTimeout(() => { void tick(); }, BG_INTERVAL_MS);
+      // .unref() so the dangling background timer doesn't keep the
+      // event loop alive on its own — graceful shutdowns can exit
+      // cleanly. R1-audit cosmetic on #86.
+      setTimeout(() => { void tick(); }, BG_INTERVAL_MS).unref();
     };
-    setTimeout(() => { void tick(); }, BG_INTERVAL_MS);
+    setTimeout(() => { void tick(); }, BG_INTERVAL_MS).unref();
   }
 
   /**

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -167,6 +167,43 @@ export class LatestMessageTracker {
   }
 }
 
+/**
+ * Pure decision: should this group-chat message be processed by the
+ * bot? (#86, #55 fix — fail-safe default when botOpenId is unknown.)
+ *
+ * Returns true iff the message has at least one mention AND we know
+ * the bot's open_id AND the bot is among the mentions. Returns false
+ * (rejects) when botOpenId is empty — better silent during startup
+ * race than spammy unsolicited replies in every group.
+ *
+ * Exported for testing.
+ */
+export function shouldAcceptGroupMention(
+  mentions: Array<{ id?: { open_id?: string; union_id?: string } }> | null | undefined,
+  botOpenId: string,
+): boolean {
+  if (!mentions || mentions.length === 0) return false;
+  if (!botOpenId) return false; // fail-safe: don't process when bot id is unknown
+  return mentions.some((m) => (m.id?.open_id ?? m.id?.union_id) === botOpenId);
+}
+
+/**
+ * Pure decision: is the bot among the parsed mentions? Forwarded to
+ * Claude as `meta.bot_mentioned`. Fail-safe default when botOpenId is
+ * unknown (#86 — pre-fix returned `parsedMentions.length > 0` which
+ * biased Claude toward replying to any group mention even when the bot
+ * wasn't actually addressed).
+ *
+ * Exported for testing.
+ */
+export function computeBotMentioned(
+  parsedMentions: Array<{ id: string }>,
+  botOpenId: string,
+): boolean {
+  if (!botOpenId) return false;
+  return parsedMentions.some((m) => m.id === botOpenId);
+}
+
 export class LarkChannel {
   private client: Lark.Client;
   private nameCache = new Map<string, string>(); // open_id/chat_id → display name
@@ -304,21 +341,25 @@ export class LarkChannel {
       return;
     }
 
-    // In group chats, only process messages that @mention the bot
+    // In group chats, only process messages that @mention the bot.
+    // Pre-v1.0.25, missing botOpenId fell through and accepted ANY
+    // group mention (#55 + #86). Now via the shared
+    // shouldAcceptGroupMention helper: deny by default when bot's id
+    // is unknown (startup race / fetch failure) — better silent than
+    // spammy unsolicited replies in every group. The fetchBotOpenId
+    // path is hardened with retries + background re-fetch so the
+    // missing-id state is short-lived.
     if (chatType === 'group') {
-      if (!mentions || mentions.length === 0) {
-        debugLog(`[channel] Ignoring group message: no mentions`);
-        return;
-      }
-      // If we know the bot's open_id, match precisely; otherwise accept any mention
-      if (this.botOpenId) {
-        const botMentioned = mentions.some(
-          (m: any) => (m.id?.open_id ?? m.id?.union_id) === this.botOpenId
+      if (!shouldAcceptGroupMention(mentions, this.botOpenId)) {
+        debugLog(
+          `[channel] Ignoring group message: ` +
+          (!mentions || mentions.length === 0
+            ? 'no mentions'
+            : !this.botOpenId
+              ? 'botOpenId not yet known (startup race or fetch failure)'
+              : 'bot not @mentioned'),
         );
-        if (!botMentioned) {
-          debugLog(`[channel] Ignoring group message: bot not @mentioned`);
-          return;
-        }
+        return;
       }
       debugLog(`[channel] Group message with @mention, processing`);
     }
@@ -351,12 +392,12 @@ export class LarkChannel {
       }),
     );
 
-    // Detect whether this bot was among the mentioned users — forwarded to
-    // Claude as meta.bot_mentioned so Claude has a text-independent signal
-    // when multiple users are @mentioned in the same message.
-    const botMentioned = this.botOpenId
-      ? parsedMentions.some((m) => m.id === this.botOpenId)
-      : parsedMentions.length > 0; // fallback: same heuristic as the group-filter
+    // Detect whether this bot was among the mentioned users — forwarded
+    // to Claude as meta.bot_mentioned. Same fail-safe default as the
+    // group-filter above (#86 fix): when botOpenId is unknown, return
+    // false rather than the pre-v1.0.25 "any mention counts" heuristic
+    // that biased Claude toward replying.
+    const botMentioned = computeBotMentioned(parsedMentions, this.botOpenId);
 
     // Parse message text, resolving @_user_N placeholders to @<name>
     const text = resolveMentionPlaceholders(
@@ -763,10 +804,51 @@ export class LarkChannel {
   }
 
   /**
-   * Fetch the bot's own open_id via the bot info API.
-   * Used to filter group messages — only process those that @mention this bot.
+   * Fetch the bot's own open_id via the bot info API. Used to filter
+   * group messages — only those that @mention this bot are forwarded
+   * to Claude.
+   *
+   * v1.0.25 (#86, #55) hardening:
+   * - **Startup retry**: 5 attempts with 2s linear backoff. Network
+   *   blips / Feishu 5xx during the initial fetch are common; failing
+   *   over to the empty `botOpenId` state would silence ALL group
+   *   @-mentions until next process restart (the new fail-safe is
+   *   deny-by-default).
+   * - **Background re-fetch**: if startup retries all fail, schedule
+   *   a periodic re-fetch every 5 minutes for the next hour so the
+   *   bot can recover without restart if the underlying issue clears
+   *   (network, transient permission). Stops on first success or
+   *   after the cap.
+   *
+   * Pre-fix the function tried once and swallowed any error; combined
+   * with the old "accept any mention" fallback, a single startup fetch
+   * failure meant the bot would noisy-reply to EVERY @mention in EVERY
+   * group for the entire process lifetime.
    */
   private async fetchBotOpenId(): Promise<void> {
+    const MAX_STARTUP_ATTEMPTS = 5;
+    const STARTUP_RETRY_DELAY_MS = 2000;
+    for (let attempt = 1; attempt <= MAX_STARTUP_ATTEMPTS; attempt++) {
+      if (await this.tryFetchBotOpenIdOnce(attempt, MAX_STARTUP_ATTEMPTS)) return;
+      if (attempt < MAX_STARTUP_ATTEMPTS) {
+        await new Promise((r) => setTimeout(r, STARTUP_RETRY_DELAY_MS));
+      }
+    }
+    console.error(
+      `[channel] WARNING: botOpenId not resolved after ${MAX_STARTUP_ATTEMPTS} startup attempts. ` +
+      `Group @-mentions will be REJECTED (fail-safe — better silent than spammy). ` +
+      `Scheduling background re-fetch every 5 minutes for the next hour.`,
+    );
+    this.startBackgroundBotIdRefetch();
+  }
+
+  /**
+   * Single attempt to fetch the bot's open_id. Returns true on success,
+   * false on any failure (transient or permanent). Logs at the level
+   * appropriate for the attempt number — last attempt and background
+   * retries log at error, intermediate startup attempts at debug.
+   */
+  private async tryFetchBotOpenIdOnce(attempt: number, totalAttempts: number): Promise<boolean> {
     try {
       const resp = await this.client.request({
         method: 'GET',
@@ -775,13 +857,50 @@ export class LarkChannel {
       const openId = (resp as any)?.bot?.open_id;
       if (openId) {
         this.botOpenId = openId;
-        debugLog(`[channel] Bot open_id resolved: ${openId}`);
-      } else {
-        console.error('[channel] Warning: could not resolve bot open_id from /bot/v3/info');
+        console.error(`[channel] Bot open_id resolved: ${openId} (attempt ${attempt}/${totalAttempts})`);
+        return true;
       }
+      console.error(
+        `[channel] /bot/v3/info attempt ${attempt}/${totalAttempts}: response had no bot.open_id`,
+      );
+      return false;
     } catch (err) {
-      console.error('[channel] Warning: failed to fetch bot info:', err);
+      const level = attempt === totalAttempts ? '[channel] ERROR' : '[channel]';
+      console.error(`${level} fetchBotOpenId attempt ${attempt}/${totalAttempts} failed:`, err);
+      return false;
     }
+  }
+
+  /**
+   * Background re-fetch loop — runs every 5 minutes for up to 1 hour
+   * after startup retries all failed. Stops on first success. Capped
+   * so a permanently-broken setup doesn't burn API quota indefinitely.
+   */
+  private startBackgroundBotIdRefetch(): void {
+    const BG_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+    const BG_MAX_ATTEMPTS = 12; // 1 hour total
+    let bgAttempt = 0;
+    const tick = async () => {
+      bgAttempt++;
+      if (this.botOpenId) return; // resolved by some other code path; stop
+      const ok = await this.tryFetchBotOpenIdOnce(bgAttempt, BG_MAX_ATTEMPTS);
+      if (ok) {
+        console.error(
+          `[channel] Background re-fetch succeeded on attempt ${bgAttempt} — group @-mentions are now active.`,
+        );
+        return;
+      }
+      if (bgAttempt >= BG_MAX_ATTEMPTS) {
+        console.error(
+          `[channel] Background re-fetch gave up after ${BG_MAX_ATTEMPTS} attempts (~1 hour). ` +
+          `Group @-mentions will remain REJECTED until process restart. ` +
+          `Check Feishu app permissions (im:bot scope) and network.`,
+        );
+        return;
+      }
+      setTimeout(() => { void tick(); }, BG_INTERVAL_MS);
+    };
+    setTimeout(() => { void tick(); }, BG_INTERVAL_MS);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.24' },
+    { name: 'claude-lark-plugin', version: '1.0.25' },
     {
       capabilities: {
         logging: {},


### PR DESCRIPTION
## Summary
- Closes #86, closes #55 (same root cause).
- Pre-fix: when \`botOpenId\` was empty (transient fetch failure / startup race), the group filter and \`bot_mentioned\` meta flag both fell through to "accept any mention". Result: bot injected unsolicited replies into unrelated group conversations.
- Fix: extract \`shouldAcceptGroupMention\` + \`computeBotMentioned\` as pure helpers with deny-by-default on empty botOpenId. Add 5-retry startup fetch + 5-minute background re-fetch loop (capped at 1 hour) so the missing-id state is short-lived. Background timers are \`.unref()\`-ed so they don't keep the event loop alive at shutdown.

## Files
- \`src/channel.ts\` — new exported helpers \`shouldAcceptGroupMention\` / \`computeBotMentioned\`. \`handleMessageEvent\` switched to use them. \`fetchBotOpenId\` rewritten with startup-retry + background re-fetch via new \`tryFetchBotOpenIdOnce\` + \`startBackgroundBotIdRefetch\`.
- \`scripts/bot-mention-failsafe-smoke.ts\` — 10 new assertions.
- Version 1.0.25 across 5 locations; CHANGELOG entry.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 10/10 bot-mention failsafe, all other suites unchanged
- [x] Reviewed: helpers deny when botOpenId='', accept correctly when known + bot present, reject when known + bot absent; union_id fallback path tested; startup-race combined scenario asserts both helpers reject
- [ ] Operator-verified: kill Feishu API access briefly at startup, observe bot is silent in groups instead of spammy; restore access, observe background re-fetch picks it up within 5 minutes

## R1-audit followups (closed in this PR)
- PR body fixed to use GitHub's auto-link form so #55 closes on merge.
- Background \`setTimeout\`s are \`.unref()\`-ed so they don't hold the event loop open at shutdown.

## Known limitation (not addressed)
- If bot permission is revoked at RUNTIME (post-successful-startup), the cached \`botOpenId\` becomes stale. No spam regression (the filter correctly rejects messages that don't mention the now-stale id), but no automatic recovery either — operator restart is needed. The background re-fetch only fires from the startup-exhaustion path. A runtime-revocation trigger could be added later if it becomes a common operational concern.

## Trade-off
The fail-safe direction is "miss a real @bot for ~10s during startup" rather than "spam every group during startup". User's MEMORY principle ("group messages that reach Claude always passed @bot filter") still holds — the filter just now correctly rejects when bot identity is unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)