### PR TITLE
fix(scheduler): reject empty schedule + validate every Nm/Nh divisibility (#95 + #79, v1.0.28)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.27",
+      "version": "1.0.28",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - 9 new job-smoke assertions (tests 17–25) covering: empty + whitespace-only rejection, `every Nm` out-of-range and non-divisor rejection, `every Nh` non-divisor rejection, exhaustive accept-set for both `every Nm` (11 divisors of 60) and `every Nh` (7 divisors of 24), 4-field cron shape rejection, 6-field cron passthrough preserved.
 
+### R1-audit followups (closed in this PR)
+- **`update_job.schedule` Zod schema mirrored from create_job** — pre-followup `update_job.schedule` was bare `z.string().optional()`. Functionally fine because `expandSchedule` rejects at the storage boundary, but the boundary-level constraint produces a clearer error for the LLM. Now both create_job and update_job apply `.min(1).max(200).refine(s => s.trim().length > 0).optional()`.
+- **`create_job.schedule` description trimmed** of historical context ("pre-v1.0.28 it was silently treated...") in favor of the prescriptive valid-set so Claude reading the schema isn't confused by version-archaeology.
+
 ### Operator notes
 - Pre-v1.0.28 jobs already in `~/.claude/channels/lark/jobs/` are NOT retroactively re-validated on startup — they continue to fire on whatever cron they were created with. If you suspect an existing job has the `every Nm` divisor bug (#79), check its `meta.schedule` and re-create via `update_job` if the actual cadence differs from the `meta.schedule_human` label.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.28] - 2026-05-25
+
+### Fixed
+- **`create_job` rejects empty schedule + validates `every Nm` / `every Nh` for divisibility** (#95 + #79 — **HIGH spam-DoS + silent wrong-interval**). Two pre-fix failure modes in the schedule-parsing path:
+  - **#95 empty schedule → every-minute spam**: `z.string()` on the tool boundary accepted `''`; `expandSchedule('')` fell through to the raw-cron path; `CronExpressionParser.parse('')` SILENTLY produced every-minute behavior (`* * * * *` semantics). For `type=message` jobs that meant chat spam every 60 seconds; for `type=prompt` jobs that burned a full Claude turn every 60 seconds. Quickly observable but already-delivered N times before the operator could delete.
+  - **#79 `every Nm` / `every Nh` for non-divisor N produced uneven intervals**: cron `step` semantics are "value % N == 0", not "every N steps". `every 90m` → `*/90 * * * *` → minute=0 satisfies only at the top of each hour → fires every HOUR not every 90m. `every 7h` → hours {0,7,14,21} → intervals 7,7,7,**3**. Human label and actual behavior diverged silently.
+
+  Fix:
+  - **Zod boundary**: `create_job.schedule` now `.min(1).max(200).refine(s => s.trim().length > 0)`. Empty / whitespace-only rejected with a clear message.
+  - **`expandSchedule` defense in depth**: throws on empty/whitespace input (closes the gap if a future caller bypasses Zod). Throws on `every Nm` with N outside [1,59] or N that doesn't divide 60 (valid set: {1,2,3,4,5,6,10,12,15,20,30}). Throws on `every Nh` with N outside divisors of 24 (valid set: {1,2,3,4,6,8,12}). All errors include the valid-set inline so the operator (or Claude reading the failure) knows the exact fix.
+  - **Raw-cron shape guard**: fallback path rejects expressions that aren't 5 or 6 space-separated fields — catches `0 9 * *` (4 fields, often a typo) and similar that cron-parser would otherwise accept loosely. The 5/6 field accept set matches cron-parser's documented schema (5 = standard, 6 = with leading seconds field).
+
+### Added
+- 9 new job-smoke assertions (tests 17–25) covering: empty + whitespace-only rejection, `every Nm` out-of-range and non-divisor rejection, `every Nh` non-divisor rejection, exhaustive accept-set for both `every Nm` (11 divisors of 60) and `every Nh` (7 divisors of 24), 4-field cron shape rejection, 6-field cron passthrough preserved.
+
+### Operator notes
+- Pre-v1.0.28 jobs already in `~/.claude/channels/lark/jobs/` are NOT retroactively re-validated on startup — they continue to fire on whatever cron they were created with. If you suspect an existing job has the `every Nm` divisor bug (#79), check its `meta.schedule` and re-create via `update_job` if the actual cadence differs from the `meta.schedule_human` label.
+
 ## [1.0.27] - 2026-05-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.27",
+      "version": "1.0.28",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/job-smoke.ts
+++ b/scripts/job-smoke.ts
@@ -90,6 +90,88 @@ if (e8.cron !== '0 17 * * 5') fail(`expand weekly fri: got ${e8.cron}`);
 const e9 = expandSchedule('weekly on sun at 08:00');
 if (e9.cron !== '0 8 * * 0') fail(`expand weekly sun: got ${e9.cron}`);
 
+// ── v1.0.28 (#95, #79) — input validation ──
+
+// 17. expandSchedule — empty input throws (#95)
+//     Pre-fix, cron-parser silently produced '* * * * *' (every-minute spam).
+try {
+  expandSchedule('');
+  fail('17: expand empty must throw');
+} catch (err: any) {
+  if (!/cannot be empty/i.test(err.message)) fail(`17: wrong error: ${err.message}`);
+}
+
+// 18. expandSchedule — whitespace-only input throws (#95)
+//     Pre-fix, '   ' threw a confusing "Constraint error" from cron-parser
+//     (asymmetric vs '' which silently passed). Now both reject with the
+//     same clear message.
+try {
+  expandSchedule('   ');
+  fail('18: whitespace-only must throw');
+} catch (err: any) {
+  if (!/cannot be empty/i.test(err.message)) fail(`18: wrong error: ${err.message}`);
+}
+
+// 19. expandSchedule — 'every Nm' rejects N > 59 (#79)
+//     Pre-fix, 'every 90m' became '*/90 * * * *' which cron-parser reads
+//     as "minute % 90 == 0" → only minute=0 → every HOUR.
+try {
+  expandSchedule('every 90m');
+  fail('19: every 90m must throw');
+} catch (err: any) {
+  if (!/1 ≤ N ≤ 59/.test(err.message)) fail(`19: wrong error: ${err.message}`);
+}
+
+// 20. expandSchedule — 'every Nm' rejects N that doesn't divide 60 (#79)
+//     'every 7m' → '*/7 * * * *' → minutes {0,7,14,21,28,35,42,49,56},
+//     interval 7,7,7,7,7,7,7,7,**4** — uneven.
+try {
+  expandSchedule('every 7m');
+  fail('20: every 7m must throw');
+} catch (err: any) {
+  if (!/UNEVEN intervals/.test(err.message)) fail(`20: wrong error: ${err.message}`);
+}
+
+// 21. expandSchedule — 'every Nh' rejects N that doesn't divide 24 (#79)
+//     'every 5h' → '0 */5 * * *' → hours {0,5,10,15,20} → intervals
+//     5,5,5,5,**4** — uneven.
+try {
+  expandSchedule('every 5h');
+  fail('21: every 5h must throw');
+} catch (err: any) {
+  if (!/UNEVEN intervals/.test(err.message)) fail(`21: wrong error: ${err.message}`);
+}
+
+// 22. expandSchedule — 'every Nh' accepts every valid divisor of 24
+//     This catches a regression that narrows the valid set.
+for (const n of [1, 2, 3, 4, 6, 8, 12]) {
+  const r = expandSchedule(`every ${n}h`);
+  if (r.cron !== `0 */${n} * * *`) fail(`22: every ${n}h: got ${r.cron}`);
+}
+
+// 23. expandSchedule — 'every Nm' accepts every valid divisor of 60
+for (const n of [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30]) {
+  const r = expandSchedule(`every ${n}m`);
+  if (r.cron !== `*/${n} * * * *`) fail(`23: every ${n}m: got ${r.cron}`);
+}
+
+// 24. expandSchedule — fallback rejects malformed cron shape (#95 defense)
+//     "0 9 * *" is only 4 fields — cron-parser is occasionally permissive
+//     on partial input. Reject explicitly upstream.
+try {
+  expandSchedule('0 9 * *');
+  fail('24: 4-field cron must throw on shape check');
+} catch (err: any) {
+  if (!/expected 5 or 6 space-separated fields/.test(err.message)) {
+    fail(`24: wrong error: ${err.message}`);
+  }
+}
+
+// 25. expandSchedule — 6-field cron (with seconds) still accepted
+//     cron-parser supports a 6th leading second field. Don't break that.
+const r6 = expandSchedule('0 0 9 * * 1-5');
+if (r6.cron !== '0 0 9 * * 1-5') fail(`25: 6-field passthrough: got ${r6.cron}`);
+
 // 17. expandSchedule — human field preserved
 if (e1.human !== 'every 30m') fail(`expand human: got ${e1.human}`);
 if (e2.human !== 'daily at 09:00') fail(`expand human daily: got ${e2.human}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.27' },
+    { name: 'claude-lark-plugin', version: '1.0.28' },
     {
       capabilities: {
         logging: {},

--- a/src/job-store.ts
+++ b/src/job-store.ts
@@ -67,23 +67,76 @@ const DAY_MAP: Record<string, string> = {
  * Expand a human-friendly schedule alias to a standard 5-field cron expression.
  * If the input is already a valid cron expression, returns it as-is.
  * Returns { cron, human } where human is the display label.
+ *
+ * v1.0.28 (#95, #79): rejects empty input and validates the `every Nm`
+ * / `every Nh` aliases for divisibility. Pre-fix:
+ *
+ *   - empty input → cron-parser silently produced an every-minute
+ *     schedule (#95) — spam.
+ *   - `every 90m` → step-N=90 in the 0..59 minute field. Cron `step`
+ *     semantics are "value % N == 0", not "every N steps", so only
+ *     minute=0 satisfies — triggers every HOUR, not every 90m as the
+ *     human label claims (#79).
+ *   - `every 7h` → hours {0,7,14,21}, intervals 7,7,7,**3** instead
+ *     of uniformly 7. Same uneven behavior for any N not dividing
+ *     60 (minutes) or 24 (hours).
+ *
+ * Now: empty / whitespace-only input throws with a clear message;
+ * `every Nm` requires 1≤N≤59 AND N divides 60; `every Nh` requires
+ * N in {1,2,3,4,6,8,12} (divisors of 24). Cron literals (5 or 6
+ * space-separated fields) are still accepted as the escape hatch.
  */
 export function expandSchedule(input: string): { cron: string; human: string } {
   const trimmed = input.trim().toLowerCase();
+  // Empty / whitespace-only input: would otherwise reach
+  // CronExpressionParser.parse('') below, which silently produces
+  // every-minute behavior (#95). Reject early with a clear message.
+  if (!trimmed) {
+    throw new Error(
+      "schedule cannot be empty. Use a cron expression (e.g. '0 9 * * 1-5') or an alias " +
+      "(e.g. 'every 30m', 'every 2h', 'daily at 09:00', 'weekdays at 09:00', " +
+      "'weekly on mon at 09:00').",
+    );
+  }
   let result: { cron: string; human: string } | null = null;
 
-  // every Nm
+  // every Nm — divisibility-check (#79): cron-parser interprets
+  // `*/N` as "value ≡ 0 mod N", not "every N steps", so N must
+  // divide its field's modulus for uniform spacing. For minutes
+  // (field range 0-59), only N | 60 yields uniform intervals.
   let match = trimmed.match(/^every\s+(\d+)\s*m(?:in(?:ute)?s?)?$/);
   if (match) {
-    const n = match[1];
+    const n = parseInt(match[1], 10);
+    if (n < 1 || n > 59) {
+      throw new Error(
+        `'every Nm' requires 1 ≤ N ≤ 59; got ${n}. ` +
+        `For larger intervals use 'every Nh' or a raw cron expression like '0 */2 * * *'.`,
+      );
+    }
+    if (60 % n !== 0) {
+      throw new Error(
+        `'every ${n}m' produces UNEVEN intervals — cron-parser reads */${n} in the 0-59 minute field as ` +
+        `"minute ≡ 0 mod ${n}", not "every ${n} minutes". Use N ∈ {1,2,3,4,5,6,10,12,15,20,30} ` +
+        `or write the cron literal explicitly (e.g. '*/${n} * * * *' if that's actually what you mean).`,
+      );
+    }
     result = { cron: `*/${n} * * * *`, human: `every ${n}m` };
   }
 
-  // every Nh
+  // every Nh — divisibility-check (#79): same as above for the
+  // hours field (0-23). Only N ∈ {1,2,3,4,6,8,12} yields uniform
+  // intervals.
   if (!result) {
     match = trimmed.match(/^every\s+(\d+)\s*h(?:ours?)?$/);
     if (match) {
-      const n = match[1];
+      const n = parseInt(match[1], 10);
+      const validHours = [1, 2, 3, 4, 6, 8, 12];
+      if (!validHours.includes(n)) {
+        throw new Error(
+          `'every ${n}h' produces UNEVEN intervals — 24 hours is not divisible by ${n}. ` +
+          `Use N ∈ {${validHours.join(', ')}} or write the cron literal explicitly.`,
+        );
+      }
       result = { cron: `0 */${n} * * *`, human: `every ${n}h` };
     }
   }
@@ -118,8 +171,23 @@ export function expandSchedule(input: string): { cron: string; human: string } {
     }
   }
 
-  // Fallback: treat input as a raw cron expression
+  // Fallback: treat input as a raw cron expression. Defense in depth
+  // (#95): basic shape check — cron literals are 5 fields (standard)
+  // or 6 fields (with seconds prefix); anything else is a malformed
+  // alias / typo that cron-parser may silently accept (e.g. empty
+  // string, partial alias). The cron-parser .parse() below will also
+  // reject most malformed inputs but is permissive at certain edges.
   if (!result) {
+    const fields = trimmed.split(/\s+/).filter(Boolean);
+    if (fields.length !== 5 && fields.length !== 6) {
+      throw new Error(
+        `schedule "${input}" is not a recognized alias and is not a valid cron expression ` +
+        `(expected 5 or 6 space-separated fields, got ${fields.length}). ` +
+        `Aliases: 'every Nm' (N∈{1,2,3,4,5,6,10,12,15,20,30}), 'every Nh' (N∈{1,2,3,4,6,8,12}), ` +
+        `'daily at HH:MM', 'weekdays at HH:MM', 'weekly on <day> at HH:MM'. ` +
+        `Or write a raw 5-field cron like '0 9 * * 1-5'.`,
+      );
+    }
     result = { cron: trimmed, human: trimmed };
   }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1147,7 +1147,7 @@ export function registerTools(
           .max(200, 'schedule must be ≤ 200 chars')
           .refine((s) => s.trim().length > 0, { message: 'schedule must contain non-whitespace' })
           .describe(
-            'Cron expression or alias: "0 9 * * 1-5", "every 30m", "daily at 09:00", "weekdays at 09:00", "weekly on mon at 09:00". Empty/whitespace-only is rejected (#95) — pre-v1.0.28 it was silently treated as every-minute and spammed the chat.'
+            'Cron expression or alias: "0 9 * * 1-5", "every 30m", "daily at 09:00", "weekdays at 09:00", "weekly on mon at 09:00". Must be non-empty. "every Nm" requires N in {1,2,3,4,5,6,10,12,15,20,30}; "every Nh" requires N in {1,2,3,4,6,8,12} (divisors of 60 / 24 — otherwise the actual cadence diverges from the human label).'
           ),
         prompt: z
           .string()
@@ -1341,7 +1341,13 @@ export function registerTools(
       inputSchema: z.object({
         id: larkIdSchema('id').describe('Job ID'),
         status: z.enum(['active', 'paused']).optional().describe('Set status'),
-        schedule: z.string().optional().describe('New cron expression or alias'),
+        schedule: z
+          .string()
+          .min(1, 'schedule cannot be empty')
+          .max(200, 'schedule must be ≤ 200 chars')
+          .refine((s) => s.trim().length > 0, { message: 'schedule must contain non-whitespace' })
+          .optional()
+          .describe('New cron expression or alias. Same validation rules as create_job (must be non-empty; "every Nm" requires N divides 60; "every Nh" requires N in {1,2,3,4,6,8,12}).'),
         prompt: z.string().optional().describe('New prompt (type=prompt)'),
         content: z.string().optional().describe('New content (type=message)'),
         name: z.string().optional().describe('New display name'),

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1143,8 +1143,11 @@ export function registerTools(
         type: z.enum(['prompt', 'message']).describe('Job type'),
         schedule: z
           .string()
+          .min(1, 'schedule cannot be empty')
+          .max(200, 'schedule must be ≤ 200 chars')
+          .refine((s) => s.trim().length > 0, { message: 'schedule must contain non-whitespace' })
           .describe(
-            'Cron expression or alias: "0 9 * * 1-5", "every 30m", "daily at 09:00", "weekdays at 09:00", "weekly on mon at 09:00"'
+            'Cron expression or alias: "0 9 * * 1-5", "every 30m", "daily at 09:00", "weekdays at 09:00", "weekly on mon at 09:00". Empty/whitespace-only is rejected (#95) — pre-v1.0.28 it was silently treated as every-minute and spammed the chat.'
           ),
         prompt: z
           .string()


### PR DESCRIPTION
## Summary
- Closes #95, closes #79 (both in expandSchedule — single PR per #95's "可三个一起合并" note).
- #95: \`create_job(schedule='')\` silently produced an every-minute job (spam every 60s for type=message; full Claude turn every 60s for type=prompt).
- #79: \`every 90m\` / \`every 7h\` etc. produced cron expressions whose ACTUAL trigger frequency diverged from the human label (cron step semantics are "value % N == 0", not "every N steps").
- Three-layer fix: Zod boundary rejects empty/whitespace; expandSchedule throws on invalid Nm/Nh with inline valid-set; raw-cron fallback shape-checks 5 or 6 fields.

## Files
- \`src/tools.ts\` — \`schedule\` Zod schema now \`.min(1).max(200).refine(s => s.trim().length > 0)\`.
- \`src/job-store.ts\` \`expandSchedule\` — early empty-input throw; divisibility checks for `every Nm` (60 % N === 0) and `every Nh` (N ∈ {1,2,3,4,6,8,12}); fallback shape check (5 or 6 fields).
- \`scripts/job-smoke.ts\` — 9 new assertions (tests 17–25).
- Version 1.0.28 across 5 locations; CHANGELOG entry.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — full suite passes; job-smoke now has empty-rejection + Nm/Nh validation + exhaustive accept-set for divisors of 60/24 + 6-field cron passthrough preserved
- [x] Reviewed: error messages include the valid set inline so operator (or Claude reading the failure) knows the exact fix; raw cron escape hatch preserved

## Out of scope
- Pre-existing jobs already in `~/.claude/channels/lark/jobs/` are NOT retroactively re-validated on startup — they continue to fire on whatever cron they were created with. CHANGELOG notes the spot-check operators can do for #79 victims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)