### PR TITLE
fix(scheduler): tick re-entrancy guard + read-modify-write race (v1.0.29)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.29] - 2026-05-25
+
+### Fixed
+- **Scheduler: tick re-entrancy + read-modify-write race** (#77 + #78 — **HIGH duplicate-execution + silent clobber of user updates**). Two correlated scheduler concurrency bugs, both reachable any time a job's execution takes more than 60s (i.e. any retry of a transient Feishu 5xx or rate-limit, which sleeps 30 + 60 + 120 = up to 210s):
+  - **#77 tick re-entrancy**: `setInterval(tick, 60s)` had no per-job guard. A job sitting in the retry loop was still `next_run_at <= now` (runtime isn't persisted until the loop exits), so the next tick saw it as due and re-launched `executeJob`. Each retry-attempt window produced one duplicate execution — for `type=message` jobs, duplicate chat sends; for `type=prompt` jobs, duplicate prompt injections into Claude. Same observable symptom #62 had already tried to eliminate via the filename-as-id refactor, only via a different root cause (timing rather than naming).
+  - **#78 read-modify-write race**: `executeJob` took a snapshot of `job` when the tick fired and `writeJob(job)` 30–210s later wrote the whole snapshot back. Any `update_job(...)` or `delete_job(...)` issued during that window was silently clobbered: `update_job(status='paused')` reverted to `active`, schedule/prompt changes lost, and **deleted jobs were resurrected** because writeJob never checked file existence. `update_job(status='paused')` is the operator's main "stop a runaway job" lever — losing it makes a misbehaving cronjob much harder to contain.
+
+  Fix:
+  - **#77**: new `private inFlight = new Set<string>()` on `JobScheduler`. `tick()` checks membership before scheduling a job and uses `.catch().finally()` (rather than `await`) so a slow job does NOT serialize other jobs in the same tick. Cleanup happens in `.finally`, so even a synchronous throw inside `executeJob` cannot leak the entry. Not applied to `recoverMissedJobs` — `start()` awaits recovery before installing the tick timer, so the two paths are temporally disjoint.
+  - **#78**: both success and failure paths of `executeJob` re-read the job via `readJob(id)` before writing. If the file is gone, the run is logged-and-dropped (no resurrection). Otherwise the fresh disk meta wins — user updates to schedule / prompt / status survive — and only the runtime fields (last_run_at, next_run_at from the FRESH schedule, run_count, last_error) plus the `#106` auto-pause status are applied to the fresh object. The fresh meta+runtime is then copied back onto the input `job` reference so existing callers (tests, recoverMissedJobs) see the post-write state.
+
+### Added
+- 8 new scheduler-smoke assertions (tests 20–27) covering:
+  - re-entrancy: pre-populated `inFlight` → tick skips; cross-job parallelism preserved (different ids don't gate each other); `.finally` cleanup on success and failure paths both work.
+  - read-modify-write: success-path mid-flight delete → no resurrection; failure-path mid-flight delete → no resurrection; mid-flight `update_job(status='paused')` → disk status wins on the post-write merge while runtime fields still apply; mid-flight `update_job(schedule=...)` → next_run_at computed from the NEW schedule, not the stale one captured at tick time.
+
+### Changed
+- Existing scheduler-smoke tests 16–19 + 19c updated to `await writeJob(job)` before `executeJob` / `recoverMissedJobs`. Pre-fix the in-memory `job` was mutated directly; post-fix `executeJob` requires the file to be on disk for its fresh-read merge — which mirrors production exactly, where `executeJob` is only ever called on jobs returned by `listAllJobs`. Test 18 also temporarily clears `appConfig.ownerOpenId` to exercise the truly-orphan path, because `backfillJob` (now invoked via `readJob`) resurrects `created_by` from `LARK_OWNER_OPEN_ID`.
+
+### Operator notes
+- No data-format changes — existing job files on disk are read and written in the same shape as v1.0.28. The fix is purely in scheduler memory semantics; there is nothing to migrate.
+- The `inFlight` Set is in-process. A daemon restart clears it, but `start()` runs `recoverMissedJobs` once before installing the tick timer, so there is no window for cross-restart re-entrancy.
+
 ## [1.0.28] - 2026-05-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   - **#78**: both success and failure paths of `executeJob` re-read the job via `readJob(id)` before writing. If the file is gone, the run is logged-and-dropped (no resurrection). Otherwise the fresh disk meta wins — user updates to schedule / prompt / status survive — and only the runtime fields (last_run_at, next_run_at from the FRESH schedule, run_count, last_error) plus the `#106` auto-pause status are applied to the fresh object. The fresh meta+runtime is then copied back onto the input `job` reference so existing callers (tests, recoverMissedJobs) see the post-write state.
 
 ### Added
-- 8 new scheduler-smoke assertions (tests 20–27) covering:
+- 10 new scheduler-smoke assertions (tests 20–29) covering:
   - re-entrancy: pre-populated `inFlight` → tick skips; cross-job parallelism preserved (different ids don't gate each other); `.finally` cleanup on success and failure paths both work.
   - read-modify-write: success-path mid-flight delete → no resurrection; failure-path mid-flight delete → no resurrection; mid-flight `update_job(status='paused')` → disk status wins on the post-write merge while runtime fields still apply; mid-flight `update_job(schedule=...)` → next_run_at computed from the NEW schedule, not the stale one captured at tick time.
+  - dead-letter on poisoned schedule (R1-followup, see below): success-path and failure-path bad-schedule cases each verify no throw escapes executeJob, `next_run_at` is cleared to `''`, and the dead-letter is logged.
 
 ### Changed
 - Existing scheduler-smoke tests 16–19 + 19c updated to `await writeJob(job)` before `executeJob` / `recoverMissedJobs`. Pre-fix the in-memory `job` was mutated directly; post-fix `executeJob` requires the file to be on disk for its fresh-read merge — which mirrors production exactly, where `executeJob` is only ever called on jobs returned by `listAllJobs`. Test 18 also temporarily clears `appConfig.ownerOpenId` to exercise the truly-orphan path, because `backfillJob` (now invoked via `readJob`) resurrects `created_by` from `LARK_OWNER_OPEN_ID`.
 
+### R1-audit followups (closed in this PR)
+- **Dead-letter on poisoned on-disk schedule** — the fresh-read merge made a pre-existing latent bug more reachable: any out-of-band edit to `meta.schedule` (manual JSON edit / restore-from-backup / a future code path that bypasses `update_job`'s Zod validation) would make `computeNextRun(fresh.meta.schedule)` throw AFTER the chat send / prompt injection had already succeeded. The throw short-circuited `writeJob`, leaving the on-disk `next_run_at` unchanged — so the next tick (60s later) would see the same `next_run_at <= now`, re-fire the message, re-throw on the schedule, and so on. Result: silent infinite re-send loop at 60s cadence until an operator noticed the stderr spam.
+
+  Fix: both success-path and failure-path `computeNextRun` calls are now wrapped in try/catch. On throw, `next_run_at` is cleared to `''` (which both `tick` and `recoverMissedJobs` skip via their existing `if (!next_run_at) continue;` guard) and `last_error` explains the resume path (`update_job` with a valid schedule). The dead-letter is logged with severity-grade prefix `DEAD-LETTERED` so it's grep-able in operator log triage.
+
 ### Operator notes
 - No data-format changes — existing job files on disk are read and written in the same shape as v1.0.28. The fix is purely in scheduler memory semantics; there is nothing to migrate.
-- The `inFlight` Set is in-process. A daemon restart clears it, but `start()` runs `recoverMissedJobs` once before installing the tick timer, so there is no window for cross-restart re-entrancy.
+- The `inFlight` Set is in-process. A daemon restart clears it, and `start()` runs `recoverMissedJobs` before installing the tick timer — so there is no window for cross-restart re-entrancy **within a single process**. If the daemon is SIGKILL'd mid-`executeJob`, on restart `recoverMissedJobs` will replay the run — same as v1.0.28 and prior, this is the intended crash-recovery semantics, not a regression.
+- If you discover a job stuck in the dead-letter state (`next_run_at: ""` + `last_error: "invalid schedule ..."`), fix it via `update_job` with a valid schedule. `update_job` validates the schedule at the Zod boundary AND via `expandSchedule`, so a successful `update_job` will recompute `next_run_at` and resume normal ticking.
 
 ## [1.0.28] - 2026-05-25
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/scheduler-smoke.ts
+++ b/scripts/scheduler-smoke.ts
@@ -867,9 +867,130 @@ try {
     }
     passed++;
   }
+
+  // 28. R1-audit followup on this PR: a poisoned on-disk schedule
+  //     (anything that bypasses update_job's Zod gate — manual edit,
+  //     restore-from-backup, future bypass path) must NOT cause an
+  //     infinite re-fire loop. Pre-fix, executeMessageJob would send
+  //     the chat message, then computeNextRun would throw, writeJob
+  //     would be skipped, and the next tick (60s later) would see
+  //     the same next_run_at <= now → re-send forever until the
+  //     operator noticed the stderr spam.
+  //
+  //     Post-fix: computeNextRun is wrapped in try/catch on both
+  //     paths. On throw, next_run_at is set to '' (empty string —
+  //     tick and recoverMissedJobs both gate on `if (!next_run_at)`)
+  //     and last_error explains the resume path.
+  {
+    let raceFired = false;
+    const racyClient = {
+      im: { v1: { message: { create: async (args: any) => {
+        if (!raceFired) {
+          const disk = await readJob('race-bad-schedule');
+          if (!disk) fail(`28: precondition: job should exist on disk pre-race`);
+          // Poison the schedule mid-flight — simulates an out-of-band
+          // edit that landed between tick's listAllJobs read and
+          // executeJob's post-execute fresh-read.
+          disk!.meta.schedule = 'not a cron expression at all';
+          await writeJob(disk!);
+          raceFired = true;
+        }
+        return { data: { message_id: 'mock' } };
+      } } } },
+    };
+    const scheduler = makeScheduler(racyClient);
+    const job = makeJob('race-bad-schedule', new Date(Date.now() - 60_000).toISOString());
+    await writeJob(job);
+
+    let threw = false;
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => { errors.push(args.map(String).join(' ')); };
+    try {
+      await (scheduler as any).executeJob(job);
+    } catch {
+      threw = true;
+    } finally {
+      console.error = origError;
+    }
+
+    if (threw) fail(`28: executeJob must NOT throw on bad on-disk schedule (would re-fire on next tick)`);
+
+    const onDisk = await readJob('race-bad-schedule');
+    if (!onDisk) fail(`28: file should still exist (dead-letter, not delete)`);
+    if (onDisk!.runtime.next_run_at !== '') {
+      fail(`28: poisoned schedule must dead-letter via next_run_at=''; got ${JSON.stringify(onDisk!.runtime.next_run_at)}`);
+    }
+    if (!onDisk!.runtime.last_error || !/invalid schedule/.test(onDisk!.runtime.last_error)) {
+      fail(`28: last_error must explain the dead-letter; got ${onDisk!.runtime.last_error}`);
+    }
+    if (!errors.some((e) => /DEAD-LETTERED/.test(e) && /race-bad-schedule/.test(e))) {
+      fail(`28: dead-letter must log to stderr; got: ${errors.join(' | ')}`);
+    }
+    // Run count was still incremented (the run DID happen — message sent).
+    if (onDisk!.runtime.run_count !== 1) {
+      fail(`28: run_count should be 1 (the run completed before schedule poison); got ${onDisk!.runtime.run_count}`);
+    }
+    passed++;
+  }
+
+  // 29. Same dead-letter defense on the FAILURE path: if executeJob's
+  //     send fails AND the schedule is also bad, computeNextRun's throw
+  //     must not propagate (same re-fire loop concern as test 28).
+  {
+    let raceFired = false;
+    const racyClient = {
+      im: { v1: { message: { create: async () => {
+        if (!raceFired) {
+          const disk = await readJob('race-bad-schedule-fail');
+          if (!disk) fail(`29: precondition`);
+          disk!.meta.schedule = 'still not a cron';
+          await writeJob(disk!);
+          raceFired = true;
+        }
+        // Now throw a non-retryable execution error.
+        const err: any = new Error('Feishu API [230001]: param error');
+        err.response = { data: { code: 230001, msg: 'param error' } };
+        throw err;
+      } } } },
+    };
+    const scheduler = makeScheduler(racyClient);
+    const job = makeJob('race-bad-schedule-fail', new Date(Date.now() - 60_000).toISOString());
+    await writeJob(job);
+
+    let threw = false;
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => { errors.push(args.map(String).join(' ')); };
+    try {
+      await (scheduler as any).executeJob(job);
+    } catch {
+      threw = true;
+    } finally {
+      console.error = origError;
+    }
+
+    if (threw) fail(`29: failure-path executeJob must NOT throw on bad on-disk schedule`);
+
+    const onDisk = await readJob('race-bad-schedule-fail');
+    if (!onDisk) fail(`29: file should still exist`);
+    if (onDisk!.runtime.next_run_at !== '') {
+      fail(`29: failure-path bad-schedule must also dead-letter; got ${JSON.stringify(onDisk!.runtime.next_run_at)}`);
+    }
+    // On the failure path, last_error reflects the EXECUTION error
+    // (more actionable than the cron error); the dead-letter is
+    // logged via stderr only.
+    if (!onDisk!.runtime.last_error || !/230001|param error/.test(onDisk!.runtime.last_error)) {
+      fail(`29: failure-path last_error should carry the execution error; got ${onDisk!.runtime.last_error}`);
+    }
+    if (!errors.some((e) => /DEAD-LETTERED/.test(e) && /race-bad-schedule-fail/.test(e))) {
+      fail(`29: failure-path dead-letter must log to stderr; got: ${errors.join(' | ')}`);
+    }
+    passed++;
+  }
 } finally {
   (appConfig as { jobsDir: string }).jobsDir = originalJobsDir;
   rmSync(tmpJobsDir, { recursive: true, force: true });
 }
 
-console.log(`scheduler smoke: ${passed}/31 PASS`);
+console.log(`scheduler smoke: ${passed}/33 PASS`);

--- a/scripts/scheduler-smoke.ts
+++ b/scripts/scheduler-smoke.ts
@@ -22,7 +22,13 @@ import { join } from 'node:path';
 import { isMissedRunStale, JobScheduler } from '../src/scheduler.js';
 import { IdentitySession } from '../src/identity-session.js';
 import { appConfig } from '../src/config.js';
-import { mostRecentMissedSlot } from '../src/job-store.js';
+import {
+  mostRecentMissedSlot,
+  writeJob,
+  readJob,
+  deleteJob,
+  computeNextRun,
+} from '../src/job-store.js';
 import type { JobFile } from '../src/job-store.js';
 
 function fail(msg: string): never {
@@ -314,6 +320,10 @@ try {
     const sent: SentMessage[] = [];
     const scheduler = makeScheduler(permanentTargetMock(sent, 230002));
     const job = makeJob('permanent-fail-job', new Date(Date.now() - 60_000).toISOString());
+    // v1.0.29 (#78): executeJob now reads fresh-from-disk before writing
+    // so callers must persist the job first. In production this is
+    // always true (executeJob is only called on jobs from listAllJobs).
+    await writeJob(job);
     await (scheduler as any).executeJob(job);
     if (job.meta.status !== 'paused') {
       fail(`16: job must be auto-paused on permanent error, got status=${job.meta.status}`);
@@ -336,6 +346,7 @@ try {
       const sent: SentMessage[] = [];
       const scheduler = makeScheduler(permanentTargetMock(sent, code));
       const job = makeJob(`code-${code}-job`, new Date(Date.now() - 60_000).toISOString());
+      await writeJob(job);
       await (scheduler as any).executeJob(job);
       if (job.meta.status !== 'paused') {
         fail(`17: code ${code} must trigger auto-pause, got ${job.meta.status}`);
@@ -347,11 +358,22 @@ try {
 
   // 18. Empty created_by → auto-paused, NO DM attempted (no owner),
   //     no throw. Mirrors test 13's stale-skip behavior.
+  //     v1.0.29 (#78) note: backfillJob (run on every readJob) now
+  //     resurrects created_by from LARK_OWNER_OPEN_ID. To exercise
+  //     the "truly orphan" path (no owner anywhere — file empty AND
+  //     env unset) we temporarily clear ownerOpenId for this test.
   {
     const sent: SentMessage[] = [];
     const scheduler = makeScheduler(permanentTargetMock(sent));
     const job = makeJob('no-owner-permanent', new Date(Date.now() - 60_000).toISOString(), '');
-    await (scheduler as any).executeJob(job);
+    await writeJob(job);
+    const originalOwner = appConfig.ownerOpenId;
+    (appConfig as { ownerOpenId: string }).ownerOpenId = '';
+    try {
+      await (scheduler as any).executeJob(job);
+    } finally {
+      (appConfig as { ownerOpenId: string }).ownerOpenId = originalOwner;
+    }
     if (job.meta.status !== 'paused') fail(`18: empty-owner job must still auto-pause`);
     if (sent.length !== 0) fail(`18: no DM should be sent when created_by is empty`);
     passed++;
@@ -504,6 +526,9 @@ try {
         last_error: null,
       },
     };
+    // v1.0.29 (#78): recoverMissedJobs calls executeJob which now
+    // requires the file to exist on disk for its fresh-read merge.
+    await writeJob(job);
     const errors: string[] = [];
     const origError = console.error;
     console.error = (...args: unknown[]) => { errors.push(args.map(String).join(' ')); };
@@ -559,10 +584,287 @@ try {
     };
     const scheduler = makeScheduler(client);
     const job = makeJob('non-permanent-fail-job', new Date(Date.now() - 60_000).toISOString());
+    await writeJob(job);
     await (scheduler as any).executeJob(job);
     if (job.meta.status === 'paused') fail(`19: code 230001 must NOT auto-pause (not in PERMANENT_TARGET_CODES)`);
     if (job.runtime.last_error == null) fail(`19: non-retryable error must record last_error`);
     if (sent.length !== 0) fail(`19: non-permanent error must NOT DM owner`);
+    passed++;
+  }
+
+  // ── Part F: tick re-entrancy guard (v1.0.29, #77) ──────────────
+  //   Pre-fix, `setInterval(tick, 60s)` had no per-job re-entrancy
+  //   protection. A job in the 30+60+120s retry loop would be re-
+  //   launched on each subsequent tick — re-introducing the
+  //   duplicate-execution symptom #62 already tried to eliminate.
+
+  // 20. Pre-populated inFlight: tick skips that job entirely.
+  //     Most direct test of the guard — no parallelism to coordinate.
+  {
+    const sent: SentMessage[] = [];
+    const scheduler = makeScheduler(mockClient(sent));
+    const job = makeJob('reentrancy-prepop', new Date(Date.now() - 60_000).toISOString());
+    await writeJob(job);
+    // Simulate "a prior tick is still executing this job"
+    (scheduler as any).inFlight.add(job.meta.id);
+
+    await (scheduler as any).tick();
+    // tick uses fire-and-forget; nothing to await for the skipped job,
+    // but give any other code paths a microtask to settle.
+    await new Promise((r) => setTimeout(r, 20));
+
+    if (sent.length !== 0) {
+      fail(`20: tick must skip re-entrant job, got ${sent.length} sends`);
+    }
+    // Guard must NOT auto-clear — only .finally() of a real executeJob does
+    if (!(scheduler as any).inFlight.has(job.meta.id)) {
+      fail(`20: tick must not erase pre-existing inFlight entry`);
+    }
+    // Cleanup: this job was never run, so its next_run_at is still in
+    // the past — subsequent tick-based tests (21, 22, 23) would see it
+    // as due and execute it, contaminating their assertions.
+    await deleteJob(job.meta.id);
+    passed++;
+  }
+
+  // 21. Two due jobs with different ids both fire in the same tick.
+  //     Confirms the .finally cleanup doesn't accidentally gate
+  //     unrelated jobs against each other (per-job key, not global).
+  {
+    const sent: SentMessage[] = [];
+    const scheduler = makeScheduler(mockClient(sent));
+    const jobA = makeJob('parallel-a', new Date(Date.now() - 60_000).toISOString());
+    const jobB = makeJob('parallel-b', new Date(Date.now() - 60_000).toISOString());
+    await writeJob(jobA);
+    await writeJob(jobB);
+
+    await (scheduler as any).tick();
+    // Wait for fire-and-forget executeJob promises to settle.
+    await new Promise((r) => setTimeout(r, 100));
+
+    if (sent.length !== 2) {
+      fail(`21: two due jobs must both execute in one tick, got ${sent.length}`);
+    }
+    const ids = sent.map((s) => s.receive_id).sort();
+    if (ids[0] !== 'oc_parallel-a' || ids[1] !== 'oc_parallel-b') {
+      fail(`21: wrong jobs executed: ${ids.join(',')}`);
+    }
+    passed++;
+  }
+
+  // 22. inFlight is cleared in .finally after executeJob success →
+  //     the same job becomes eligible for a future tick once its
+  //     next_run_at comes around again.
+  {
+    const sent: SentMessage[] = [];
+    const scheduler = makeScheduler(mockClient(sent));
+    const job = makeJob('inflight-clear-success', new Date(Date.now() - 60_000).toISOString());
+    await writeJob(job);
+
+    await (scheduler as any).tick();
+    // Let fire-and-forget settle.
+    await new Promise((r) => setTimeout(r, 100));
+
+    if ((scheduler as any).inFlight.has(job.meta.id)) {
+      fail(`22: inFlight must be cleared via .finally after successful executeJob`);
+    }
+    passed++;
+  }
+
+  // 23. inFlight is cleared in .finally even when executeJob throws
+  //     (e.g. unexpected non-retry error). Without .finally, a single
+  //     synchronous throw inside executeJob would permanently lock the
+  //     job out of future ticks.
+  {
+    const throwClient = {
+      im: { v1: { message: { create: async () => {
+        const err: any = new Error('synthetic non-retryable failure');
+        err.response = { data: { code: 230001, msg: 'synthetic' } };
+        throw err;
+      } } } },
+    };
+    const scheduler = makeScheduler(throwClient);
+    const job = makeJob('inflight-clear-fail', new Date(Date.now() - 60_000).toISOString());
+    await writeJob(job);
+
+    await (scheduler as any).tick();
+    await new Promise((r) => setTimeout(r, 100));
+
+    if ((scheduler as any).inFlight.has(job.meta.id)) {
+      fail(`23: inFlight must be cleared via .finally even after executeJob failure`);
+    }
+    passed++;
+  }
+
+  // ── Part G: read-modify-write race fix (v1.0.29, #78) ─────────────
+  //   Pre-fix, executeJob held a stale in-memory snapshot of the job
+  //   and blindly wrote it back after the retry loop. User updates
+  //   (update_job / delete_job) issued during the 0-210s execution
+  //   window were silently clobbered — including deletions, which
+  //   the writeJob would resurrect.
+
+  // 24. Success path: file deleted during execution → no writeJob
+  //     resurrects it. Stderr logs the deliberate drop.
+  {
+    const sent: SentMessage[] = [];
+    let raceFired = false;
+    const racyClient = {
+      im: { v1: { message: { create: async (args: any) => {
+        if (!raceFired) {
+          await deleteJob('race-delete-success');
+          raceFired = true;
+        }
+        const parsed = JSON.parse(args?.data?.content ?? '{}');
+        sent.push({
+          receive_id_type: args?.params?.receive_id_type,
+          receive_id: args?.data?.receive_id,
+          text: parsed.text ?? '',
+        });
+        return { data: { message_id: 'mock' } };
+      } } } },
+    };
+    const scheduler = makeScheduler(racyClient);
+    const job = makeJob('race-delete-success', new Date(Date.now() - 60_000).toISOString());
+    await writeJob(job);
+
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => { errors.push(args.map(String).join(' ')); };
+    try {
+      await (scheduler as any).executeJob(job);
+    } finally {
+      console.error = origError;
+    }
+
+    if (sent.length !== 1) fail(`24: the send happened before delete, got ${sent.length}`);
+    const onDisk = await readJob('race-delete-success');
+    if (onDisk !== null) fail(`24: file must NOT be resurrected after mid-exec delete (success path)`);
+    if (!errors.some((e) => /race-delete-success/.test(e) && /deleted during execution/.test(e) && /not resurrecting/.test(e))) {
+      fail(`24: success path must log the not-resurrecting decision; got: ${errors.join(' | ')}`);
+    }
+    passed++;
+  }
+
+  // 25. Failure path: file deleted during execution → failure
+  //     details logged to stderr only, no writeJob resurrects.
+  {
+    let raceFired = false;
+    const racyClient = {
+      im: { v1: { message: { create: async () => {
+        if (!raceFired) {
+          await deleteJob('race-delete-fail');
+          raceFired = true;
+        }
+        const err: any = new Error('Feishu API [230002]: chat not found');
+        err.response = { data: { code: 230002, msg: 'chat not found' } };
+        throw err;
+      } } } },
+    };
+    const scheduler = makeScheduler(racyClient);
+    const job = makeJob('race-delete-fail', new Date(Date.now() - 60_000).toISOString());
+    await writeJob(job);
+
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => { errors.push(args.map(String).join(' ')); };
+    try {
+      await (scheduler as any).executeJob(job);
+    } finally {
+      console.error = origError;
+    }
+
+    const onDisk = await readJob('race-delete-fail');
+    if (onDisk !== null) fail(`25: file must NOT be resurrected via failure path`);
+    if (!errors.some((e) => /race-delete-fail/.test(e) && /deleted during execution/.test(e) && /failure/.test(e))) {
+      fail(`25: failure path must log the not-resurrecting decision; got: ${errors.join(' | ')}`);
+    }
+    passed++;
+  }
+
+  // 26. Success path: user mid-flight `update_job(status='paused')`
+  //     (simulated by direct disk mutation) → fresh status wins on
+  //     the post-execution write; the run is still recorded.
+  //     Without #78, the stale in-memory `status='active'` would
+  //     stomp the user's pause.
+  {
+    let raceFired = false;
+    const racyClient = {
+      im: { v1: { message: { create: async (args: any) => {
+        if (!raceFired) {
+          const disk = await readJob('race-user-pause');
+          if (!disk) fail(`26: precondition: job should exist on disk pre-race`);
+          disk!.meta.status = 'paused';
+          await writeJob(disk!);
+          raceFired = true;
+        }
+        return { data: { message_id: 'mock' } };
+      } } } },
+    };
+    const scheduler = makeScheduler(racyClient);
+    const job = makeJob('race-user-pause', new Date(Date.now() - 60_000).toISOString());
+    await writeJob(job);
+
+    await (scheduler as any).executeJob(job);
+
+    const onDisk = await readJob('race-user-pause');
+    if (!onDisk) fail(`26: file should still exist`);
+    if (onDisk!.meta.status !== 'paused') {
+      fail(`26: user mid-flight pause must survive on disk; got status=${onDisk!.meta.status}`);
+    }
+    if (onDisk!.runtime.run_count !== 1) {
+      fail(`26: runtime fields must still apply (run_count=1); got ${onDisk!.runtime.run_count}`);
+    }
+    if (onDisk!.runtime.last_run_at == null) {
+      fail(`26: runtime.last_run_at must be set on successful run`);
+    }
+    // Back-copy: input job ref reflects post-write disk state.
+    if (job.meta.status !== 'paused') {
+      fail(`26: input job reference must reflect post-write status=paused`);
+    }
+    passed++;
+  }
+
+  // 27. Success path: user mid-flight `update_job(schedule=<new>)` →
+  //     next_run_at is computed from the NEW schedule on disk, not
+  //     the stale schedule from the in-memory snapshot.
+  {
+    let raceFired = false;
+    const NEW_SCHEDULE = '0 0 * * *'; // daily midnight; very different from makeJob's '10 21 * * 1-5'
+    const racyClient = {
+      im: { v1: { message: { create: async () => {
+        if (!raceFired) {
+          const disk = await readJob('race-schedule-change');
+          if (!disk) fail(`27: precondition: job should exist on disk pre-race`);
+          disk!.meta.schedule = NEW_SCHEDULE;
+          await writeJob(disk!);
+          raceFired = true;
+        }
+        return { data: { message_id: 'mock' } };
+      } } } },
+    };
+    const scheduler = makeScheduler(racyClient);
+    const job = makeJob('race-schedule-change', new Date(Date.now() - 60_000).toISOString());
+    await writeJob(job);
+    // executeJob will run, race mid-flight, then computeNextRun against
+    // NEW_SCHEDULE for the next_run_at value.
+    await (scheduler as any).executeJob(job);
+
+    const onDisk = await readJob('race-schedule-change');
+    if (!onDisk) fail(`27: file should still exist`);
+    if (onDisk!.meta.schedule !== NEW_SCHEDULE) {
+      fail(`27: user mid-flight schedule change must survive; got ${onDisk!.meta.schedule}`);
+    }
+    // Re-derive expected next_run_at from the new schedule and confirm
+    // disk value matches (day-precision tolerates the few-ms gap between
+    // executeJob's computeNextRun call and ours).
+    const expectedNext = computeNextRun(NEW_SCHEDULE);
+    if (onDisk!.runtime.next_run_at.slice(0, 10) !== expectedNext.slice(0, 10)) {
+      fail(
+        `27: next_run_at must derive from NEW schedule; expected day ` +
+        `${expectedNext.slice(0, 10)}, got ${onDisk!.runtime.next_run_at} (` +
+        `would be ${computeNextRun('10 21 * * 1-5')} for the stale schedule)`,
+      );
+    }
     passed++;
   }
 } finally {
@@ -570,4 +872,4 @@ try {
   rmSync(tmpJobsDir, { recursive: true, force: true });
 }
 
-console.log(`scheduler smoke: ${passed}/23 PASS`);
+console.log(`scheduler smoke: ${passed}/31 PASS`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.28' },
+    { name: 'claude-lark-plugin', version: '1.0.29' },
     {
       capabilities: {
         logging: {},

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -413,9 +413,32 @@ export class JobScheduler {
           return;
         }
         fresh.runtime.last_run_at = new Date(startTime).toISOString();
-        fresh.runtime.next_run_at = computeNextRun(fresh.meta.schedule);
         fresh.runtime.run_count = (fresh.runtime.run_count ?? 0) + 1;
-        fresh.runtime.last_error = null;
+        // Compute next_run_at defensively (R1-audit followup on this PR):
+        // the on-disk schedule can be poisoned by an out-of-band edit
+        // (manual JSON edit / restore-from-backup / future code path
+        // that bypasses update_job's Zod validation). Pre-fix, a thrown
+        // computeNextRun would short-circuit the writeJob — leaving
+        // `next_run_at` unchanged on disk → next tick re-fires with the
+        // same `<= now` value → the chat message is RE-SENT every 60s
+        // until an operator notices the stderr spam. The dead-letter
+        // (next_run_at='') makes both tick and recoverMissedJobs skip
+        // the job via their existing `if (!next_run_at) continue;`
+        // guards. last_error explains the resume path.
+        try {
+          fresh.runtime.next_run_at = computeNextRun(fresh.meta.schedule);
+          fresh.runtime.last_error = null;
+        } catch (cronErr: any) {
+          fresh.runtime.next_run_at = '';
+          fresh.runtime.last_error =
+            `invalid schedule '${fresh.meta.schedule}': ${cronErr?.message ?? cronErr} ` +
+            `— job dead-lettered; fix via update_job to resume.`;
+          console.error(
+            `[scheduler] Job ${fresh.meta.id}: invalid schedule '${fresh.meta.schedule}' ` +
+            `(${cronErr?.message ?? cronErr}) — DEAD-LETTERED (cleared next_run_at to ` +
+            `prevent re-fire loop). Fix with update_job.`,
+          );
+        }
 
         if (attempt > 0) {
           console.error(`[scheduler] Job ${fresh.meta.id} succeeded on retry #${attempt} (run #${fresh.runtime.run_count})`);
@@ -459,7 +482,22 @@ export class JobScheduler {
       return;
     }
     freshFail.runtime.last_run_at = new Date(startTime).toISOString();
-    freshFail.runtime.next_run_at = computeNextRun(freshFail.meta.schedule);
+    // Same dead-letter defense as the success path (R1-audit followup).
+    // A poisoned on-disk schedule throws here and would otherwise leave
+    // next_run_at unchanged → tick re-fires every 60s, hitting the same
+    // execution failure each time. On the failure path, the execution
+    // error itself goes into last_error (more actionable for the
+    // operator than the cron error); the dead-letter is only logged.
+    try {
+      freshFail.runtime.next_run_at = computeNextRun(freshFail.meta.schedule);
+    } catch (cronErr: any) {
+      freshFail.runtime.next_run_at = '';
+      console.error(
+        `[scheduler] Job ${freshFail.meta.id}: invalid schedule '${freshFail.meta.schedule}' ` +
+        `(${cronErr?.message ?? cronErr}) — DEAD-LETTERED on failure-path advance ` +
+        `(cleared next_run_at). Fix with update_job.`,
+      );
+    }
     freshFail.runtime.last_error = lastErr?.message ?? String(lastErr);
 
     // #106 fix: detect permanent target-chat errors (bot kicked / chat

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -13,6 +13,7 @@ import { sanitizeOutboundText } from './tools.js';
 import type { IdentitySession } from './identity-session.js';
 import {
   listAllJobs,
+  readJob,
   writeJob,
   computeNextRun,
   mostRecentMissedSlot,
@@ -149,6 +150,26 @@ export class JobScheduler {
   private client: Lark.Client;
   private identitySession: IdentitySession;
   private running = false;
+  /**
+   * Per-job re-entrancy guard (#77, v1.0.29).
+   *
+   * `tick()` runs on a 60s setInterval, but `executeJob()` can sit inside
+   * the retry loop for up to 210s (30 + 60 + 120). Without this guard,
+   * the second tick would see the same job's `next_run_at <= now`
+   * (because runtime isn't persisted until the retry loop exits) and
+   * fire executeJob a second time — duplicate execution, the exact
+   * symptom #62 already tried to eliminate via filename-as-id.
+   *
+   * Membership is keyed by `job.meta.id` (the filename stem). The
+   * Set is in-process: a daemon restart clears it, but on restart
+   * recoverMissedJobs runs once before tick begins, so there is no
+   * window for cross-restart re-entrancy.
+   *
+   * NOT used by recoverMissedJobs — start() awaits recoverMissedJobs
+   * before installing the tick timer, so the two paths are temporally
+   * disjoint.
+   */
+  private inFlight = new Set<string>();
 
   constructor(opts: SchedulerOptions) {
     this.server = opts.server;
@@ -303,6 +324,13 @@ export class JobScheduler {
    * Periodic tick: scan all active jobs and execute due ones.
    * Also piggybacks a cleanup pass over the identity session to drop
    * stale entries so the in-memory map does not grow unboundedly.
+   *
+   * Per-job re-entrancy is gated by `this.inFlight` (#77, v1.0.29).
+   * Execution is launched fire-and-forget (`.catch().finally()` rather
+   * than `await`) so a slow job — typically one churning through the
+   * 30/60/120s retry sleeps — does NOT serialize the rest of this
+   * tick's jobs, and the next tick can still run other jobs while
+   * the slow one is in flight.
    */
   private async tick(): Promise<void> {
     this.identitySession.cleanup();
@@ -313,14 +341,21 @@ export class JobScheduler {
     for (const job of jobs) {
       if (job.meta.status !== 'active') continue;
       if (!job.runtime.next_run_at) continue;
+      // #77 re-entrancy guard: skip jobs whose previous execution is
+      // still in flight. Without this, a job in the 30+60+120s retry
+      // sleep window would be re-launched on each subsequent tick.
+      if (this.inFlight.has(job.meta.id)) continue;
 
       const nextRun = new Date(job.runtime.next_run_at).getTime();
       if (nextRun <= now) {
-        try {
-          await this.executeJob(job);
-        } catch (err) {
-          console.error(`[scheduler] Failed to execute job ${job.meta.id}:`, err);
-        }
+        this.inFlight.add(job.meta.id);
+        this.executeJob(job)
+          .catch((err) => {
+            console.error(`[scheduler] Failed to execute job ${job.meta.id}:`, err);
+          })
+          .finally(() => {
+            this.inFlight.delete(job.meta.id);
+          });
       }
     }
   }
@@ -333,6 +368,23 @@ export class JobScheduler {
    * - Only retries transient errors (network, 5xx, rate-limit)
    * - Permanent errors (permission denied, invalid params) fail immediately
    * - On final failure, records last_error and advances next_run_at
+   *
+   * #78 read-modify-write race fix (v1.0.29): the in-memory `job`
+   * snapshot taken when the tick fired can be stale by the time the
+   * retry loop exits (up to 210s later). During that window the user
+   * may have `update_job`'d schedule/status/prompt or `delete_job`'d
+   * entirely. Pre-fix, `writeJob(job)` blindly stomped those changes
+   * (resurrecting deleted jobs, un-pausing user-paused jobs, ignoring
+   * a new schedule).
+   *
+   * Post-fix: before each write we re-read the file via {@link readJob}.
+   * If the file is gone the run is logged-and-dropped (no resurrection).
+   * Otherwise we apply only the runtime fields we computed (and the
+   * auto-pause status from the #106 path) onto the fresh on-disk meta,
+   * so user updates to schedule / prompt / status survive in-flight
+   * executions. The fresh meta+runtime is also copied back onto the
+   * input `job` reference so callers see the post-write state without
+   * needing a separate readJob.
    */
   private async executeJob(job: JobFile): Promise<void> {
     const startTime = Date.now();
@@ -346,19 +398,37 @@ export class JobScheduler {
           await this.executePromptJob(job);
         }
 
-        // Success — update runtime
-        job.runtime.last_run_at = new Date(startTime).toISOString();
-        job.runtime.next_run_at = computeNextRun(job.meta.schedule);
-        job.runtime.run_count += 1;
-        job.runtime.last_error = null;
+        // Success — fresh-read merge (#78). The on-disk file may have
+        // changed mid-execution; user updates to meta (schedule,
+        // status, prompt, etc.) win, and `next_run_at` is computed
+        // against the FRESH schedule so a `update_job(schedule=...)`
+        // mid-flight takes effect on the next tick. A deletion mid-
+        // flight is honored: no writeJob, no resurrection.
+        const fresh = await readJob(job.meta.id);
+        if (!fresh) {
+          console.error(
+            `[scheduler] Job ${job.meta.id} was deleted during execution — ` +
+            `the run succeeded but no runtime is recorded (not resurrecting the file).`,
+          );
+          return;
+        }
+        fresh.runtime.last_run_at = new Date(startTime).toISOString();
+        fresh.runtime.next_run_at = computeNextRun(fresh.meta.schedule);
+        fresh.runtime.run_count = (fresh.runtime.run_count ?? 0) + 1;
+        fresh.runtime.last_error = null;
 
         if (attempt > 0) {
-          console.error(`[scheduler] Job ${job.meta.id} succeeded on retry #${attempt} (run #${job.runtime.run_count})`);
+          console.error(`[scheduler] Job ${fresh.meta.id} succeeded on retry #${attempt} (run #${fresh.runtime.run_count})`);
         } else {
-          console.error(`[scheduler] Job ${job.meta.id} executed successfully (run #${job.runtime.run_count})`);
+          console.error(`[scheduler] Job ${fresh.meta.id} executed successfully (run #${fresh.runtime.run_count})`);
         }
 
-        await writeJob(job);
+        await writeJob(fresh);
+        // Reflect post-write state on the caller's `job` reference so
+        // existing call sites (tick / recoverMissedJobs / tests) see
+        // the same state that's now on disk.
+        job.meta = fresh.meta;
+        job.runtime = fresh.runtime;
         return;
       } catch (err: any) {
         lastErr = err;
@@ -377,10 +447,20 @@ export class JobScheduler {
       }
     }
 
-    // All retries exhausted or permanent error — record failure.
-    job.runtime.last_run_at = new Date(startTime).toISOString();
-    job.runtime.next_run_at = computeNextRun(job.meta.schedule);
-    job.runtime.last_error = lastErr?.message ?? String(lastErr);
+    // Failure path — fresh-read merge (#78). Same rationale as the
+    // success path above. If the file was deleted during execution,
+    // record the failure to stderr only and do not resurrect.
+    const freshFail = await readJob(job.meta.id);
+    if (!freshFail) {
+      console.error(
+        `[scheduler] Job ${job.meta.id} was deleted during execution — ` +
+        `failure (${lastErr?.message ?? lastErr}) not recorded (not resurrecting the file).`,
+      );
+      return;
+    }
+    freshFail.runtime.last_run_at = new Date(startTime).toISOString();
+    freshFail.runtime.next_run_at = computeNextRun(freshFail.meta.schedule);
+    freshFail.runtime.last_error = lastErr?.message ?? String(lastErr);
 
     // #106 fix: detect permanent target-chat errors (bot kicked / chat
     // archived / etc) and AUTO-PAUSE the job so it stops re-firing every
@@ -389,29 +469,38 @@ export class JobScheduler {
     // tokens for type=prompt cronjobs that never produced output.
     // The owner gets a one-shot DM with the failure reason so they
     // can decide whether to re-target, re-create, or delete the job.
+    //
+    // Note: the auto-pause OVERRIDES whatever status was on disk. If
+    // the user paused mid-flight, the disk already says 'paused' →
+    // setting 'paused' again is a no-op. If the user un-paused or
+    // changed nothing, the auto-pause still applies — correct, because
+    // the target is unreachable regardless of user intent.
     const apiCode = getFeishuApiCode(lastErr);
     const isPermanentTarget = apiCode !== null && PERMANENT_TARGET_CODES.has(apiCode);
     if (isPermanentTarget) {
-      job.meta.status = 'paused';
+      freshFail.meta.status = 'paused';
       console.error(
-        `[scheduler] Job ${job.meta.id} AUTO-PAUSED — target chat ${job.meta.target_chat_id} ` +
+        `[scheduler] Job ${freshFail.meta.id} AUTO-PAUSED — target chat ${freshFail.meta.target_chat_id} ` +
         `permanently unreachable (Feishu code ${apiCode}: ${getFeishuApiMsg(lastErr)}). ` +
-        `Owner ${job.meta.created_by} notified via DM (best-effort).`,
+        `Owner ${freshFail.meta.created_by} notified via DM (best-effort).`,
       );
     } else {
       const retryNote = isRetryableError(lastErr)
         ? ` (exhausted ${MAX_RETRIES} retries)`
         : ' (non-retryable)';
-      console.error(`[scheduler] Job ${job.meta.id} failed${retryNote}: ${job.runtime.last_error}`);
+      console.error(`[scheduler] Job ${freshFail.meta.id} failed${retryNote}: ${freshFail.runtime.last_error}`);
     }
 
-    await writeJob(job);
+    await writeJob(freshFail);
+    // Reflect post-write state on the caller's `job` reference.
+    job.meta = freshFail.meta;
+    job.runtime = freshFail.runtime;
 
     // Best-effort owner notification AFTER the file is persisted so a
     // DM failure (owner unreachable too) doesn't lose the paused-state
     // write. Throws are swallowed — recovery must not abort.
     if (isPermanentTarget) {
-      await this.notifyOwnerOnTargetFail(job, apiCode!, getFeishuApiMsg(lastErr));
+      await this.notifyOwnerOnTargetFail(freshFail, apiCode!, getFeishuApiMsg(lastErr));
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #77, closes #78. Two correlated scheduler concurrency bugs, both reachable any time a job's execution exceeds 60s — which any retry of a transient Feishu 5xx / rate-limit does (30+60+120 = up to 210s in retries alone).

- **#77 tick re-entrancy**: `setInterval(tick, 60s)` had no per-job guard. A job in the retry loop still satisfied `next_run_at <= now` (runtime only persists once the loop exits), so the next tick re-launched `executeJob`. Each retry window produced one duplicate execution — the same symptom #62 tried to eliminate via filename-as-id, only surfaced via a different root cause (timing rather than naming). For `type=message` cronjobs: duplicate chat sends; for `type=prompt`: duplicate prompt injections into Claude.
- **#78 read-modify-write race**: `executeJob` took a snapshot of `job` when the tick fired and `writeJob(job)` up to 210s later wrote the whole snapshot back. Any `update_job(...)` or `delete_job(...)` issued in that window was silently clobbered. `update_job(status='paused')` reverted to `active`; schedule/prompt changes lost; **deleted jobs were resurrected** because `writeJob` never checked file existence. `update_job(status='paused')` is the operator's main "stop a runaway job" lever — losing it makes containing a misbehaving cronjob much harder.

## Fix

### #77 — `private inFlight = new Set<string>()` on `JobScheduler`

`tick()` checks membership before scheduling and uses `.catch().finally()` (not `await`) so a slow job does NOT serialize other jobs in the same tick. `.finally` cleanup covers synchronous throws inside `executeJob`, so even a thrown error cannot leak the entry. Not applied to `recoverMissedJobs` — `start()` awaits recovery before installing the tick timer, so the two paths are temporally disjoint within a single process.

### #78 — fresh-read merge

Both success and failure paths of `executeJob` re-read the job via `readJob(id)` before writing. If the file is gone, the run is logged-and-dropped (no resurrection). Otherwise the fresh disk meta wins — user updates to schedule / prompt / status survive — and only the runtime fields (`last_run_at`, `next_run_at` derived from the FRESH schedule, `run_count`, `last_error`) plus the `#106` auto-pause status are applied to the fresh object. The fresh meta+runtime is also copied back onto the input `job` reference so existing callers (tests, `recoverMissedJobs`) see post-write state without a separate `readJob`.

### R1-followup commit — dead-letter on poisoned schedule

R1 audit found that the fresh-read merge made a pre-existing latent bug more reachable: any out-of-band edit to `meta.schedule` (manual JSON edit / restore-from-backup) would make `computeNextRun(fresh.meta.schedule)` throw AFTER the chat send / prompt injection had succeeded. The throw short-circuited `writeJob` → on-disk `next_run_at` unchanged → next tick re-fires → infinite re-send at 60s cadence.

Fix: `computeNextRun` calls now wrapped in try/catch on both paths. On throw, `next_run_at` is cleared to `''` (tick and recoverMissedJobs both skip via existing `if (!next_run_at) continue;`) and `last_error` explains the resume path. Logged with grep-able `DEAD-LETTERED` prefix.

## Tests

10 new `scheduler-smoke` assertions (tests 20–29):

| # | Behavior |
|---|---|
| 20 | Pre-populated `inFlight` → `tick()` skips that job |
| 21 | Two due jobs with different ids both fire in one tick (parallelism preserved) |
| 22 | `.finally` clears `inFlight` after successful `executeJob` |
| 23 | `.finally` clears `inFlight` after failed `executeJob` (even synchronous throws) |
| 24 | Mid-flight `deleteJob` on success path → no resurrection, stderr logs the drop |
| 25 | Mid-flight `deleteJob` on failure path → no resurrection, stderr logs the drop |
| 26 | Mid-flight `update_job(status='paused')` → disk status wins, runtime still applied |
| 27 | Mid-flight `update_job(schedule=...)` → `next_run_at` from NEW schedule, not stale |
| 28 | R1-followup: success-path bad schedule → no throw, dead-lettered (`next_run_at=''`), `last_error` explains resume |
| 29 | R1-followup: failure-path bad schedule + execution error → no throw, dead-lettered, `last_error` carries execution error (cron error logged via stderr) |

Existing tests 16–19 + 19c updated to `writeJob()` before `executeJob`, mirroring production where `executeJob` is only called on jobs returned by `listAllJobs`. Test 18 also temporarily clears `appConfig.ownerOpenId` to exercise the truly-orphan path — `backfillJob` (now invoked via `readJob`) resurrects `created_by` from `LARK_OWNER_OPEN_ID`, which is the correct v0.11.1+ production behavior.

`scheduler smoke: 33/33 PASS`. Full suite green.

## Followups filed during audit

- **#132** — auto-pause on permanent target error silently reverts a concurrent user un-pause/retarget (R1 finding)
- **#133** — mid-flight type/target change runs OLD values but persists NEW values (R1 finding)
- **#134** — delete+create same-id race during executeJob corrupts new job's runtime fields (R2 finding)

All three are lower-severity than #77/#78 themselves; this PR ships the core concurrency fix and the dead-letter defense.

## Operator notes

- No data-format changes. Existing job files on disk are read/written in the same shape as v1.0.28; nothing to migrate.
- The `inFlight` Set is in-process. A daemon restart clears it, and `start()` runs `recoverMissedJobs` before installing the tick timer — so there is no window for cross-restart re-entrancy **within a single process**. SIGKILL during executeJob still replays the run on next start (same as v1.0.28; intended crash-recovery semantics).
- If you discover a job stuck in the dead-letter state (`next_run_at: ""` + `last_error: "invalid schedule ..."`), fix it via `update_job` with a valid schedule. `update_job` validates the schedule at the Zod boundary AND via `expandSchedule`, so a successful `update_job` will recompute `next_run_at` and resume normal ticking.

## Test plan

- [x] `npm run typecheck` clean
- [x] `bash scripts/test.sh` all green (`scheduler smoke: 33/33 PASS`)
- [x] Version bumped to 1.0.29 across `package.json`, `package-lock.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `src/index.ts`
- [x] R1 audit findings addressed in-PR (dead-letter) or filed as followups (#132, #133)
- [x] R2 audit finding filed as followup (#134)

🤖 Generated with [Claude Code](https://claude.com/claude-code)