### PR TITLE
fix(privacy): extend L1 regex for real-world tokens + separator-tolerant phone/ID (#76, v1.0.27)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.26",
+      "version": "1.0.27",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   Fix: 6 new service-specific regexes (anthropic-key, github-token, aws-access-key, slack-token, stripe-key, jwt) with documented real formats. Generic `token-like` widened to accept `[-_]` in the body. `cn-mobile` and `cn-id` both gained the `[-.\s]?` separator pattern that `us-phone` already had.
 
 ### Added
-- 18 new L1 smoke assertions covering all 6 service-specific token formats (with real example payloads — Anthropic, GitHub `ghp_`/`gho_`/`ghs_`, AWS `AKIA`/`ASIA`, Slack `xoxb-`/`xoxp-`, Stripe `sk_live_`/`rk_test_`, JWT 3-segment), separator-tolerant phone/ID variants (space, dash, dot separators at standard grouping boundaries), and 4 negative regression-guards (short `AKI` prefix, `ghp_short` body, plain word "JWT", short numeric code) so future regex weakenings are caught.
-- L1 test count: 10 → 28.
+- 23 new L1 smoke assertions covering all 6 service-specific token formats (with real example payloads — Anthropic, GitHub `ghp_`/`gho_`/`ghs_`, AWS `AKIA`/`ASIA`, Slack `xoxb-`/`xoxp-`, Stripe `sk_live_`/`rk_test_`, JWT 3-segment), separator-tolerant phone/ID variants (space, dash, dot separators at standard grouping boundaries), 4 negative regression-guards (short `AKI` prefix, `ghp_short` body, plain word "JWT", short numeric code), AND 5 hyphenated-English FP regression-guards (R1-audit followup — `api-documentation-string`, `token-bucket-rate-limit-pattern`, `secret-management-best-practices`, `sk-ant-cipated-future-events-here`, `sk-ant-arctic-temperature-anomaly` — all stay gray after the tightening).
+- L1 test count: 10 → 33.
+
+### R1-audit followups (closed in this PR)
+- **`token-like` body tightened** to require at least one digit OR underscore (`[A-Za-z0-9-]*[_0-9][A-Za-z0-9_-]{14,}`). Pre-followup the widened body matched hyphenated English compounds — `api-documentation-string`, `token-bucket-rate-limit-pattern`, `secret-management-best-practices` would all have been forced to private.md, silently splitting the user's public profile. Real tokens essentially always contain digits or underscore-separated chunks; pure-hyphenated English doesn't.
+- **`anthropic-key` regex tightened** to require the role+digits prefix `(api|admin|sid)\d{2}-`. Pre-followup `sk-ant-cipated-future-events-here` and `sk-ant-arctic-temperature-anomaly` (incidental hyphenated English) would have matched.
+
+### Filed as separate followup
+- **#129** — `L1_WHITELIST_KEYWORDS` short ASCII entries (`Go`, `PM`, `TL`) substring-match aggressively. Discovered while writing FP guards: `applyL1('alGOrithm')` returns `public` because of `Go`. Mirror-image of the #90 over-broad PRIVATE rule, but on the PUBLIC side. Pre-existing — not introduced by this PR.
+
+### Operator notes
 
 ### Operator notes
 - Existing on-disk `public.md` files written under v0.13–v1.0.26 may contain L1-class data the broader regex set would have caught. v1.0.27 only protects FUTURE writes — it does NOT retroactively rescan (same model as the v1.0.13 #75 fix). Operators concerned about historical exposure can spot-check `~/.claude/channels/lark/memories/profiles/*/public.md` against the patterns documented in `src/privacy-rules.ts`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.27] - 2026-05-25
+
+### Fixed
+- **L1 privacy blacklist now catches real-world API tokens and separator-containing CN phone/ID** (#76 — **HIGH, classification miss for the most common sensitive-data formats**). Pre-v1.0.27 the L1 regex set had three significant misses:
+  - **`token-like`** required prefix `sk|pk|api|token|secret` followed by a single `-`/`_` and then 16+ alphanumeric chars with NO further `-`/`_`. This caught NOTHING in practice — every real-world API token has structural separators in its body. `sk-ant-api03-...` (Anthropic), `sk_live_...` (Stripe), `ghp_...` (GitHub), `AKIA...` (AWS), `xoxb-...` (Slack), `eyJ...` (JWT) — all missed.
+  - **`cn-mobile`** required 11 consecutive digits. Human-written forms like `138 1234 5678`, `138-1234-5678`, `+86 138 1234 5678` — all missed.
+  - **`cn-id`** required 18 consecutive characters. Grouped form `110101 19900101 1234` — missed.
+
+  Combined with the L1 safety net wired in via #75 (v1.0.13) and the distiller envelope (#114, v1.0.18), the missing patterns meant LLM-classified-public content with these formats stayed in `public.md` instead of being forced to `private.md`.
+
+  Fix: 6 new service-specific regexes (anthropic-key, github-token, aws-access-key, slack-token, stripe-key, jwt) with documented real formats. Generic `token-like` widened to accept `[-_]` in the body. `cn-mobile` and `cn-id` both gained the `[-.\s]?` separator pattern that `us-phone` already had.
+
+### Added
+- 18 new L1 smoke assertions covering all 6 service-specific token formats (with real example payloads — Anthropic, GitHub `ghp_`/`gho_`/`ghs_`, AWS `AKIA`/`ASIA`, Slack `xoxb-`/`xoxp-`, Stripe `sk_live_`/`rk_test_`, JWT 3-segment), separator-tolerant phone/ID variants (space, dash, dot separators at standard grouping boundaries), and 4 negative regression-guards (short `AKI` prefix, `ghp_short` body, plain word "JWT", short numeric code) so future regex weakenings are caught.
+- L1 test count: 10 → 28.
+
+### Operator notes
+- Existing on-disk `public.md` files written under v0.13–v1.0.26 may contain L1-class data the broader regex set would have caught. v1.0.27 only protects FUTURE writes — it does NOT retroactively rescan (same model as the v1.0.13 #75 fix). Operators concerned about historical exposure can spot-check `~/.claude/channels/lark/memories/profiles/*/public.md` against the patterns documented in `src/privacy-rules.ts`.
+- Token regexes are based on documented public formats as of 2026-05. New providers (or schema changes by existing providers) need to be added explicitly — the generic `token-like` regex is a fallback but is intentionally conservative (requires the well-known prefix words).
+
 ## [1.0.26] - 2026-05-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.26",
+      "version": "1.0.27",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/privacy-rules-smoke.ts
+++ b/scripts/privacy-rules-smoke.ts
@@ -27,6 +27,34 @@ const l1Cases: [string, 'private' | 'public' | 'gray'][] = [
   ['熟悉 TypeScript 和 Rust', 'public'],
   ['晚上想吃烤鱼', 'gray'],
   ['偏好会议安排在下午', 'gray'],
+
+  // ── #76 fix: separator-tolerant phone/ID ──
+  // Pre-fix, cn-mobile required 11 consecutive digits — these all missed.
+  ['mobile: 138 1234 5678', 'private'],
+  ['手机: 138-1234-5678', 'private'],
+  ['contact 138.1234.5678', 'private'],
+  // Pre-fix cn-id required 18 consecutive — grouped form missed.
+  ['ID: 110101 19900101 1234', 'private'],
+  ['身份证 110101-19900101-1234', 'private'],
+
+  // ── #76 fix: service-specific tokens (real formats) ──
+  ['Anthropic key: sk-ant-api03-abc123def456ghi789jkl012mno345pqr', 'private'],
+  ['github token ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', 'private'],
+  ['aws AKIAIOSFODNN7EXAMPLE', 'private'],
+  ['aws temporary ASIAIOSFODNN7EXAMPLE', 'private'],
+  ['slack: xoxb-1234567890-abcdefghijklm', 'private'],
+  ['slack bot xoxp-1234567890-abcdefghijklm', 'private'],
+  ['stripe live sk_live_abcdefghijklmnopqrstuvwxyz123456', 'private'],
+  ['stripe restricted rk_test_abcdefghijklmnopqrstuvwxyz12', 'private'],
+  ['jwt eyJhbGciOiJIUzI1NiIs.eyJzdWIiOiIxMjM.SflKxwRJSMeKKF7zjA', 'private'],
+
+  // ── #76 negative tests (lookalikes that should NOT trigger) ──
+  // Conservative — these LOOK token-y but don't match real formats.
+  // Catches a future regression where someone weakens a regex.
+  ['the variable AKI was set', 'gray'],        // short AKI prefix, not 16+ uppercase suffix
+  ['ghp_short', 'gray'],                       // ghp_ prefix but body too short
+  ['just talking about JWTs in general', 'gray'], // word "JWT" alone, no payload
+  ['code 12345', 'gray'],                      // 5 digits, no phone/id pattern
 ];
 
 let l1Passed = 0;

--- a/scripts/privacy-rules-smoke.ts
+++ b/scripts/privacy-rules-smoke.ts
@@ -55,6 +55,24 @@ const l1Cases: [string, 'private' | 'public' | 'gray'][] = [
   ['ghp_short', 'gray'],                       // ghp_ prefix but body too short
   ['just talking about JWTs in general', 'gray'], // word "JWT" alone, no payload
   ['code 12345', 'gray'],                      // 5 digits, no phone/id pattern
+
+  // ── R1-audit followup on #76 — hyphenated-English false-positive
+  // guards. Pre-tighten `token-like` would have flagged these as
+  // private (over-broad body); pre-tighten `anthropic-key` would
+  // have flagged sk-ant-<English> as private. After tightening
+  // (digit-or-underscore required in token-like body; sk-ant-
+  // requires role+digits prefix), these stay gray.
+  // Note on input choice: avoid words containing "go" (e.g. algorithm,
+  // category, golang) because the pre-existing L1 whitelist keyword
+  // `Go` (the language) substring-matches them as `public`, masking
+  // the actual `token-like` decision we want to assert. Worth a
+  // separate cleanup PR — the whitelist substring matcher is too
+  // greedy on the short keyword `Go`. Filed for triage.
+  ['See the api-documentation-string for details', 'gray'],
+  ['the token-bucket-rate-limit-pattern', 'gray'],
+  ['read the secret-management-best-practices', 'gray'],
+  ['sk-ant-cipated-future-events-here', 'gray'],          // English -ipated suffix
+  ['sk-ant-arctic-temperature-anomaly', 'gray'],          // English geography phrase
 ];
 
 let l1Passed = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.26' },
+    { name: 'claude-lark-plugin', version: '1.0.27' },
     {
       capabilities: {
         logging: {},

--- a/src/privacy-rules.ts
+++ b/src/privacy-rules.ts
@@ -32,11 +32,40 @@ import { homedir } from 'node:os';
  * distiller will respect it.
  */
 export const L1_BLACKLIST_REGEX: { name: string; regex: RegExp }[] = [
-  { name: 'cn-mobile', regex: /\b1[3-9]\d{9}\b/ },
+  // Phone: CN mobile + US phone. Both allow optional separators
+  // (`-`, `.`, space) at the standard grouping boundaries so that
+  // human-written forms like `138 1234 5678` or `138-1234-5678` are
+  // caught. Pre-v1.0.27 (#76) cn-mobile required 11 consecutive
+  // digits and missed every separator-containing variant.
+  { name: 'cn-mobile', regex: /\b1[3-9]\d[-.\s]?\d{4}[-.\s]?\d{4}\b/ },
   { name: 'us-phone', regex: /\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b/ },
-  { name: 'cn-id', regex: /\b\d{17}[\dXx]\b/ },
+  // CN national ID: 18 digits/X. Allow separators at the standard
+  // 6-8-3+1 grouping (region-yyyymmdd-seq+check) since humans
+  // commonly read them out grouped. Pre-v1.0.27 required 18
+  // consecutive chars.
+  { name: 'cn-id', regex: /\b\d{6}[-.\s]?\d{8}[-.\s]?\d{3}[\dXx]\b/ },
   { name: 'credit-card', regex: /\b(?:\d[ -]*?){13,16}\b/ },
-  { name: 'token-like', regex: /\b(?:sk|pk|api|token|secret)[-_][a-zA-Z0-9]{16,}\b/i },
+
+  // ── Service-specific API tokens (#76 fix) ──
+  //
+  // Pre-v1.0.27 only the generic `token-like` regex existed, which
+  // required `sk|pk|api|token|secret` LITERAL prefix followed by a
+  // single `-`/`_` and then 16+ alphanumeric chars with NO further
+  // `-`/`_`. That signature caught nothing in practice — every
+  // real-world API token has structural separators in its body
+  // (e.g. `sk-ant-api03-...`, `sk_live_...`). Each major provider
+  // gets a dedicated regex matching its documented format.
+  { name: 'github-token', regex: /\b(ghp|gho|ghs|ghu|ghr)_[A-Za-z0-9]{36,}\b/ },
+  { name: 'aws-access-key', regex: /\b(AKIA|ASIA)[0-9A-Z]{16}\b/ },
+  { name: 'slack-token', regex: /\bxox[abprs]-[A-Za-z0-9-]{10,}\b/ },
+  { name: 'anthropic-key', regex: /\bsk-ant-[A-Za-z0-9_-]{20,}\b/ },
+  { name: 'stripe-key', regex: /\b(sk|rk|pk)_(live|test)_[A-Za-z0-9]{20,}\b/ },
+  { name: 'jwt', regex: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/ },
+  // Generic token-like fallback: now allows `[-_]` in the body so
+  // hybrid forms not matching the specific patterns above (custom
+  // internal tokens, vendor-specific schemes) still trigger.
+  { name: 'token-like', regex: /\b(?:sk|pk|api|token|secret)[-_][A-Za-z0-9_-]{16,}\b/i },
+
   { name: 'money-amount', regex: /\b\d+\s*[wk万千]\s*(?:元|块|RMB|CNY|USD)?\b|\$\d{3,}/ },
 ];
 

--- a/src/privacy-rules.ts
+++ b/src/privacy-rules.ts
@@ -58,13 +58,24 @@ export const L1_BLACKLIST_REGEX: { name: string; regex: RegExp }[] = [
   { name: 'github-token', regex: /\b(ghp|gho|ghs|ghu|ghr)_[A-Za-z0-9]{36,}\b/ },
   { name: 'aws-access-key', regex: /\b(AKIA|ASIA)[0-9A-Z]{16}\b/ },
   { name: 'slack-token', regex: /\bxox[abprs]-[A-Za-z0-9-]{10,}\b/ },
-  { name: 'anthropic-key', regex: /\bsk-ant-[A-Za-z0-9_-]{20,}\b/ },
+  // R1-audit followup on PR #128: anchor the body shape so plain
+  // English like `sk-ant-cipated-future-events-here` or
+  // `sk-ant-arctic-temperature-anomaly` doesn't false-positive.
+  // Real Anthropic keys have the form `sk-ant-<role><digits>-<payload>`
+  // where role ∈ {api, admin, sid} and digits ∈ \d{2}, e.g. `api03`.
+  { name: 'anthropic-key', regex: /\bsk-ant-(?:api|admin|sid)\d{2}-[A-Za-z0-9_-]{20,}\b/ },
   { name: 'stripe-key', regex: /\b(sk|rk|pk)_(live|test)_[A-Za-z0-9]{20,}\b/ },
   { name: 'jwt', regex: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/ },
-  // Generic token-like fallback: now allows `[-_]` in the body so
-  // hybrid forms not matching the specific patterns above (custom
-  // internal tokens, vendor-specific schemes) still trigger.
-  { name: 'token-like', regex: /\b(?:sk|pk|api|token|secret)[-_][A-Za-z0-9_-]{16,}\b/i },
+  // Generic token-like fallback: allows `[-_]` in the body so hybrid
+  // forms not matching the specific patterns above (custom internal
+  // tokens, vendor-specific schemes) still trigger. R1-audit followup
+  // on PR #128: require the body to contain at least one digit OR
+  // underscore — kills FPs on hyphenated English doc-strings like
+  // `api-documentation-string`, `token-bucket-rate-limiting-algorithm`,
+  // `secret-management-best-practices`. Real tokens essentially always
+  // contain digits or underscore-separated chunks; pure-hyphenated
+  // English compound words don't.
+  { name: 'token-like', regex: /\b(?:sk|pk|api|token|secret)[-_][A-Za-z0-9-]*[_0-9][A-Za-z0-9_-]{14,}\b/i },
 
   { name: 'money-amount', regex: /\b\d+\s*[wk万千]\s*(?:元|块|RMB|CNY|USD)?\b|\$\d{3,}/ },
 ];


### PR DESCRIPTION
## Summary
- Closes #76 (**HIGH**). Pre-fix L1 \`token-like\` regex caught NOTHING in practice (every real-world API token has structural separators in its body). \`cn-mobile\` and \`cn-id\` required fully-consecutive digits — human-written forms missed.
- Fix: 6 service-specific token regexes (anthropic / github / aws / slack / stripe / jwt) + widen generic \`token-like\` + add separator tolerance to \`cn-mobile\` and \`cn-id\` (matching the pattern \`us-phone\` already had).

## Files
- \`src/privacy-rules.ts\` — extended \`L1_BLACKLIST_REGEX\` array.
- \`scripts/privacy-rules-smoke.ts\` — 18 new L1 cases (10 → 28).
- Version 1.0.27 across 5 locations; CHANGELOG entry.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 28/28 L1 (was 10), all other suites unchanged
- [x] Reviewed: each token regex matches documented real format; phone/ID separators consistent with us-phone; 4 negative tests prevent over-broadening regression
- [ ] Operator-verified: a future distillation flush including \`sk-ant-...\` content lands in private.md, not public.md

## Combined with prior PRs
- #75 (v1.0.13) wired L1 into \`saveProfile\`'s write path
- #114 (v1.0.18) wrapped enrichment in untrusted-data envelope
- This PR (#76) completes the picture by ensuring the L1 patterns themselves cover the formats Claude is most likely to misclassify as public

## Out of scope
- New token providers (or schema changes by existing providers) need to be added explicitly. The generic \`token-like\` regex is intentionally conservative.
- Pre-existing on-disk \`public.md\` not retroactively rescanned (same model as #75 v1.0.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)