### PR TITLE
fix(memory): per-user async mutex for saveProfile + removeProfileLine TOCTOU (v1.0.34)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.33",
+      "version": "1.0.34",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.34] - 2026-05-25
+
+### Fixed
+- **`saveProfile` TOCTOU race on concurrent same-user writes across chats** (#54 — **HIGH silent-data-loss when triggered**). `saveProfile` and (same shape) `removeProfileLine` both do `read existing → merge → write back` on the profile tier file. Two concurrent calls for the SAME `userId` from different chats — a cronjob with `created_by = ou_user` firing while user is messaging in a group, or two chats both seeing distillation results land at once for the same speaker — race on the read-then-write sequence: both read snapshot S, both compute different merges (S ∪ deltaA vs S ∪ deltaB), the second write silently clobbers the first → one fact lost with no user-visible error.
+
+  Per-chat `MessageQueue` already serializes traffic within a single chat, so the race only fires for CROSS-chat same-user concurrency — narrow but reachable in any deployment with cronjobs targeting a user who's also actively chatting elsewhere.
+
+  Fix: per-user async mutex on `MemoryStore` (`profileMutex: Map<userId, Promise<void>>`). `saveProfile` and `removeProfileLine` both wrap their bodies in `withProfileMutex(userId, async () => { ... })`. Subsequent calls for the same `userId` queue behind any in-flight one; calls for different `userId`s proceed in parallel (per-user keying preserves cross-user throughput). Failures in one queued call do NOT poison the chain — the chain advances regardless (matches `MessageQueue` semantics in `src/queue.ts`). Mutex Map entries are cleaned up on completion when no later call has chained on top, so the Map stays empty in steady state.
+
+  Scope decision: also applied to `removeProfileLine` since it has the same RMW shape and the same exposure (a `forget_memory` in chat A racing with `save_memory` in chat B for the same user would lose the save's delta if forget's write landed last). The issue mentioned `saveProfile` explicitly; covering both with the same mutex avoids a follow-up PR for the symmetric path.
+
+  Cross-process note: this is a single-process construct. A second MCP process writing the same profile would still race, but the file lock at `src/lock.ts` (v1.0.23) blocks two processes from running concurrently — so cross-process exposure is structurally prevented.
+
+### Added
+- New `scripts/profile-toctou-smoke.ts` (7 tests, wired into `scripts/test.sh`):
+  - **1**: sequential baseline (test-harness sanity check)
+  - **2** (the bug): 20 concurrent same-user `saveProfile` calls — pre-fix would have lost most deltas, post-fix all 20 survive
+  - **3**: cross-user writes run in parallel (loose timing bound) — confirms the per-user keying doesn't degenerate into a global mutex
+  - **4**: Map cleanup — entry removed after a save completes when no chain follows
+  - **5**: Map keeps entries while a chain is active (no premature cleanup)
+  - **6**: one call throwing does NOT poison the chain — A→B(throw)→C all observed in order, A and C fulfill, B rejects
+  - **7**: `saveProfile` + `removeProfileLine` concurrent on same user → both outcomes survive (remove targets only its line, save's delta is preserved)
+
+### Operator notes
+- No data-format or config changes. Existing profile files are read/written in the same shape as v1.0.33; nothing to migrate.
+- Pre-#54 data already lost to the race cannot be recovered — the race produced no on-disk evidence (the losing write just doesn't reach disk). Going forward writes serialize correctly.
+- The mutex Map is bounded by concurrent-active-users (empty in steady state). No tunable; growth is naturally bounded by Feishu's per-user activity.
+
 ## [1.0.33] - 2026-05-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   Cross-process note: this is a single-process construct. A second MCP process writing the same profile would still race, but the file lock at `src/lock.ts` (v1.0.23) blocks two processes from running concurrently — so cross-process exposure is structurally prevented.
 
 ### Added
-- New `scripts/profile-toctou-smoke.ts` (7 tests, wired into `scripts/test.sh`):
+- New `scripts/profile-toctou-smoke.ts` (9 tests, wired into `scripts/test.sh`):
   - **1**: sequential baseline (test-harness sanity check)
   - **2** (the bug): 20 concurrent same-user `saveProfile` calls — pre-fix would have lost most deltas, post-fix all 20 survive
   - **3**: cross-user writes run in parallel (loose timing bound) — confirms the per-user keying doesn't degenerate into a global mutex
@@ -26,6 +26,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   - **5**: Map keeps entries while a chain is active (no premature cleanup)
   - **6**: one call throwing does NOT poison the chain — A→B(throw)→C all observed in order, A and C fulfill, B rejects
   - **7**: `saveProfile` + `removeProfileLine` concurrent on same user → both outcomes survive (remove targets only its line, save's delta is preserved)
+  - **8 (R1-followup)**: `saveProfileTiered` atomicity — tiered-replace + private-append concurrent on same user → result is one of two well-defined orderings, NEVER the pre-followup "mid-pair clobber" outcome
+  - **9 (R1-followup)**: 10 concurrent `saveProfileTiered` calls serialize → last writer wins exactly (REPLACE semantic preserved, no in-flight clobber)
+
+### R1-audit followups (closed in this PR)
+- **`saveProfileTiered` (new method)** — R1 caught a MEDIUM gap: the `profile_tiered` flow at `src/tools.ts:1100` issued two separate `saveProfile(...,'replace')` calls. Each grabbed the per-user mutex independently → a cross-chat save could land BETWEEN the public-replace and private-replace and have its private-tier delta clobbered by the private-replace. The pair was NOT atomic from a same-user-cross-chat concurrency perspective even with the #54 fix. New `MemoryStore.saveProfileTiered(userId, {public, private})` performs both writes inside ONE `withProfileMutex` invocation so the pair is observable as atomic to any other concurrent same-user save / remove. The L1 safety net is re-applied on the public tier (defense-in-depth — even though `parseTieredProfile` already classified, a future caller bypassing it still gets the protection). Updated both the production call site (`src/tools.ts:save_memory(type='profile_tiered')`) and the test harness (`scripts/profile-tiered-smoke.ts`'s `applyTieredProfile`).
+- **Cleanup belt-and-suspenders** — added explicit `.catch` handler on the `tail.then(cleanup)` chain so a future refactor that swaps `tail` for `next` (which can reject) doesn't silently produce unhandled rejections.
+- **Test 4/5 timer dependency removed** — replaced `setTimeout(10)` with `await Promise.resolve()` ×2 to drain the cleanup microtask without a wall-clock dependency. R1 noted 10ms is theoretically flaky on loaded CI; this removes the timing dependency entirely.
+- **Invariant comments propagated** — the "must NOT recurse back into mutex-wrapped function on same userId" deadlock guard was only documented on the helper. Added explicit comments to `saveProfile` and `removeProfileLine` bodies too so a future contributor adding internal recursion can't miss it.
+
+### R1-audit findings filed as followups
+- **#143 — `migrateIfNeeded` race**: concurrent same-user `saveProfile` (mutex-wrapped) + `getProfile` / `listProfileLines` (unwrapped) on a legacy pre-v0.10 user's first touch can race during migration. The save's tier writes can be clobbered by the concurrent migration's tier writes. Narrow exposure — only on first-touch of legacy users — but worth a separate focused fix.
 
 ### Operator notes
 - No data-format or config changes. Existing profile files are read/written in the same shape as v1.0.33; nothing to migrate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **Test 4/5 timer dependency removed** — replaced `setTimeout(10)` with `await Promise.resolve()` ×2 to drain the cleanup microtask without a wall-clock dependency. R1 noted 10ms is theoretically flaky on loaded CI; this removes the timing dependency entirely.
 - **Invariant comments propagated** — the "must NOT recurse back into mutex-wrapped function on same userId" deadlock guard was only documented on the helper. Added explicit comments to `saveProfile` and `removeProfileLine` bodies too so a future contributor adding internal recursion can't miss it.
 
+### R2-audit followups (closed in this PR)
+- **`src/prompts.ts` distiller prompt updated** — R2 caught that lines 89/91 still told Claude the tiered path is non-atomic and that "the writes are NOT a single atomic transaction", which is exactly the failure mode the R1 followup eliminated. The system prompt is sent on every initialize handshake; leaving the stale doc in would have taught every fresh session an inaccurate mental model of the storage layer. Rewrote the paragraph to describe the new per-user-lock atomic-pair semantic; the residual read-side window (mid-pair `getProfile`) is still mentioned but pinned to its correct cause.
+
 ### R1-audit findings filed as followups
 - **#143 — `migrateIfNeeded` race**: concurrent same-user `saveProfile` (mutex-wrapped) + `getProfile` / `listProfileLines` (unwrapped) on a legacy pre-v0.10 user's first touch can race during migration. The save's tier writes can be clobbered by the concurrent migration's tier writes. Narrow exposure — only on first-touch of legacy users — but worth a separate focused fix.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.33",
+      "version": "1.0.34",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/profile-tiered-smoke.ts
+++ b/scripts/profile-tiered-smoke.ts
@@ -73,8 +73,14 @@ async function applyTieredProfile(store: MemoryStore, userId: string, json: stri
       .map((line) => (line.startsWith('-') ? line : `- ${line}`))
       .join('\n') +
     (arr.some((s) => oneLine(s).length > 0) ? '\n' : '');
-  await store.saveProfile(userId, fmt(tiered.public), 'public', 'replace');
-  await store.saveProfile(userId, fmt(tiered.private), 'private', 'replace');
+  // v1.0.34 (R1-followup on #54): mirror tools.ts's switch to
+  // saveProfileTiered for the atomic-pair write. Pre-followup these
+  // were two separate saveProfile calls; the test still exercises the
+  // same end-to-end behavior, now under one mutex acquisition.
+  await store.saveProfileTiered(userId, {
+    public: fmt(tiered.public),
+    private: fmt(tiered.private),
+  });
   return {};
 }
 

--- a/scripts/profile-toctou-smoke.ts
+++ b/scripts/profile-toctou-smoke.ts
@@ -1,0 +1,212 @@
+/**
+ * Profile TOCTOU smoke test (v1.0.34, closes #54).
+ *
+ * Exercises the per-user async mutex added to `MemoryStore.saveProfile`
+ * and `MemoryStore.removeProfileLine`. Pre-fix two concurrent same-user
+ * writes across different chats raced on the `read → merge → write`
+ * sequence and silently dropped the older delta. Post-fix the mutex
+ * serializes them within one process.
+ *
+ * NOTE: a per-user async mutex is a single-process construct. If two
+ * MCP processes (rare; the file lock at src/lock.ts blocks this) wrote
+ * the same profile, the race would still exist. The single-instance
+ * lock makes that effectively unreachable.
+ */
+
+// Pin a tmp memories dir BEFORE importing the store, so the constructor
+// resolves to it (the default reads appConfig.memoriesDir, which we
+// override via the constructor arg below — but we still set the env
+// for any other module that captures at import time).
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const tmp = mkdtempSync(join(tmpdir(), 'profile-toctou-'));
+process.env.LARK_MEMORIES_DIR = tmp;
+
+import { MemoryStore } from '../src/memory/file.js';
+
+function fail(msg: string): never {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+let testNum = 0;
+const store = new MemoryStore(tmp);
+
+// Helper: read a profile tier file directly off disk
+function readTier(userId: string, tier: 'public' | 'private'): string {
+  const p = join(tmp, 'profiles', userId, `${tier}.md`);
+  return existsSync(p) ? readFileSync(p, 'utf-8') : '';
+}
+
+// Helper: parse the list of bullet texts from a tier file
+function tierLines(userId: string, tier: 'public' | 'private'): string[] {
+  return readTier(userId, tier)
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((l) => (l.startsWith('- ') ? l.slice(2).trim() : l));
+}
+
+try {
+  // 1. Sequential baseline — confirms the test harness works.
+  {
+    await store.saveProfile('ou_seq', '- fact 1', 'private');
+    await store.saveProfile('ou_seq', '- fact 2', 'private');
+    const lines = tierLines('ou_seq', 'private');
+    if (!lines.includes('fact 1') || !lines.includes('fact 2')) {
+      fail(`1: sequential writes lost a fact: ${JSON.stringify(lines)}`);
+    }
+    testNum++;
+  }
+
+  // 2. THE BUG: concurrent same-user writes across two simulated chats.
+  //    Pre-#54 fix the second writer's `existing` snapshot was taken
+  //    before the first writer's commit landed; second write overwrote
+  //    with `S ∪ deltaB`, dropping deltaA. With the mutex, both deltas
+  //    must survive.
+  {
+    const user = 'ou_concurrent';
+    const N = 20;
+    // Fire all N writes in parallel without awaiting between them — the
+    // pre-fix code would lose most of them.
+    const writes = Array.from({ length: N }, (_, i) =>
+      store.saveProfile(user, `- fact ${i}`, 'private'),
+    );
+    await Promise.all(writes);
+    const lines = tierLines(user, 'private');
+    for (let i = 0; i < N; i++) {
+      if (!lines.includes(`fact ${i}`)) {
+        fail(`2: concurrent writes lost "fact ${i}" — got ${lines.length}/${N} survivors: ${JSON.stringify(lines)}`);
+      }
+    }
+    testNum++;
+  }
+
+  // 3. Different users do NOT serialize against each other — confirms
+  //    the per-user keying actually works (a global mutex would
+  //    pessimize parallel cross-user traffic).
+  {
+    const t0 = Date.now();
+    // Simulate two users with intentionally-slow writes by chaining
+    // multiple writes per user; if cross-user serialization existed,
+    // total time would be ~2× the per-user time.
+    const userA = Array.from({ length: 5 }, (_, i) =>
+      store.saveProfile('ou_userA', `- a${i}`, 'private'),
+    );
+    const userB = Array.from({ length: 5 }, (_, i) =>
+      store.saveProfile('ou_userB', `- b${i}`, 'private'),
+    );
+    await Promise.all([...userA, ...userB]);
+    const elapsedMs = Date.now() - t0;
+    // Loose bound — just confirms parallelism is preserved across users.
+    // Sequential 10 file-writes on a workstation is comfortably <500ms.
+    if (elapsedMs > 5000) {
+      fail(`3: cross-user writes took ${elapsedMs}ms — suggests global mutex (should be per-user)`);
+    }
+    const linesA = tierLines('ou_userA', 'private');
+    const linesB = tierLines('ou_userB', 'private');
+    if (linesA.length !== 5) fail(`3: ou_userA missing facts: ${JSON.stringify(linesA)}`);
+    if (linesB.length !== 5) fail(`3: ou_userB missing facts: ${JSON.stringify(linesB)}`);
+    testNum++;
+  }
+
+  // 4. Mutex map cleanup — after a save completes and no other call
+  //    has chained on top, the entry must be removed to prevent
+  //    unbounded growth in long-lived daemons.
+  {
+    const user = 'ou_cleanup';
+    await store.saveProfile(user, '- one', 'private');
+    // Give the .then() cleanup microtask a chance to run
+    await new Promise((r) => setTimeout(r, 10));
+    const mutexMap = (store as any).profileMutex as Map<string, unknown>;
+    if (mutexMap.has(user)) {
+      fail(`4: profileMutex entry for ${user} not cleaned up (size=${mutexMap.size})`);
+    }
+    testNum++;
+  }
+
+  // 5. Mutex map keeps entries during active chains — cleanup must NOT
+  //    fire while a later call is still queued.
+  {
+    const user = 'ou_active';
+    // Start a chain of 3 writes
+    const writes = [
+      store.saveProfile(user, '- one', 'private'),
+      store.saveProfile(user, '- two', 'private'),
+      store.saveProfile(user, '- three', 'private'),
+    ];
+    // While the chain is active, the mutex entry must exist
+    const mutexMap = (store as any).profileMutex as Map<string, unknown>;
+    if (!mutexMap.has(user)) {
+      fail(`5: profileMutex entry for active user ${user} missing`);
+    }
+    await Promise.all(writes);
+    // Now flush microtasks and confirm cleanup
+    await new Promise((r) => setTimeout(r, 10));
+    if (mutexMap.has(user)) fail(`5: profileMutex not cleaned up after chain drained`);
+    testNum++;
+  }
+
+  // 6. Error in one chained call doesn't poison subsequent calls.
+  //    We can't easily force saveProfile to throw without monkey-patching;
+  //    instead exercise the mutex helper directly via the `as any` escape.
+  {
+    const user = 'ou_err_chain';
+    const results: string[] = [];
+    const calls = [
+      (store as any).withProfileMutex(user, async () => {
+        results.push('A-ok');
+      }),
+      (store as any).withProfileMutex(user, async () => {
+        results.push('B-throw');
+        throw new Error('synthetic B failure');
+      }),
+      (store as any).withProfileMutex(user, async () => {
+        results.push('C-ok');
+      }),
+    ];
+    // Catch B's rejection so Promise.all doesn't short-circuit early
+    const settled = await Promise.allSettled(calls);
+    if (settled[0].status !== 'fulfilled') fail(`6: A should fulfill`);
+    if (settled[1].status !== 'rejected') fail(`6: B should reject`);
+    if (settled[2].status !== 'fulfilled') fail(`6: C should fulfill despite B's throw`);
+    if (results.join(',') !== 'A-ok,B-throw,C-ok') {
+      fail(`6: out of order: ${results.join(',')}`);
+    }
+    testNum++;
+  }
+
+  // 7. saveProfile + removeProfileLine concurrent on same user serialize
+  //    via the SAME mutex — remove can't run mid-save, save can't run
+  //    mid-remove, the final state is consistent.
+  {
+    const user = 'ou_save_remove';
+    // Seed with two facts
+    await store.saveProfile(user, '- keep me\n- delete me', 'private');
+    const initial = await store.listProfileLines(user, 'private');
+    const deleteTarget = initial.find((l) => l.text === 'delete me');
+    if (!deleteTarget) fail(`7: setup failed — 'delete me' not found`);
+
+    // Fire concurrent remove + save. The interleaving doesn't matter
+    // for correctness; what matters is that BOTH outcomes survive.
+    const ops = [
+      store.removeProfileLine(user, 'private', deleteTarget!.hash),
+      store.saveProfile(user, '- added during remove', 'private'),
+    ];
+    await Promise.all(ops);
+
+    const after = tierLines(user, 'private');
+    if (after.includes('delete me')) fail(`7: 'delete me' should be gone, got ${JSON.stringify(after)}`);
+    if (!after.includes('keep me')) fail(`7: 'keep me' should survive, got ${JSON.stringify(after)}`);
+    if (!after.includes('added during remove')) {
+      fail(`7: concurrent save's delta lost, got ${JSON.stringify(after)}`);
+    }
+    testNum++;
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log(`profile-toctou smoke: ${testNum}/${testNum} PASS`);

--- a/scripts/profile-toctou-smoke.ts
+++ b/scripts/profile-toctou-smoke.ts
@@ -119,7 +119,11 @@ try {
     const user = 'ou_cleanup';
     await store.saveProfile(user, '- one', 'private');
     // Give the .then() cleanup microtask a chance to run
-    await new Promise((r) => setTimeout(r, 10));
+    // R1-followup: drain the cleanup microtask without a wall-clock
+    // dependency. tail.then(cleanup) schedules a microtask; one
+    // Promise.resolve roundtrip is enough to drain it on any runtime.
+    await Promise.resolve();
+    await Promise.resolve();
     const mutexMap = (store as any).profileMutex as Map<string, unknown>;
     if (mutexMap.has(user)) {
       fail(`4: profileMutex entry for ${user} not cleaned up (size=${mutexMap.size})`);
@@ -144,7 +148,11 @@ try {
     }
     await Promise.all(writes);
     // Now flush microtasks and confirm cleanup
-    await new Promise((r) => setTimeout(r, 10));
+    // R1-followup: drain the cleanup microtask without a wall-clock
+    // dependency. tail.then(cleanup) schedules a microtask; one
+    // Promise.resolve roundtrip is enough to drain it on any runtime.
+    await Promise.resolve();
+    await Promise.resolve();
     if (mutexMap.has(user)) fail(`5: profileMutex not cleaned up after chain drained`);
     testNum++;
   }
@@ -202,6 +210,100 @@ try {
     if (!after.includes('keep me')) fail(`7: 'keep me' should survive, got ${JSON.stringify(after)}`);
     if (!after.includes('added during remove')) {
       fail(`7: concurrent save's delta lost, got ${JSON.stringify(after)}`);
+    }
+    testNum++;
+  }
+
+  // 8. R1-followup: saveProfileTiered is atomic across BOTH tier writes.
+  //    Pre-followup the production `profile_tiered` path made two
+  //    separate saveProfile calls (each grabbed the mutex individually),
+  //    so a concurrent same-user save could interleave between them
+  //    and have its private-tier delta clobbered by the private-replace.
+  //    Test: start a tiered write + a single-tier private append in
+  //    parallel; depending on which acquires the mutex first, EITHER
+  //    the append lands cleanly (tiered runs after, replacing private)
+  //    OR the append lands cleanly (tiered runs first, append lands
+  //    after replace). Critical: the append's fact must NOT be
+  //    silently dropped — that was the pre-followup behavior.
+  //    Per-user mutex serializes both operations, so the final state
+  //    is one of two well-defined outcomes.
+  {
+    const user = 'ou_tiered_atomic';
+    // Seed with empty profiles
+    await store.saveProfileTiered(user, { public: '', private: '' });
+
+    // Fire concurrent tiered-replace + private-append
+    const ops = [
+      store.saveProfileTiered(user, {
+        public: '- public fact\n',
+        private: '- tiered private fact\n',
+      }),
+      store.saveProfile(user, '- appended private fact', 'private'),
+    ];
+    await Promise.all(ops);
+
+    const finalPub = tierLines(user, 'public');
+    const finalPriv = tierLines(user, 'private');
+
+    // Public is always '- public fact' (only one writer touches it)
+    if (!finalPub.includes('public fact')) {
+      fail(`8: public tier must always end with tiered's content, got ${JSON.stringify(finalPub)}`);
+    }
+    // Private must contain 'tiered private fact' (from the tiered write)
+    if (!finalPriv.includes('tiered private fact')) {
+      fail(`8: tiered private write lost, got ${JSON.stringify(finalPriv)}`);
+    }
+    // The 'appended private fact' must ALSO appear: if the append ran
+    // FIRST, the tiered replace's private overwrites it. If the append
+    // ran LAST, both survive. The mutex serializes; outcomes per order:
+    //   - tiered first, append second  → both facts present
+    //   - append first, tiered second  → only tiered's fact (append wiped by replace)
+    // Per #54's semantic, BOTH orderings are "no data loss" only if the
+    // operations are conceptually idempotent or commutative — but here
+    // the user explicitly asked for "replace" via tiered. So losing the
+    // append in the (append-first, tiered-second) ordering is correct
+    // behavior: the user's last write (tiered) wins. Test asserts the
+    // final state is ONE of these two outcomes, not the broken
+    // pre-followup "mid-pair clobber" outcome (where private would
+    // contain neither 'tiered private' nor 'appended private').
+    const hasAppended = finalPriv.includes('appended private fact');
+    const onlyTiered =
+      finalPriv.length === 1 && finalPriv.includes('tiered private fact');
+    const bothPresent =
+      finalPriv.includes('tiered private fact') && hasAppended;
+    if (!onlyTiered && !bothPresent) {
+      fail(`8: private must be {tiered only} or {tiered + appended}, got ${JSON.stringify(finalPriv)}`);
+    }
+    testNum++;
+  }
+
+  // 9. R1-followup: saveProfileTiered itself is mutex-wrapped — N
+  //    concurrent tiered writes for the same user serialize correctly,
+  //    none lost.
+  {
+    const user = 'ou_tiered_concurrent';
+    const N = 10;
+    const writes = Array.from({ length: N }, (_, i) =>
+      store.saveProfileTiered(user, {
+        public: `- pub ${i}\n`,
+        private: `- priv ${i}\n`,
+      }),
+    );
+    await Promise.all(writes);
+    // All tiered writes are REPLACE — only the LAST one's content
+    // survives. But the chain order is the order the calls were
+    // queued (synchronous .then chaining in the mutex), which
+    // matches array order, so the last-to-resolve has pub N-1 / priv N-1.
+    const finalPub = tierLines(user, 'public');
+    const finalPriv = tierLines(user, 'private');
+    if (finalPub.length !== 1 || finalPriv.length !== 1) {
+      fail(`9: tiered REPLACE must leave exactly 1 line per tier, got pub=${finalPub.length} priv=${finalPriv.length}`);
+    }
+    if (!finalPub.includes(`pub ${N - 1}`)) {
+      fail(`9: last tiered write's public should survive, got ${JSON.stringify(finalPub)}`);
+    }
+    if (!finalPriv.includes(`priv ${N - 1}`)) {
+      fail(`9: last tiered write's private should survive, got ${JSON.stringify(finalPriv)}`);
     }
     testNum++;
   }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -110,4 +110,8 @@ echo "=== Reaction event whitelist + identity unit checks ==="
 npx tsx scripts/reaction-event-smoke.ts
 
 echo ""
+echo "=== Profile TOCTOU mutex unit checks ==="
+npx tsx scripts/profile-toctou-smoke.ts
+
+echo ""
 echo "All tests passed."

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.33' },
+    { name: 'claude-lark-plugin', version: '1.0.34' },
     {
       capabilities: {
         logging: {},

--- a/src/memory/file.ts
+++ b/src/memory/file.ts
@@ -167,12 +167,70 @@ export interface SkillMeta {
  */
 export class MemoryStore {
   private baseDir: string;
+  /**
+   * Per-user async mutex for profile-tier read-modify-write operations
+   * (#54 fix). `saveProfile` and `removeProfileLine` both do
+   * `read existing → merge → write back`; two concurrent calls for the
+   * same userId from different chats (e.g. a cronjob with `created_by =
+   * ou_user` firing while user is messaging in a group, or two group
+   * chats both seeing distillation results land at once) would race —
+   * both read snapshot S, both compute different merges, second write
+   * silently clobbers the first → one fact lost with no user-visible
+   * error.
+   *
+   * Per-chat `MessageQueue` already serializes traffic within a single
+   * chat, so this only fires for CROSS-chat same-user concurrency. Map
+   * keyed by userId; values are the promise tail of the in-flight chain
+   * for that user. Empty Map in the steady state — entries are cleaned
+   * up on completion to prevent unbounded growth.
+   */
+  private profileMutex = new Map<string, Promise<void>>();
 
   constructor(baseDir?: string) {
     this.baseDir = baseDir ?? appConfig.memoriesDir;
   }
 
   async healthCheck(): Promise<boolean> { return true; }
+
+  /**
+   * Run `fn` under the per-user profile mutex (#54). Subsequent calls
+   * for the same userId queue behind any in-flight one; calls for
+   * different userIds proceed in parallel.
+   *
+   * Failures in `fn` do NOT poison subsequent calls — the chain
+   * advances regardless of outcome (matches `MessageQueue` semantics in
+   * `src/queue.ts`). The caller of `withProfileMutex` sees fn's own
+   * rejection; the next queued call still gets its turn.
+   *
+   * NOTE on deadlock safety: callers of this method must NOT recurse
+   * back into a mutex-wrapped function on the same userId. Today only
+   * `saveProfile` and `removeProfileLine` are wrapped, neither calls
+   * the other, and they don't call themselves. A future addition that
+   * violates this would deadlock — gate via code review.
+   */
+  private withProfileMutex<T>(userId: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.profileMutex.get(userId) ?? Promise.resolve();
+    // Chain fn after prev SYNCHRONOUSLY (no await between get and set —
+    // else two callers reading the same `prev` would both register as
+    // its successor and run in parallel, defeating the mutex).
+    const next: Promise<T> = prev.then(
+      () => fn(),
+      () => fn(), // run even if a prior call rejected
+    );
+    const tail: Promise<void> = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.profileMutex.set(userId, tail);
+    // Cleanup: delete the entry when this call's tail resolves AND no
+    // later call has chained on top. Prevents unbounded Map growth.
+    tail.then(() => {
+      if (this.profileMutex.get(userId) === tail) {
+        this.profileMutex.delete(userId);
+      }
+    });
+    return next;
+  }
 
   // ── User Profile (tiered, v0.10.0+) ──
 
@@ -321,6 +379,24 @@ export class MemoryStore {
     tier: Tier,
     mode: 'append' | 'replace' = 'append',
   ): Promise<void> {
+    // #54 fix: serialize cross-chat concurrent writes for the same userId.
+    return this.withProfileMutex(userId, async () => {
+      await this._saveProfileLocked(userId, content, tier, mode);
+    });
+  }
+
+  /**
+   * Body of saveProfile, callable only under the per-user profile mutex.
+   * Split from the public method so the mutex wrapping lives at the
+   * boundary and the body stays readable (and future internal callers
+   * that ARE already under the mutex can skip the re-entry).
+   */
+  private async _saveProfileLocked(
+    userId: string,
+    content: string,
+    tier: Tier,
+    mode: 'append' | 'replace',
+  ): Promise<void> {
     await this.migrateIfNeeded(userId);
 
     // L1 safety net (#75). CLAUDE.md promises a 3-layer defense
@@ -460,18 +536,25 @@ export class MemoryStore {
     tier: Tier,
     hash: string,
   ): Promise<{ removed: number; sample: string | null; allTexts: string[] }> {
-    const lines = await this.listProfileLines(ownerId, tier);
-    const targets = lines.filter((l) => l.hash === hash);
-    if (targets.length === 0) return { removed: 0, sample: null, allTexts: [] };
-    const kept = lines.filter((l) => l.hash !== hash);
+    // #54 fix: same per-user mutex as saveProfile. removeProfileLine has
+    // the same read-modify-write shape (`listProfileLines → filter →
+    // writeFile`) and the same cross-chat race window: a forget_memory
+    // in chat A concurrent with a save_memory in chat B for the same
+    // user would lose the save's delta if forget's write landed last.
+    return this.withProfileMutex(ownerId, async () => {
+      const lines = await this.listProfileLines(ownerId, tier);
+      const targets = lines.filter((l) => l.hash === hash);
+      if (targets.length === 0) return { removed: 0, sample: null, allTexts: [] };
+      const kept = lines.filter((l) => l.hash !== hash);
 
-    const next = kept.map((l) => `- ${l.text}`).join('\n') + (kept.length > 0 ? '\n' : '');
-    await fs.writeFile(this.profileTierPath(ownerId, tier), next, 'utf-8');
-    return {
-      removed: targets.length,
-      sample: targets[0].text,
-      allTexts: targets.map((t) => t.text),
-    };
+      const next = kept.map((l) => `- ${l.text}`).join('\n') + (kept.length > 0 ? '\n' : '');
+      await fs.writeFile(this.profileTierPath(ownerId, tier), next, 'utf-8');
+      return {
+        removed: targets.length,
+        sample: targets[0].text,
+        allTexts: targets.map((t) => t.text),
+      };
+    });
   }
 
   // ── Episodes ──

--- a/src/memory/file.ts
+++ b/src/memory/file.ts
@@ -224,11 +224,24 @@ export class MemoryStore {
     this.profileMutex.set(userId, tail);
     // Cleanup: delete the entry when this call's tail resolves AND no
     // later call has chained on top. Prevents unbounded Map growth.
-    tail.then(() => {
-      if (this.profileMutex.get(userId) === tail) {
-        this.profileMutex.delete(userId);
-      }
-    });
+    //
+    // R1-followup belt-and-suspenders: tail is already constructed with
+    // both .then handlers returning undefined (lines just above) so it
+    // can never reject — but a future contributor refactoring this
+    // file might inadvertently swap `tail` for `next` here, which would
+    // produce unhandled rejections every time fn() rejects. The
+    // explicit .catch closes that hole.
+    tail.then(
+      () => {
+        if (this.profileMutex.get(userId) === tail) {
+          this.profileMutex.delete(userId);
+        }
+      },
+      () => {
+        // Unreachable today (tail handlers above always resolve),
+        // belt-and-suspenders only.
+      },
+    );
     return next;
   }
 
@@ -380,8 +393,75 @@ export class MemoryStore {
     mode: 'append' | 'replace' = 'append',
   ): Promise<void> {
     // #54 fix: serialize cross-chat concurrent writes for the same userId.
+    // INVARIANT: anything inside this closure must NOT recurse back into
+    // saveProfile / saveProfileTiered / removeProfileLine for the same
+    // userId — would deadlock the per-user mutex.
     return this.withProfileMutex(userId, async () => {
       await this._saveProfileLocked(userId, content, tier, mode);
+    });
+  }
+
+  /**
+   * Atomic dual-tier replace (#54 R1-followup). The `profile_tiered` path
+   * (called from `tools.ts:save_memory(type='profile_tiered')` and the
+   * auto-flush distillation flow) needs to REPLACE both `public.md` and
+   * `private.md` from a single fresh read of recent history. Pre-followup
+   * this was two separate `saveProfile(...,'replace')` calls — each grabbed
+   * the per-user mutex independently, so a CROSS-CHAT save between the two
+   * calls could land mid-pair (after public-replace but before private-
+   * replace), then be silently clobbered by the private-replace. The dual
+   * write was NOT atomic from a same-user-cross-chat concurrency
+   * perspective even with the #54 fix.
+   *
+   * This method does both writes inside ONE `withProfileMutex` invocation,
+   * so the public+private pair is observable as atomic to any other
+   * concurrent same-user save / remove.
+   *
+   * Inputs are pre-formatted strings (caller does the JSON parse + bullet
+   * formatting; we don't re-parse). L1 safety net is re-applied to the
+   * public tier as defense-in-depth — even though `parseTieredProfile`
+   * already classified, a future caller bypassing parseTieredProfile
+   * would still get the L1 protection.
+   */
+  async saveProfileTiered(
+    userId: string,
+    content: { public: string; private: string },
+  ): Promise<void> {
+    return this.withProfileMutex(userId, async () => {
+      await this.migrateIfNeeded(userId);
+
+      // L1 safety net (defense-in-depth — see saveProfile's analogous
+      // path at lines 408-440). Lines that pass parseTieredProfile but
+      // L1 thinks are private get moved into the replacement private
+      // content here, not appended on top of existing private — because
+      // the caller's intent is REPLACE of both tiers.
+      const publicLines = content.public.split('\n');
+      const safePublic: string[] = [];
+      const redirected: string[] = [];
+      for (const line of publicLines) {
+        if (line.trim() && applyL1(line) === 'private') {
+          redirected.push(line);
+        } else {
+          safePublic.push(line);
+        }
+      }
+      if (redirected.length > 0) {
+        console.error(
+          `[memory] L1 safety net (saveProfileTiered): redirected ${redirected.length} line(s) ` +
+          `from public to private for ${userId} (LLM-classified public but L1 matched private rules).`,
+        );
+      }
+      const sep =
+        content.private && !content.private.endsWith('\n') ? '\n' : '';
+      const finalPrivate =
+        redirected.length > 0
+          ? content.private + sep + redirected.join('\n')
+          : content.private;
+
+      // Atomic pair INSIDE the single mutex acquisition. No other
+      // same-user save / remove can interleave between these two writes.
+      await this._writeProfileTier(userId, 'public', safePublic.join('\n'), 'replace');
+      await this._writeProfileTier(userId, 'private', finalPrivate, 'replace');
     });
   }
 
@@ -541,6 +621,10 @@ export class MemoryStore {
     // writeFile`) and the same cross-chat race window: a forget_memory
     // in chat A concurrent with a save_memory in chat B for the same
     // user would lose the save's delta if forget's write landed last.
+    //
+    // INVARIANT: anything inside this closure must NOT recurse back into
+    // saveProfile / saveProfileTiered / removeProfileLine for the same
+    // ownerId — would deadlock the per-user mutex.
     return this.withProfileMutex(ownerId, async () => {
       const lines = await this.listProfileLines(ownerId, tier);
       const targets = lines.filter((l) => l.hash === hash);

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -86,9 +86,9 @@ Return the JSON object inline (no code fence). Then call save_memory once with t
 
   save_memory(type="profile_tiered", content=<the JSON string>, reason=<why>, chat_id=<current>)
 
-The server parses the JSON, applies the L1 privacy safety net (anything classified public that matches a regex/keyword rule like phone numbers, IDs, credentials, salary keywords is forced into private), and writes the two tier files via sequential saveProfile calls. The writes are NOT a single atomic transaction — a concurrent getProfile in the window between them sees public-new + private-old — but each individual write IS atomic, and per-chat queueing serializes any other save_memory call on the same user.
+The server parses the JSON, applies the L1 privacy safety net (anything classified public that matches a regex/keyword rule like phone numbers, IDs, credentials, salary keywords is forced into private), and writes BOTH tier files atomically under a per-user lock (v1.0.34, #54). No other save_memory call for the same user can interleave between the two tier writes. (A concurrent getProfile read mid-pair can still see public-new + private-old for a sub-ms window — acceptable for an enrichment read.)
 
-Do NOT make two separate save_memory(type="profile") calls. The pre-v1.0.17 dual-call pattern (public-replace then private-replace) races with the L1 safety net inside saveProfile: the first call's L1 redirect appends sensitive lines to private.md, then the second call's replace silently wipes them (#97).
+Do NOT make two separate save_memory(type="profile") calls for one logical update. The pre-v1.0.17 dual-call pattern (public-replace then private-replace) was racy with the L1 safety net (#97); use the single type="profile_tiered" call instead.
 
 If the call returns isError (malformed JSON / non-array shape), fix the JSON and retry once. Both arrays empty is a NO-OP (existing tiers preserved) — emit at least one array element if you want to commit a real update.`;
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1088,17 +1088,24 @@ export function registerTools(
             .map((line) => (line.startsWith('-') ? line : `- ${line}`))
             .join('\n') +
           (arr.some((s) => oneLine(s).length > 0) ? '\n' : '');
-        // The two writes are sequential, NOT a single atomic transaction.
-        // A concurrent getProfile call in the window between them would
-        // see public-new + private-old (sub-ms window on a healthy
-        // filesystem). Per-chat queueing (src/queue.ts) serializes any
-        // other save_memory on the same user, so no save can race here,
-        // but read paths (memory enrichment in src/channel.ts) are
-        // unqueued. Tracked alongside the saveProfile TOCTOU at #54;
-        // a true atomic-pair write would need a per-user lock or a
-        // temp-dir-and-rename of profiles/<userId>/.
-        await memoryStore.saveProfile(caller, fmt(tiered.public), 'public', 'replace');
-        await memoryStore.saveProfile(caller, fmt(tiered.private), 'private', 'replace');
+        // v1.0.34 (R1-followup on #54): single atomic-pair write under
+        // the per-user profile mutex. Pre-fix two sequential saveProfile
+        // calls each grabbed the mutex independently — a cross-chat
+        // save landing AFTER public-replace but BEFORE private-replace
+        // would have its private-tier delta clobbered. The new
+        // saveProfileTiered method serializes the pair under ONE mutex
+        // acquisition so the public+private write is observable as
+        // atomic to any other concurrent same-user save / remove.
+        //
+        // Residual: read paths (memory enrichment in src/channel.ts) are
+        // still unqueued — a concurrent getProfile mid-pair sees
+        // public-new + private-old for a sub-ms window. Acceptable for
+        // an enrichment read (which is best-effort context); not for
+        // the WRITE path where a lost delta is data loss.
+        await memoryStore.saveProfileTiered(caller, {
+          public: fmt(tiered.public),
+          private: fmt(tiered.private),
+        });
         void audit('save_memory', caller, auditArgs, 'ok');
         return {
           content: [


### PR DESCRIPTION
## Summary

Closes #54. `saveProfile` and `removeProfileLine` both do `read existing → merge → write back` on the profile tier file. Two concurrent calls for the SAME `userId` from different chats race:

1. Call A reads `existing = S`
2. Call B reads `existing = S` (same snapshot)
3. Call A writes `S ∪ deltaA`
4. Call B writes `S ∪ deltaB` → **deltaA silently lost**

Per-chat `MessageQueue` already serializes within a single chat, so this only fires for **CROSS-chat same-user concurrency** — narrow but reachable in any deployment with cronjobs targeting a user who's also actively chatting elsewhere, or two chats (DM + group) both processing messages from the same user concurrently.

## Fix

Per-user async mutex on `MemoryStore`:

```ts
private profileMutex = new Map<string, Promise<void>>();

private withProfileMutex<T>(userId: string, fn: () => Promise<T>): Promise<T>
```

`saveProfile` and `removeProfileLine` wrap their bodies via `withProfileMutex(userId, async () => { ... })`. Per-user keying preserves cross-user parallelism. Failures don't poison the chain (matches `MessageQueue` in `src/queue.ts`). Map entries clean up on completion when no chain follows.

### Scope decision

Also wrapped `removeProfileLine` — it has the same RMW shape (`listProfileLines → filter → writeFile`) and the same cross-chat exposure (a `forget_memory` racing with `save_memory` would lose the save's delta if forget's write landed last). Covering both with the same mutex avoids a follow-up PR for the symmetric path.

### Cross-process note

The mutex is single-process. A second MCP process writing the same profile would still race — but `src/lock.ts` (v1.0.23) structurally blocks two processes from running concurrently, so cross-process exposure is unreachable.

## Tests

New `scripts/profile-toctou-smoke.ts` (7 tests, wired into `scripts/test.sh`):

| # | Behavior |
|---|---|
| 1 | Sequential baseline (harness sanity check) |
| **2** | **THE BUG**: 20 concurrent same-user `saveProfile` calls — pre-fix would have lost most deltas, post-fix all 20 survive |
| 3 | Cross-user writes run in parallel (loose timing bound) — confirms per-user keying isn't a global mutex |
| 4 | Map cleanup post-completion |
| 5 | Map keeps entries while a chain is active (no premature cleanup) |
| 6 | One call throwing does NOT poison the chain — `A → B(throw) → C` all in order, A/C fulfill, B rejects |
| 7 | `saveProfile` + `removeProfileLine` concurrent on same user → both outcomes survive |

`profile-toctou smoke: 7/7 PASS`. Full suite green.

## Operator notes

- No data-format or config changes. Existing profile files are read/written in the same shape as v1.0.33; nothing to migrate.
- Pre-#54 data lost to the race cannot be recovered — the losing write just doesn't reach disk, no on-disk evidence.
- The mutex Map is bounded by concurrent-active-users (empty in steady state). No tunable.

## Test plan

- [x] `npm run typecheck` clean
- [x] `bash scripts/test.sh` all green (`profile-toctou smoke: 7/7`)
- [x] Version bumped to 1.0.34 across 5 locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)