### PR TITLE
fix(channel): inbox GC — age expiry + LRU size cap + startup sweep (v1.0.35)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.34",
+      "version": "1.0.35",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   Best-effort throughout: `unlink` failures (file vanished concurrently, EACCES) are swallowed so one bad file doesn't abort cleanup of the rest. `readdir` failure (dir missing during a race) is a no-op.
 
 ### Added
-- New module `src/inbox-gc.ts` — `gcInbox(opts)` returns `{ removed, bytesFreed, finalSize, remaining }` for tests + operator logging. `runInboxGcOnce()` is the timer wrapper that logs at info-level only when something was actually removed (silent on most idle ticks).
-- New `scripts/inbox-gc-smoke.ts` (10 tests, wired into `scripts/test.sh`):
+- New module `src/inbox-gc.ts` — `gcInbox(opts)` returns `{ removed, bytesFreed, finalSize, remaining }` for tests + operator logging. `runInboxGcOnce()` is the timer wrapper that logs at info-level only when something was actually removed (silent on most idle ticks). The `unlinkFn` option is a test-only hook for cross-platform EACCES simulation.
+- New `scripts/inbox-gc-smoke.ts` (12 tests, wired into `scripts/test.sh`):
   - 1: missing directory → all-zeros result, no throw
   - 2: empty directory → all-zeros
   - 3: age expiry — older-than-cutoff deleted, fresher kept
@@ -32,6 +32,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   - 8: nothing-to-do happy path (all fresh, under cap)
   - 9: size cap boundary (total === cap, no eviction — strict `>`)
   - 10: mixed file types — PNG, PDF, BIN, no-extension all eligible
+  - **11 (R2-followup)**: pass 1 (age) — `unlink` failure pushes the entry back into survivors so `finalSize`/`remaining` reflect actual on-disk state (this path was already correct pre-followup; locking in as regression guard)
+  - **12 (R2-followup, THE BUG)**: pass 2 (LRU) — `unlink` failure must NOT silently subtract from `totalSize`. Pre-followup the undeletable's bytes were subtracted as if freed, and the entry was dropped from survivors → `finalSize=0, remaining=0` lied about disk state. Post-followup: undeletables are stashed and re-pushed into survivors at loop exit; `finalSize`/`remaining` are accurate.
+
+### R2-audit followups (closed in this PR)
+- **Pass-2 LRU accounting asymmetry** (the bug above). Pre-followup, pass 1 (age) correctly handled `unlink` failure by re-pushing the entry into `survivors`; pass 2 (LRU) was asymmetric — unconditional `shift()` + unconditional `totalSize -= oldest.size` even in the catch branch. An undeletable file (EACCES) was silently counted as freed in the stats. The stderr log line `[inbox-gc] removed X file(s), freed YMB (N remain, ZMB total)` lied about actual disk state. Operator-cosmetic (the loop still terminated correctly), but the dishonest stats are exactly the kind of regression that erodes operator trust in the GC. Fixed by stashing undeletables in a separate list and pushing them back into `survivors` after the loop, so the returned stats reflect what's actually on disk.
+- **`timer.unref?.()` → `timer.unref()`** in `src/index.ts` — R2 noted the optional-chain was cosmetic since `setInterval` always returns a `NodeJS.Timeout` with `unref` defined.
+- **`unlinkFn` test hook** added to `GcInboxOptions` — test-only dependency injection for cross-platform EACCES simulation (cleaner than chmod gymnastics). Production callers don't pass it.
 - New env vars (in `src/config.ts`):
   - `LARK_INBOX_MAX_AGE_DAYS` (default 7) — age threshold in days
   - `LARK_INBOX_MAX_SIZE_MB` (default 500) — directory size cap in MB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.35] - 2026-05-25
+
+### Fixed
+- **Inbox directory grew unboundedly — no rotation / GC for downloaded images and attachments** (#89 — **MEDIUM production disk hygiene**). `~/.claude/channels/lark/inbox/` was the unified landing zone for `LarkChannel.downloadImage` (auto-downloaded images from inbound messages) and the `download_attachment` tool. Both paths called `fs.writeFile` and never `fs.unlink` — no startup sweep, no periodic GC, no size cap. A heavy-image deployment (group with screenshots / PDFs / memes) would silently fill the disk over weeks (4MB screenshot × 50/day/group × multiple groups × 30 days easily exceeds 6GB/month). Privacy residue too: users assumed sending an image in chat was the end of it; the file in fact persisted locally forever even after plugin uninstall.
+
+  Fix: new `src/inbox-gc.ts` module exporting `gcInbox(opts)` pure function + `runInboxGcOnce()` wrapper for the scheduler. Two complementary policies:
+  - **Age expiry**: files with `mtime < now - maxAgeMs` are unlinked. Default 7 days — comfortably exceeds any reasonable Claude turn (largest observed is single-digit minutes), so a mid-turn `Read` of `image_path` notification meta always finds its file. Strict `<` boundary so an entry exactly at the threshold is borderline-kept (matches `isMissedRunStale` convention in `src/scheduler.ts`).
+  - **Size cap (LRU)**: if total directory size exceeds `maxSizeBytes` AFTER the age pass, sort surviving entries by `mtime` ascending and unlink oldest-first until under cap. Default 500 MB.
+
+  `src/index.ts` runs `runInboxGcOnce()` at startup, then installs a `setInterval` at `LARK_INBOX_GC_INTERVAL_MIN` cadence (default 60 min). `.unref()` so the timer never holds an idle process open.
+
+  Subdirectories are NOT recursed (the inbox is flat by file path construction in both call sites; `path.join(inboxDir, filename)` lands files at top-level only). The `e.isFile()` check at scan time skips any operator-created subdirectory (e.g. manual archival via `mv old/* inbox/archive-2026-04/`).
+
+  Best-effort throughout: `unlink` failures (file vanished concurrently, EACCES) are swallowed so one bad file doesn't abort cleanup of the rest. `readdir` failure (dir missing during a race) is a no-op.
+
+### Added
+- New module `src/inbox-gc.ts` — `gcInbox(opts)` returns `{ removed, bytesFreed, finalSize, remaining }` for tests + operator logging. `runInboxGcOnce()` is the timer wrapper that logs at info-level only when something was actually removed (silent on most idle ticks).
+- New `scripts/inbox-gc-smoke.ts` (10 tests, wired into `scripts/test.sh`):
+  - 1: missing directory → all-zeros result, no throw
+  - 2: empty directory → all-zeros
+  - 3: age expiry — older-than-cutoff deleted, fresher kept
+  - 4: boundary — file at exactly `cutoff` is KEPT (strict `<`); file at `cutoff - 1ms` is removed
+  - 5: size cap LRU — 5 × 100MB files, cap 250MB → 3 oldest evicted, 2 newest survive
+  - 6: combined — age pass removes 2, size pass removes 2 more; final state asserted
+  - 7: subdirectories untouched
+  - 8: nothing-to-do happy path (all fresh, under cap)
+  - 9: size cap boundary (total === cap, no eviction — strict `>`)
+  - 10: mixed file types — PNG, PDF, BIN, no-extension all eligible
+- New env vars (in `src/config.ts`):
+  - `LARK_INBOX_MAX_AGE_DAYS` (default 7) — age threshold in days
+  - `LARK_INBOX_MAX_SIZE_MB` (default 500) — directory size cap in MB
+  - `LARK_INBOX_GC_INTERVAL_MIN` (default 60) — periodic GC cadence in minutes
+  - `LARK_INBOX_GC_DISABLED` (default false) — opt-out for forensic / archival deployments
+
+### Operator notes
+- Pre-#89 deployments: on first startup after upgrade, the GC will sweep accumulated files older than 7 days AND evict to the 500MB cap. A long-running deployment with GBs of accumulated images will see a large one-shot cleanup in the startup log (`[inbox-gc] removed N file(s), freed XYZ MB ...`). This is intentional. If you want to preserve everything for one-time archival, set `LARK_INBOX_GC_DISABLED=true` for the first run, move what you need out of the inbox, then re-enable.
+- The startup line `[index] Inbox GC enabled (maxAge=7d, maxSize=500MB, interval=60min)` is the operator's confirmation that the GC is active and visible into the configuration.
+- Mid-turn safety: the 7-day age threshold is intentionally far larger than any reasonable Claude turn. A turn that opens an `image_path` from inbox WILL find its file. If you have unusual long-running turns (research agents, large prompts), tune `LARK_INBOX_MAX_AGE_DAYS` UP, never down.
+- Future improvement filed as a scope-note: month-subdirectory rotation (`inbox/2026-05/`) would make manual archival easier; not in this PR (keeps the flat-directory invariant the call sites assume).
+
 ## [1.0.34] - 2026-05-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Operator notes
 - Pre-#89 deployments: on first startup after upgrade, the GC will sweep accumulated files older than 7 days AND evict to the 500MB cap. A long-running deployment with GBs of accumulated images will see a large one-shot cleanup in the startup log (`[inbox-gc] removed N file(s), freed XYZ MB ...`). This is intentional. If you want to preserve everything for one-time archival, set `LARK_INBOX_GC_DISABLED=true` for the first run, move what you need out of the inbox, then re-enable.
 - The startup line `[index] Inbox GC enabled (maxAge=7d, maxSize=500MB, interval=60min)` is the operator's confirmation that the GC is active and visible into the configuration.
-- Mid-turn safety: the 7-day age threshold is intentionally far larger than any reasonable Claude turn. A turn that opens an `image_path` from inbox WILL find its file. If you have unusual long-running turns (research agents, large prompts), tune `LARK_INBOX_MAX_AGE_DAYS` UP, never down.
+- Mid-turn safety: the 7-day age threshold is intentionally far larger than any reasonable Claude turn. A turn that opens an `image_path` from inbox WILL find its file. If you have unusual long-running turns (research agents, large prompts), tune `LARK_INBOX_MAX_AGE_DAYS` UP, never down — there is NO reference-counting layer between the GC and in-flight turns; if you lower below the longest expected turn duration, a Read can race the GC and fail with ENOENT.
+- **Env footgun (R1-followup)**: `LARK_INBOX_MAX_AGE_DAYS=0` and `LARK_INBOX_MAX_SIZE_MB=0` are NOT safe "disable" knobs — they are "delete essentially everything on the next tick." The actual disable is `LARK_INBOX_GC_DISABLED=true`.
 - Future improvement filed as a scope-note: month-subdirectory rotation (`inbox/2026-05/`) would make manual archival easier; not in this PR (keeps the flat-directory invariant the call sites assume).
 
 ## [1.0.34] - 2026-05-25

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.34",
+      "version": "1.0.35",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/inbox-gc-smoke.ts
+++ b/scripts/inbox-gc-smoke.ts
@@ -1,0 +1,245 @@
+/**
+ * Inbox GC smoke test (v1.0.35, closes #89).
+ *
+ * Exercises `gcInbox` (pure function) directly. Uses an injected `dir`
+ * so we don't touch the real ~/.claude inbox, and an injected `now`
+ * for deterministic age computations.
+ */
+
+// Set env BEFORE importing config — values aren't actually used because
+// we inject opts directly, but config validation happens at import time.
+process.env.LARK_APP_ID = process.env.LARK_APP_ID ?? 'cli_test_app_id';
+process.env.LARK_APP_SECRET = process.env.LARK_APP_SECRET ?? 'test_secret';
+
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+  utimesSync,
+  readdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { gcInbox } from '../src/inbox-gc.js';
+
+function fail(msg: string): never {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+let testNum = 0;
+
+// Helper: create a file with a specific mtime (seconds since epoch) and
+// content of `sizeBytes` bytes.
+function makeFile(dir: string, name: string, sizeBytes: number, mtimeMs: number): string {
+  const p = join(dir, name);
+  writeFileSync(p, Buffer.alloc(sizeBytes, 0));
+  const t = mtimeMs / 1000; // utimes wants seconds
+  utimesSync(p, t, t);
+  return p;
+}
+
+const tmp = mkdtempSync(join(tmpdir(), 'inbox-gc-'));
+const DAY_MS = 86_400_000;
+const MB = 1024 * 1024;
+const NOW = 1_700_000_000_000;
+
+try {
+  // 1. Missing directory → no throw, all-zeros result
+  {
+    const r = await gcInbox({
+      dir: join(tmp, 'nonexistent'),
+      maxAgeMs: 7 * DAY_MS,
+      maxSizeBytes: 500 * MB,
+      now: NOW,
+    });
+    if (r.removed !== 0 || r.bytesFreed !== 0 || r.finalSize !== 0 || r.remaining !== 0) {
+      fail(`1: missing dir should return zeros, got ${JSON.stringify(r)}`);
+    }
+    testNum++;
+  }
+
+  // 2. Empty directory → no throw, all-zeros result
+  {
+    const dir = mkdtempSync(join(tmp, 'empty-'));
+    const r = await gcInbox({ dir, maxAgeMs: 7 * DAY_MS, maxSizeBytes: 500 * MB, now: NOW });
+    if (r.removed !== 0 || r.remaining !== 0) {
+      fail(`2: empty dir should return zeros, got ${JSON.stringify(r)}`);
+    }
+    testNum++;
+  }
+
+  // 3. Age expiry: file older than maxAge gets deleted, fresh file kept
+  {
+    const dir = mkdtempSync(join(tmp, 'age-'));
+    makeFile(dir, 'old.png', 1024, NOW - 8 * DAY_MS); // 8 days old → delete
+    makeFile(dir, 'fresh.png', 2048, NOW - 1 * DAY_MS); // 1 day old → keep
+    const r = await gcInbox({
+      dir,
+      maxAgeMs: 7 * DAY_MS,
+      maxSizeBytes: 500 * MB,
+      now: NOW,
+    });
+    if (r.removed !== 1) fail(`3: expected 1 removed, got ${r.removed}`);
+    if (r.bytesFreed !== 1024) fail(`3: bytesFreed expected 1024, got ${r.bytesFreed}`);
+    if (r.remaining !== 1) fail(`3: 1 file should remain, got ${r.remaining}`);
+    if (!existsSync(join(dir, 'fresh.png'))) fail(`3: fresh file should survive`);
+    if (existsSync(join(dir, 'old.png'))) fail(`3: old file should be gone`);
+    testNum++;
+  }
+
+  // 4. Boundary: file exactly at threshold (mtime === cutoff) is KEPT
+  //    (strict `<` for stale check, matches isMissedRunStale convention)
+  {
+    const dir = mkdtempSync(join(tmp, 'boundary-'));
+    makeFile(dir, 'exactly-at.png', 1024, NOW - 7 * DAY_MS); // exactly 7 days
+    makeFile(dir, 'just-over.png', 1024, NOW - 7 * DAY_MS - 1); // 7d + 1ms
+    const r = await gcInbox({
+      dir,
+      maxAgeMs: 7 * DAY_MS,
+      maxSizeBytes: 500 * MB,
+      now: NOW,
+    });
+    if (r.removed !== 1) fail(`4: expected exactly 1 removed (just-over), got ${r.removed}`);
+    if (!existsSync(join(dir, 'exactly-at.png'))) fail(`4: exactly-at-threshold must survive`);
+    if (existsSync(join(dir, 'just-over.png'))) fail(`4: just-over-threshold must be removed`);
+    testNum++;
+  }
+
+  // 5. Size cap LRU: total > cap → evict oldest first until under cap.
+  //    All files fresh (within age), only size matters.
+  {
+    const dir = mkdtempSync(join(tmp, 'lru-'));
+    // 5 files, 100MB each, total 500MB. Cap = 250MB → evict 3 oldest.
+    for (let i = 0; i < 5; i++) {
+      makeFile(dir, `file-${i}.png`, 100 * MB, NOW - (5 - i) * 60_000);
+      // file-0 is oldest (5min), file-4 is newest (1min)
+    }
+    const r = await gcInbox({
+      dir,
+      maxAgeMs: 7 * DAY_MS,
+      maxSizeBytes: 250 * MB,
+      now: NOW,
+    });
+    if (r.removed !== 3) fail(`5: expected 3 evicted, got ${r.removed}`);
+    // Should remain: file-3, file-4 (the two newest)
+    if (existsSync(join(dir, 'file-0.png'))) fail(`5: file-0 (oldest) should be evicted`);
+    if (existsSync(join(dir, 'file-1.png'))) fail(`5: file-1 should be evicted`);
+    if (existsSync(join(dir, 'file-2.png'))) fail(`5: file-2 should be evicted`);
+    if (!existsSync(join(dir, 'file-3.png'))) fail(`5: file-3 should survive`);
+    if (!existsSync(join(dir, 'file-4.png'))) fail(`5: file-4 should survive`);
+    if (r.finalSize !== 200 * MB) fail(`5: finalSize expected 200MB, got ${r.finalSize}`);
+    testNum++;
+  }
+
+  // 6. Combined: age expiry FIRST removes some files; remaining size
+  //    still over cap → LRU pass removes more. Confirms the two passes
+  //    compose correctly.
+  {
+    const dir = mkdtempSync(join(tmp, 'combined-'));
+    // 2 stale files (10MB each) + 4 fresh files (100MB each) = 420MB
+    // After age pass: 4 × 100MB = 400MB
+    // Size cap 250MB → evict 2 oldest fresh ones
+    // Final: 2 × 100MB = 200MB
+    makeFile(dir, 'stale-a.png', 10 * MB, NOW - 8 * DAY_MS);
+    makeFile(dir, 'stale-b.png', 10 * MB, NOW - 9 * DAY_MS);
+    for (let i = 0; i < 4; i++) {
+      makeFile(dir, `fresh-${i}.png`, 100 * MB, NOW - (4 - i) * 60_000);
+    }
+    const r = await gcInbox({
+      dir,
+      maxAgeMs: 7 * DAY_MS,
+      maxSizeBytes: 250 * MB,
+      now: NOW,
+    });
+    // 2 stale removed by age + 2 fresh evicted by size = 4 total
+    if (r.removed !== 4) fail(`6: expected 4 total removed, got ${r.removed}`);
+    if (r.bytesFreed !== 2 * 10 * MB + 2 * 100 * MB) {
+      fail(`6: bytesFreed mismatch: ${r.bytesFreed}`);
+    }
+    if (r.finalSize !== 200 * MB) fail(`6: finalSize expected 200MB, got ${r.finalSize}`);
+    // Verify the right files survive (the 2 NEWEST of the 4 fresh)
+    if (!existsSync(join(dir, 'fresh-2.png'))) fail(`6: fresh-2 should survive`);
+    if (!existsSync(join(dir, 'fresh-3.png'))) fail(`6: fresh-3 should survive`);
+    if (existsSync(join(dir, 'fresh-0.png'))) fail(`6: fresh-0 should be size-evicted`);
+    if (existsSync(join(dir, 'fresh-1.png'))) fail(`6: fresh-1 should be size-evicted`);
+    testNum++;
+  }
+
+  // 7. Subdirectories ignored — only top-level files counted
+  {
+    const dir = mkdtempSync(join(tmp, 'subdir-'));
+    makeFile(dir, 'top.png', 100, NOW - 8 * DAY_MS); // stale, should delete
+    // Create a subdir with a stale file inside — must NOT be touched
+    const sub = mkdtempSync(join(dir, 'sub-'));
+    makeFile(sub, 'inner.png', 100, NOW - 30 * DAY_MS);
+    const r = await gcInbox({
+      dir,
+      maxAgeMs: 7 * DAY_MS,
+      maxSizeBytes: 500 * MB,
+      now: NOW,
+    });
+    if (r.removed !== 1) fail(`7: only top-level file should be removed, got ${r.removed}`);
+    if (!existsSync(join(sub, 'inner.png'))) fail(`7: subdirectory contents must survive`);
+    testNum++;
+  }
+
+  // 8. All files survive when nothing is stale + size is under cap
+  {
+    const dir = mkdtempSync(join(tmp, 'survive-'));
+    for (let i = 0; i < 3; i++) {
+      makeFile(dir, `keep-${i}.png`, 10 * MB, NOW - i * 60_000);
+    }
+    const r = await gcInbox({
+      dir,
+      maxAgeMs: 7 * DAY_MS,
+      maxSizeBytes: 500 * MB,
+      now: NOW,
+    });
+    if (r.removed !== 0) fail(`8: nothing should be removed, got ${r.removed}`);
+    if (r.remaining !== 3) fail(`8: all 3 should remain, got ${r.remaining}`);
+    if (readdirSync(dir).length !== 3) fail(`8: 3 files should still be on disk`);
+    testNum++;
+  }
+
+  // 9. Size cap exactly at total: borderline case, nothing evicted
+  //    (uses strict `>`, so total === cap is fine)
+  {
+    const dir = mkdtempSync(join(tmp, 'exact-'));
+    for (let i = 0; i < 5; i++) {
+      makeFile(dir, `f-${i}.png`, 50 * MB, NOW - i * 60_000); // 250MB total
+    }
+    const r = await gcInbox({
+      dir,
+      maxAgeMs: 7 * DAY_MS,
+      maxSizeBytes: 250 * MB, // exactly equal — no eviction
+      now: NOW,
+    });
+    if (r.removed !== 0) fail(`9: at-cap should not evict (strict >), got ${r.removed}`);
+    if (r.finalSize !== 250 * MB) fail(`9: finalSize should equal cap, got ${r.finalSize}`);
+    testNum++;
+  }
+
+  // 10. Mixed file types (no extension filtering — inbox holds whatever)
+  {
+    const dir = mkdtempSync(join(tmp, 'mixed-'));
+    makeFile(dir, 'screenshot.png', 100, NOW - 8 * DAY_MS);
+    makeFile(dir, 'report.pdf', 100, NOW - 8 * DAY_MS);
+    makeFile(dir, 'data.bin', 100, NOW - 8 * DAY_MS);
+    makeFile(dir, 'no-ext', 100, NOW - 8 * DAY_MS);
+    const r = await gcInbox({
+      dir,
+      maxAgeMs: 7 * DAY_MS,
+      maxSizeBytes: 500 * MB,
+      now: NOW,
+    });
+    if (r.removed !== 4) fail(`10: all 4 stale should be removed regardless of extension, got ${r.removed}`);
+    testNum++;
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log(`inbox-gc smoke: ${testNum}/${testNum} PASS`);

--- a/scripts/inbox-gc-smoke.ts
+++ b/scripts/inbox-gc-smoke.ts
@@ -238,6 +238,94 @@ try {
     if (r.removed !== 4) fail(`10: all 4 stale should be removed regardless of extension, got ${r.removed}`);
     testNum++;
   }
+
+  // 11. R2-followup: pass 1 (age expiry) — unlink failure pushes the
+  //     entry into survivors so finalSize + remaining reflect on-disk
+  //     state. Pre-followup the swallow worked but the stats counted
+  //     the file as evicted; pass 1 ALREADY did this correctly, so
+  //     this test is the symmetric guard / regression lock.
+  {
+    const dir = mkdtempSync(join(tmp, 'age-eacces-'));
+    makeFile(dir, 'undeletable.png', 100, NOW - 8 * DAY_MS); // stale
+    makeFile(dir, 'fresh.png', 200, NOW - 1 * DAY_MS); // not stale
+    const r = await gcInbox({
+      dir,
+      maxAgeMs: 7 * DAY_MS,
+      maxSizeBytes: 500 * MB,
+      now: NOW,
+      // Simulate EACCES on the stale file (and any other unlink) —
+      // cross-platform via injected mock.
+      unlinkFn: async (p) => {
+        if (p.endsWith('undeletable.png')) {
+          throw Object.assign(new Error('mock EACCES'), { code: 'EACCES' });
+        }
+        // For other paths, defer to real unlink
+        const realFs = await import('node:fs/promises');
+        return realFs.unlink(p);
+      },
+    });
+    if (r.removed !== 0) fail(`11: unlink failed, nothing should count as removed (got ${r.removed})`);
+    if (r.bytesFreed !== 0) fail(`11: bytesFreed must reflect actual freed, got ${r.bytesFreed}`);
+    if (r.remaining !== 2) fail(`11: both files still on disk → remaining=2, got ${r.remaining}`);
+    if (r.finalSize !== 300) fail(`11: finalSize must reflect both files, got ${r.finalSize}`);
+    if (!existsSync(join(dir, 'undeletable.png'))) fail(`11: undeletable.png still on disk per mock`);
+    testNum++;
+  }
+
+  // 12. R2-followup: pass 2 (LRU) — unlink failure must NOT silently
+  //     subtract from totalSize. Pre-followup THIS was the real bug:
+  //     undeletable file's bytes were subtracted as if freed, and the
+  //     entry was dropped from survivors → finalSize and remaining
+  //     lied about actual disk state.
+  {
+    const dir = mkdtempSync(join(tmp, 'lru-eacces-'));
+    // 3 files × 100MB each, cap 150MB → must evict 2 oldest.
+    // Make the oldest undeletable. Expected: middle+newest survive
+    // (size-evict middle one too since cap is 150MB and oldest blocks
+    // 100MB), undeletable counted in finalSize.
+    makeFile(dir, 'lru-old.png', 100 * MB, NOW - 3 * 60_000);
+    makeFile(dir, 'lru-mid.png', 100 * MB, NOW - 2 * 60_000);
+    makeFile(dir, 'lru-new.png', 100 * MB, NOW - 1 * 60_000);
+    const r = await gcInbox({
+      dir,
+      maxAgeMs: 7 * DAY_MS,
+      maxSizeBytes: 150 * MB,
+      now: NOW,
+      unlinkFn: async (p) => {
+        if (p.endsWith('lru-old.png')) {
+          throw Object.assign(new Error('mock EACCES'), { code: 'EACCES' });
+        }
+        const realFs = await import('node:fs/promises');
+        return realFs.unlink(p);
+      },
+    });
+    // Loop: shift old → unlink fails → undeletable. Still over cap (300MB).
+    //       shift mid → unlink succeeds → totalSize=200MB. Still over cap.
+    //       shift new → unlink succeeds → totalSize=100MB. Under cap, exit.
+    // Wait — that would leave NOTHING behind that we wanted to keep.
+    // Re-check: survivors after sort = [old, mid, new]. Cap is 150MB.
+    // After shift+fail(old): totalSize=300 (unchanged). survivors=[mid, new].
+    // After shift+succeed(mid): totalSize=200. survivors=[new]. Still > cap.
+    // After shift+succeed(new): totalSize=100. Under cap, exit.
+    // Push undeletables back into survivors: survivors=[old].
+    // So: removed=2 (mid, new), bytesFreed=200MB, finalSize=100MB (only
+    // the old's 100MB), remaining=1 (only old).
+    if (r.removed !== 2) fail(`12: 2 files actually deleted (mid+new), got ${r.removed}`);
+    if (r.bytesFreed !== 200 * MB) fail(`12: bytesFreed should be 200MB, got ${r.bytesFreed}`);
+    // Pre-followup: totalSize would have been mis-subtracted on the
+    // first iteration → finalSize=0, remaining=0. THE BUG.
+    // Post-followup: undeletable's bytes never subtracted → finalSize=100MB.
+    if (r.finalSize !== 100 * MB) {
+      fail(`12 (THE BUG): finalSize must reflect undeletable still on disk, got ${r.finalSize} (pre-fix would have reported 0)`);
+    }
+    if (r.remaining !== 1) {
+      fail(`12 (THE BUG): remaining must count the undeletable, got ${r.remaining} (pre-fix would have reported 0)`);
+    }
+    if (!existsSync(join(dir, 'lru-old.png'))) fail(`12: undeletable file still on disk per mock`);
+    if (existsSync(join(dir, 'lru-mid.png'))) fail(`12: lru-mid should be evicted`);
+    if (existsSync(join(dir, 'lru-new.png'))) fail(`12: lru-new should be evicted`);
+    testNum++;
+  }
 } finally {
   rmSync(tmp, { recursive: true, force: true });
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -114,4 +114,8 @@ echo "=== Profile TOCTOU mutex unit checks ==="
 npx tsx scripts/profile-toctou-smoke.ts
 
 echo ""
+echo "=== Inbox GC unit checks ==="
+npx tsx scripts/inbox-gc-smoke.ts
+
+echo ""
 echo "All tests passed."

--- a/src/config.ts
+++ b/src/config.ts
@@ -122,6 +122,26 @@ export const appConfig = {
   memoriesDir: path.join(os.homedir(), '.claude', 'channels', 'lark', 'memories'),
   inboxDir: path.join(os.homedir(), '.claude', 'channels', 'lark', 'inbox'),
   jobsDir: path.join(os.homedir(), '.claude', 'channels', 'lark', 'jobs'),
+
+  // Inbox garbage collection (#89). The inbox directory was write-only
+  // pre-v1.0.35 — every downloaded image and every download_attachment
+  // file accumulated forever. In a heavy-image deployment (group with
+  // screenshots / PDF reports / memes) an SSD would fill in months.
+  //
+  // GC runs at startup and periodically. Files are removed when:
+  //   1. mtime is older than maxAgeDays (age expiry), OR
+  //   2. total directory size exceeds maxSizeMB → oldest-first LRU
+  //      eviction until under cap.
+  //
+  // The 7-day default age comfortably exceeds any reasonable Claude
+  // turn duration (largest turn we've observed is single-digit minutes),
+  // so a mid-turn `Read` of an `image_path` notification meta will
+  // always find its file. Operators can disable entirely via
+  // LARK_INBOX_GC_DISABLED=true for forensic / archival deployments.
+  inboxMaxAgeDays: optionalNumber('LARK_INBOX_MAX_AGE_DAYS', 7),
+  inboxMaxSizeMB: optionalNumber('LARK_INBOX_MAX_SIZE_MB', 500),
+  inboxGcIntervalMin: optionalNumber('LARK_INBOX_GC_INTERVAL_MIN', 60),
+  inboxGcDisabled: (process.env.LARK_INBOX_GC_DISABLED ?? '').toLowerCase() === 'true',
 } as const;
 
 export type AppConfig = typeof appConfig;

--- a/src/inbox-gc.ts
+++ b/src/inbox-gc.ts
@@ -1,0 +1,175 @@
+/**
+ * Inbox garbage collection (#89). The inbox directory
+ * (`~/.claude/channels/lark/inbox/`) is where:
+ *   - `LarkChannel.downloadImage` writes auto-downloaded images from
+ *     inbound messages (channel.ts).
+ *   - The `download_attachment` tool writes attachments fetched by
+ *     Claude (tools.ts).
+ *
+ * Pre-v1.0.35 neither path called `fs.unlink` and there was no startup
+ * sweep or periodic cleanup. A heavy-image deployment would silently
+ * fill the disk over weeks. This module is the missing GC.
+ *
+ * Two complementary policies (both apply on each run):
+ *   1. **Age expiry**: files whose mtime is older than `maxAgeMs`
+ *      are deleted. 7 days by default — comfortably exceeds any
+ *      reasonable Claude turn so a mid-turn Read of `image_path`
+ *      always finds its file.
+ *   2. **Size cap**: if total directory size exceeds `maxSizeBytes`,
+ *      oldest-first LRU eviction continues until under cap.
+ *
+ * The age pass runs FIRST. Files already gone via age don't contribute
+ * to the size check, so an operator who configured a small age + large
+ * size cap (rotate quickly, keep recent burst) gets predictable
+ * behavior.
+ *
+ * Best-effort throughout: `unlink` failures (file vanished concurrently,
+ * permission revoked) are swallowed so one bad file doesn't abort
+ * cleanup of the rest. `readdir` failure (dir missing) is a no-op —
+ * nothing to collect.
+ *
+ * Returns a stats object for tests + operator logging.
+ */
+import * as fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { appConfig } from './config.js';
+
+export interface GcInboxOptions {
+  /** Inbox directory. Defaults to appConfig.inboxDir. */
+  dir?: string;
+  /** Max age in ms. Defaults to appConfig.inboxMaxAgeDays × 86400_000. */
+  maxAgeMs?: number;
+  /** Max total size in bytes. Defaults to appConfig.inboxMaxSizeMB × 1024 × 1024. */
+  maxSizeBytes?: number;
+  /** Reference "now" timestamp in ms (for deterministic tests). Defaults to Date.now(). */
+  now?: number;
+}
+
+export interface GcInboxResult {
+  /** Total files removed (age + LRU combined). */
+  removed: number;
+  /** Bytes freed. */
+  bytesFreed: number;
+  /** Final directory size in bytes after GC. */
+  finalSize: number;
+  /** Files left in the directory after GC. */
+  remaining: number;
+}
+
+export async function gcInbox(opts: GcInboxOptions = {}): Promise<GcInboxResult> {
+  const dir = opts.dir ?? appConfig.inboxDir;
+  const maxAgeMs = opts.maxAgeMs ?? appConfig.inboxMaxAgeDays * 86_400_000;
+  const maxSizeBytes = opts.maxSizeBytes ?? appConfig.inboxMaxSizeMB * 1024 * 1024;
+  const now = opts.now ?? Date.now();
+
+  if (!existsSync(dir)) {
+    return { removed: 0, bytesFreed: 0, finalSize: 0, remaining: 0 };
+  }
+
+  // Snapshot all file entries + stats up-front. A concurrent writer can
+  // land a NEW file after this snapshot — that file is just skipped by
+  // this GC pass and considered by the next one. No staleness concern
+  // for correctness; mtime monotone-forward.
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    // readdir failed (race with rmdir, permission revoke). Nothing to do.
+    return { removed: 0, bytesFreed: 0, finalSize: 0, remaining: 0 };
+  }
+
+  interface Entry {
+    path: string;
+    mtimeMs: number;
+    size: number;
+  }
+  const files: Entry[] = [];
+  for (const e of entries) {
+    if (!e.isFile()) continue;
+    const p = path.join(dir, e.name);
+    try {
+      const s = await fs.stat(p);
+      files.push({ path: p, mtimeMs: s.mtimeMs, size: s.size });
+    } catch {
+      // File vanished between readdir and stat — benign race with
+      // another caller of gcInbox or a manual rm. Skip silently.
+    }
+  }
+
+  let removed = 0;
+  let bytesFreed = 0;
+
+  // Pass 1: age expiry. Strict `<` so an entry whose mtime is exactly
+  // (now - maxAgeMs) is borderline and KEPT. This matches the
+  // isMissedRunStale convention in src/scheduler.ts.
+  const cutoff = now - maxAgeMs;
+  const survivors: Entry[] = [];
+  for (const f of files) {
+    if (f.mtimeMs < cutoff) {
+      try {
+        await fs.unlink(f.path);
+        removed++;
+        bytesFreed += f.size;
+      } catch {
+        // unlink failed (already gone, EACCES). Keep the entry in
+        // survivors so the size accounting reflects what's actually on
+        // disk — better to over-count than under-count when deciding
+        // whether the size cap is reached.
+        survivors.push(f);
+      }
+    } else {
+      survivors.push(f);
+    }
+  }
+
+  // Pass 2: size cap (LRU). Sum surviving sizes; if over cap, sort by
+  // mtime ascending and unlink until under cap.
+  let totalSize = survivors.reduce((acc, f) => acc + f.size, 0);
+  if (totalSize > maxSizeBytes) {
+    survivors.sort((a, b) => a.mtimeMs - b.mtimeMs);
+    while (totalSize > maxSizeBytes && survivors.length > 0) {
+      const oldest = survivors.shift()!;
+      try {
+        await fs.unlink(oldest.path);
+        removed++;
+        bytesFreed += oldest.size;
+        totalSize -= oldest.size;
+      } catch {
+        // unlink failed. Subtract from running total anyway so we don't
+        // loop forever on an undeletable file. Operator will see it on
+        // disk; we just can't reach it.
+        totalSize -= oldest.size;
+      }
+    }
+  }
+
+  return {
+    removed,
+    bytesFreed,
+    finalSize: totalSize,
+    remaining: survivors.length,
+  };
+}
+
+/**
+ * Convenience wrapper for the periodic scheduler: logs the GC result
+ * to stderr at info-level if anything was actually removed. Silent
+ * when there's nothing to do (most ticks).
+ */
+export async function runInboxGcOnce(): Promise<void> {
+  if (appConfig.inboxGcDisabled) return;
+  try {
+    const result = await gcInbox();
+    if (result.removed > 0) {
+      const mb = (result.bytesFreed / (1024 * 1024)).toFixed(1);
+      const finalMb = (result.finalSize / (1024 * 1024)).toFixed(1);
+      console.error(
+        `[inbox-gc] removed ${result.removed} file(s), freed ${mb}MB ` +
+        `(${result.remaining} remain, ${finalMb}MB total)`,
+      );
+    }
+  } catch (err) {
+    console.error('[inbox-gc] run failed:', err);
+  }
+}

--- a/src/inbox-gc.ts
+++ b/src/inbox-gc.ts
@@ -12,9 +12,9 @@
  *
  * Two complementary policies (both apply on each run):
  *   1. **Age expiry**: files whose mtime is older than `maxAgeMs`
- *      are deleted. 7 days by default — comfortably exceeds any
- *      reasonable Claude turn so a mid-turn Read of `image_path`
- *      always finds its file.
+ *      are deleted. 7 days by default — the threshold is intentionally
+ *      far larger than any reasonable Claude turn so a mid-turn `Read`
+ *      of `image_path` notification meta always finds its file.
  *   2. **Size cap**: if total directory size exceeds `maxSizeBytes`,
  *      oldest-first LRU eviction continues until under cap.
  *
@@ -22,6 +22,21 @@
  * to the size check, so an operator who configured a small age + large
  * size cap (rotate quickly, keep recent burst) gets predictable
  * behavior.
+ *
+ * **Mid-turn race warning (R1-followup)**: there is NO reference-counting
+ * layer between the GC and in-flight Claude turns. If an operator
+ * lowers `LARK_INBOX_MAX_AGE_DAYS` below the longest expected turn
+ * duration (e.g. setting it to 1 day with a multi-hour research-agent
+ * turn pending), the GC can unlink a file the turn is about to `Read`,
+ * causing the Read to fail with ENOENT. The 7-day default makes this
+ * effectively unreachable for normal operation; the env exists for
+ * operators tightening disk usage, who must keep age > worst-turn-time.
+ *
+ * **Safety invariant**: this module assumes writers
+ * (`downloadImage`, `download_attachment`) use unique filenames per
+ * call (both do — `${Date.now()}-${imageKey}.png` / `${file_key}-...`).
+ * Without uniqueness, a GC unlink could race a writer's open — but
+ * uniqueness makes the race structurally impossible.
  *
  * Best-effort throughout: `unlink` failures (file vanished concurrently,
  * permission revoked) are swallowed so one bad file doesn't abort

--- a/src/inbox-gc.ts
+++ b/src/inbox-gc.ts
@@ -59,6 +59,12 @@ export interface GcInboxOptions {
   maxSizeBytes?: number;
   /** Reference "now" timestamp in ms (for deterministic tests). Defaults to Date.now(). */
   now?: number;
+  /**
+   * Test hook: override `fs.unlink`. Lets the smoke test simulate EACCES
+   * cross-platform without chmod gymnastics. Production callers don't
+   * pass this — defaults to real `fs.unlink`.
+   */
+  unlinkFn?: (filePath: string) => Promise<void>;
 }
 
 export interface GcInboxResult {
@@ -77,6 +83,7 @@ export async function gcInbox(opts: GcInboxOptions = {}): Promise<GcInboxResult>
   const maxAgeMs = opts.maxAgeMs ?? appConfig.inboxMaxAgeDays * 86_400_000;
   const maxSizeBytes = opts.maxSizeBytes ?? appConfig.inboxMaxSizeMB * 1024 * 1024;
   const now = opts.now ?? Date.now();
+  const unlinkFn = opts.unlinkFn ?? fs.unlink;
 
   if (!existsSync(dir)) {
     return { removed: 0, bytesFreed: 0, finalSize: 0, remaining: 0 };
@@ -123,7 +130,7 @@ export async function gcInbox(opts: GcInboxOptions = {}): Promise<GcInboxResult>
   for (const f of files) {
     if (f.mtimeMs < cutoff) {
       try {
-        await fs.unlink(f.path);
+        await unlinkFn(f.path);
         removed++;
         bytesFreed += f.size;
       } catch {
@@ -143,20 +150,34 @@ export async function gcInbox(opts: GcInboxOptions = {}): Promise<GcInboxResult>
   let totalSize = survivors.reduce((acc, f) => acc + f.size, 0);
   if (totalSize > maxSizeBytes) {
     survivors.sort((a, b) => a.mtimeMs - b.mtimeMs);
+    // R2-followup: track unlink failures so the returned finalSize +
+    // remaining reflect what's ACTUALLY on disk, not what we wanted
+    // to remove. Pre-fix this branch unconditionally subtracted
+    // oldest.size from totalSize even on failure — `[inbox-gc] freed
+    // XMB (N remain, YMB total)` would lie about disk state.
+    //
+    // Loop termination: each iteration `shift()`s exactly one entry
+    // out of `survivors`. Even if EVERY remaining file is undeletable
+    // (and totalSize stays > cap forever), `survivors.length > 0`
+    // becomes false after exhausting the list. No infinite loop.
+    const undeletable: Entry[] = [];
     while (totalSize > maxSizeBytes && survivors.length > 0) {
       const oldest = survivors.shift()!;
       try {
-        await fs.unlink(oldest.path);
+        await unlinkFn(oldest.path);
         removed++;
         bytesFreed += oldest.size;
         totalSize -= oldest.size;
       } catch {
-        // unlink failed. Subtract from running total anyway so we don't
-        // loop forever on an undeletable file. Operator will see it on
-        // disk; we just can't reach it.
-        totalSize -= oldest.size;
+        // File is still on disk — do NOT subtract from totalSize
+        // (would misreport finalSize). Stash for post-loop push-back
+        // into `survivors` so the count of remaining files is right.
+        undeletable.push(oldest);
       }
     }
+    // Push failed unlinks back into the survivor set so finalSize +
+    // remaining returned below reflect the true on-disk state.
+    survivors.push(...undeletable);
   }
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { buildFlushPrompt } from './memory/distiller.js';
 import { MemoryStore } from './memory/file.js';
 import { IdentitySession, SYSTEM_FLUSH_CALLER } from './identity-session.js';
 import { JobScheduler } from './scheduler.js';
+import { runInboxGcOnce } from './inbox-gc.js';
 import { mcpServerInstructions } from './prompts.js';
 
 const LOCK_FILE = path.join(os.tmpdir(), `claude-lark-${appConfig.appId}.lock`);
@@ -209,7 +210,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.34' },
+    { name: 'claude-lark-plugin', version: '1.0.35' },
     {
       capabilities: {
         logging: {},
@@ -404,6 +405,26 @@ async function main() {
     botMessageTracker: channel.getBotMessageTracker(),
   });
   await scheduler.start();
+
+  // 11. Inbox garbage collection (#89). Pre-v1.0.35 the inbox grew
+  //     unboundedly. Run once at startup to sweep accumulated files,
+  //     then install a periodic timer at LARK_INBOX_GC_INTERVAL_MIN
+  //     cadence. `.unref()` so the timer never holds an idle process
+  //     open. Opt out with LARK_INBOX_GC_DISABLED=true for forensic
+  //     deployments that want everything preserved.
+  if (!appConfig.inboxGcDisabled) {
+    // Fire-and-forget; runInboxGcOnce swallows its own errors.
+    void runInboxGcOnce();
+    const intervalMs = appConfig.inboxGcIntervalMin * 60 * 1000;
+    const timer = setInterval(() => { void runInboxGcOnce(); }, intervalMs);
+    timer.unref?.();
+    console.error(
+      `[index] Inbox GC enabled (maxAge=${appConfig.inboxMaxAgeDays}d, ` +
+      `maxSize=${appConfig.inboxMaxSizeMB}MB, interval=${appConfig.inboxGcIntervalMin}min)`,
+    );
+  } else {
+    console.error('[index] Inbox GC disabled via LARK_INBOX_GC_DISABLED');
+  }
 
   console.error('[index] claude-lark-plugin started successfully');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -417,7 +417,9 @@ async function main() {
     void runInboxGcOnce();
     const intervalMs = appConfig.inboxGcIntervalMin * 60 * 1000;
     const timer = setInterval(() => { void runInboxGcOnce(); }, intervalMs);
-    timer.unref?.();
+    // R2-followup: setInterval always returns a NodeJS.Timeout with
+    // unref defined; no optional-chain needed.
+    timer.unref();
     console.error(
       `[index] Inbox GC enabled (maxAge=${appConfig.inboxMaxAgeDays}d, ` +
       `maxSize=${appConfig.inboxMaxSizeMB}MB, interval=${appConfig.inboxGcIntervalMin}min)`,


### PR DESCRIPTION
## Summary

Closes #89. `~/.claude/channels/lark/inbox/` was the unified landing zone for `LarkChannel.downloadImage` (auto-downloaded images) and the `download_attachment` tool. Both paths called `fs.writeFile` and **never `fs.unlink`** — no startup sweep, no periodic GC, no size cap. A heavy-image deployment would silently fill the disk over weeks. Privacy residue too: users assumed sending an image in chat was the end of it; the file persisted forever, even after plugin uninstall.

## Fix

New `src/inbox-gc.ts` module with two complementary policies:

1. **Age expiry**: files with `mtime < now - maxAgeMs` are unlinked. Default 7 days — comfortably exceeds any reasonable Claude turn (largest observed is single-digit minutes), so a mid-turn `Read` of `image_path` notification meta always finds its file. Strict `<` boundary matches `isMissedRunStale` convention.
2. **Size cap (LRU)**: if total directory size exceeds `maxSizeBytes` after the age pass, sort surviving entries by mtime ascending and unlink oldest-first until under cap. Default 500 MB.

`src/index.ts` runs `runInboxGcOnce()` once at startup, then installs a `setInterval` at `LARK_INBOX_GC_INTERVAL_MIN` cadence (default 60 min). `.unref()` so the timer never holds an idle process open.

Subdirectories are NOT recursed (inbox is flat by construction at both call sites; `e.isFile()` check skips any operator-created subdirectory). Best-effort throughout — `unlink`/`readdir` failures are swallowed so one bad file doesn't abort the rest.

## New env vars

| Env | Default | Effect |
|---|---|---|
| `LARK_INBOX_MAX_AGE_DAYS` | 7 | Files older than this are deleted |
| `LARK_INBOX_MAX_SIZE_MB` | 500 | Directory size cap (LRU eviction) |
| `LARK_INBOX_GC_INTERVAL_MIN` | 60 | Periodic GC cadence |
| `LARK_INBOX_GC_DISABLED` | false | Opt-out for forensic deployments |

## Tests

`scripts/inbox-gc-smoke.ts` (10 assertions, wired into `scripts/test.sh`):

| # | Behavior |
|---|---|
| 1 | Missing directory → all-zeros result, no throw |
| 2 | Empty directory → all-zeros |
| 3 | Age expiry — older-than-cutoff deleted, fresher kept |
| 4 | Boundary — file exactly at `cutoff` is KEPT (strict `<`); file at `cutoff - 1ms` removed |
| 5 | LRU eviction — 5 × 100MB files, cap 250MB → 3 oldest evicted, 2 newest survive |
| 6 | Combined — age pass removes 2, size pass removes 2 more; final state asserted |
| 7 | Subdirectories untouched |
| 8 | Nothing-to-do happy path (all fresh, under cap) |
| 9 | Size cap boundary (total === cap, no eviction — strict `>`) |
| 10 | Mixed file types — PNG / PDF / BIN / no-extension all eligible |

`inbox-gc smoke: 10/10 PASS`. Full suite green.

## Operator notes

- **Pre-#89 deployments on first startup after upgrade**: GC will sweep accumulated files older than 7 days AND evict to the 500MB cap. A long-running deployment with GBs of accumulated images sees a large one-shot cleanup in the startup log (`[inbox-gc] removed N file(s), freed XYZ MB ...`). This is intentional. If you want to preserve everything for one-time archival, set `LARK_INBOX_GC_DISABLED=true` for the first run, move what you need out of the inbox, then re-enable.
- Startup log line `[index] Inbox GC enabled (maxAge=7d, maxSize=500MB, interval=60min)` confirms the GC is active.
- Mid-turn safety: 7-day age threshold is intentionally far larger than any reasonable Claude turn. A turn that opens an `image_path` from inbox WILL find its file. If you have unusual long-running turns, tune `LARK_INBOX_MAX_AGE_DAYS` UP, never down.

## Test plan

- [x] `npm run typecheck` clean
- [x] `bash scripts/test.sh` all green (`inbox-gc smoke: 10/10`)
- [x] Version bumped to 1.0.35 across 5 locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)