### PR TITLE
fix(buffer): skip cron-replies + hard-cap force-flush (v1.0.38)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.37",
+      "version": "1.0.38",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   - 5: per-chat independence (chat A at cap flushes; chat B unaffected)
 - New `reply-card-smoke.ts` test 8b: cron-thread reply (`thread_id` prefixed with `JOB_THREAD_PREFIX`) does NOT record into the buffer; non-cron-thread reply DOES (sanity check the detection isn't over-eager).
 
+### R1-audit followups (closed in this PR)
+- **Test 8b stale-ordering bug** — the "sanity check" (non-cron-thread DOES record) was effectively dead code: the first non-cron call ran BEFORE its identity was bound, then `buffer.recorded.length = 0` wiped the result before assertion. R1 caught the test could have silently passed even if the cron-skip logic broke on the first attempt. Fixed: bind both identities up front, two clean sub-cases (8b-cron expects 0 records, 8b-sanity expects 1).
+- **`isCronOriginated` alias** — `recordReply` reused the `isSyntheticThread` flag (also load-bearing for thread-routing). A future narrowing of the routing flag would have silently changed buffer behavior. Local alias with a comment forces the future maintainer to think about both consumers.
+
+### R2-audit followups (closed in this PR)
+- **`ConversationBuffer` constructor rejects `maxMessages <= 0`** — nullish coalescing accepted `0` (force-flush every push). Env path was guarded by `optionalPositiveNumber` (#109 hardening); constructor path bypassed it. Now throws at construct time to match the env-hardening contract.
+- **Test 8b also asserts `apiCalls.length > 0`** — pre-followup the test only checked `buffer.recorded.length`. A future regression that disabled both the buffer record AND the actual Feishu send (e.g. confused cron-skip with full short-circuit) would have passed the original assertion. Now both sub-cases (cron + non-cron) confirm send happened.
+
+### R2-audit findings filed as followups
+- **#148 — Concurrent `record()` between `flushing.delete` and `buffers.delete` is silently wiped.** Pre-existing race in `triggerFlush`'s cleanup sequence — not introduced by this PR. Race window is microscopically small (microtasks between finally and the next sync statement). Fix is straightforward (move buffer/timer cleanup INTO the finally before `flushing.delete`), filed for a focused PR.
+
 ### Operator notes
 - No data-format or config changes; existing buffers carry over.
 - Pre-#110 deployments may have accumulated large in-memory buffers for chats with active cronjobs. On first restart after upgrade those buffers are dropped (they're in-memory only) — no on-disk impact. Future flushes will produce cleaner episodes since cron output is no longer recorded.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.38] - 2026-05-25
+
+### Fixed
+- **Cronjob replies bled into ConversationBuffer → auto-flush never fired → buffer grew unbounded + cron mixed with user dialogue** (#110 — **HIGH memory leak + episode quality regression**). The `reply` tool unconditionally recorded every reply (including prompt-type cronjob outputs) into the per-chat `ConversationBuffer`. A cronjob targeting an active chat (typical: hourly "team status update" → that team's group chat) reset the buffer's inactivity timer on every fire — auto-flush (default 3h) NEVER triggered as long as the cron kept hitting. Effects:
+  - **Memory leak**: per-chat buffer grew unboundedly across days/weeks.
+  - **Episode garbage**: when a flush eventually happened (cron paused, chat went truly idle), the distillation prompt saw a mixed stream of cron output + real user dialogue; the resulting episode `.md` blended "the bot's hourly status update" with "what users actually said."
+  - **No memory enrichment for the affected chat**: distillation effectively disabled for as long as the cron kept the timer reset.
+
+  Fix (two layers):
+
+  **1. Skip buffer-record for cron-originated replies** (`src/tools.ts:recordReply`). The detection reuses the `isSyntheticThread` flag (`thread_id.startsWith(JOB_THREAD_PREFIX)`) already computed earlier in the same handler for thread-routing decisions. One-line root-cause fix:
+  ```ts
+  if (isSyntheticThread) return; // cron output is not user dialogue
+  ```
+  Semantically correct: a cronjob's reply is not part of the conversation history that should be distilled.
+
+  **2. Hard-cap backstop on `ConversationBuffer`** — even if a future regression re-introduces bleed (or a high-cadence non-cron writer somehow keeps the timer reset), the buffer can't grow unboundedly. New `LARK_BUFFER_MAX_MESSAGES` env (default 200) caps per-chat entries; the (cap-1)th push triggers a force-flush regardless of timer state. Idempotent via the existing `flushing.has(chatId)` guard — concurrent records during the flush short-circuit (same as the pre-existing timer-flush path).
+
+  `ConversationBuffer` constructor now takes an optional `{ maxMessages }` override for testability — ESM hoisting prevents env overrides at the top of a smoke-test from reaching config.ts's capture point.
+
+### Added
+- New `LARK_BUFFER_MAX_MESSAGES` env (default 200, positive-validated via `optionalPositiveNumber`).
+- New `scripts/buffer-cap-smoke.ts` (5 tests, wired into `scripts/test.sh`):
+  - 1: under-cap pushes do NOT trigger flush
+  - 2: at-cap push (5th of 5) triggers exactly one force-flush
+  - 3: concurrent pushes during flush DO NOT double-flush (idempotent via `flushing` guard)
+  - 4: after flush completes, fresh pushes accumulate again (cap doesn't permanently disable timer-flush)
+  - 5: per-chat independence (chat A at cap flushes; chat B unaffected)
+- New `reply-card-smoke.ts` test 8b: cron-thread reply (`thread_id` prefixed with `JOB_THREAD_PREFIX`) does NOT record into the buffer; non-cron-thread reply DOES (sanity check the detection isn't over-eager).
+
+### Operator notes
+- No data-format or config changes; existing buffers carry over.
+- Pre-#110 deployments may have accumulated large in-memory buffers for chats with active cronjobs. On first restart after upgrade those buffers are dropped (they're in-memory only) — no on-disk impact. Future flushes will produce cleaner episodes since cron output is no longer recorded.
+- If you've been relying on cronjob outputs appearing in episode history for that chat, that's no longer the case post-fix. The cron's `[scheduler] Job X executed ...` stderr line remains the canonical audit trail.
+- `LARK_BUFFER_MAX_MESSAGES=0` rejected by `optionalPositiveNumber` and snapped to default 200 with a breadcrumb (matches the env-hardening pattern from #109).
+
 ## [1.0.37] - 2026-05-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.37",
+      "version": "1.0.38",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/buffer-cap-smoke.ts
+++ b/scripts/buffer-cap-smoke.ts
@@ -1,0 +1,190 @@
+/**
+ * ConversationBuffer cap smoke test (v1.0.38, closes #110 part 2).
+ *
+ * Direct unit test of the hard-cap force-flush added to
+ * `ConversationBuffer.record`. Pre-fix, anything that kept resetting
+ * the inactivity timer (e.g. the now-fixed cron-into-buffer bleed)
+ * would let the per-chat buffer grow unbounded. The cap is the
+ * belt-and-suspenders backstop.
+ */
+
+// Make the inactivity timer effectively never fire in this test so the
+// hard cap is the only trigger we observe. ConversationBuffer takes the
+// cap via constructor `{ maxMessages: 5 }` (ESM hoisting makes the
+// env-set-here-import-below pattern unreliable for the cap default).
+process.env.LARK_INACTIVITY_HOURS = '99';
+
+import { ConversationBuffer } from '../src/memory/buffer.js';
+
+function fail(msg: string): never {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+let testNum = 0;
+
+// 1. Under-cap pushes do NOT trigger flush
+{
+  const buf = new ConversationBuffer({ maxMessages: 5 });
+  let flushFires = 0;
+  buf.setFlushHandler(async () => { flushFires++; });
+  for (let i = 0; i < 4; i++) {
+    buf.record('chat_under', {
+      role: 'user',
+      senderId: 'u',
+      text: `m${i}`,
+      timestamp: new Date().toISOString(),
+    });
+  }
+  // Synchronous record returns; force-flush is fire-and-forget. Let
+  // microtasks settle so any spurious flush has a chance to fire.
+  await new Promise((r) => setImmediate(r));
+  if (flushFires !== 0) fail(`1: under-cap (4 of 5) should not flush, fired ${flushFires}`);
+  if (buf.getMessages('chat_under').length !== 4) {
+    fail(`1: buffer should hold 4 messages, got ${buf.getMessages('chat_under').length}`);
+  }
+  testNum++;
+}
+
+// 2. At-cap push triggers force-flush (cap=5, push 5th → flush)
+{
+  const buf = new ConversationBuffer({ maxMessages: 5 });
+  let flushFires = 0;
+  let flushedMessages: any[] = [];
+  buf.setFlushHandler(async (chatId, messages) => {
+    flushFires++;
+    flushedMessages = messages;
+  });
+  for (let i = 0; i < 5; i++) {
+    buf.record('chat_atcap', {
+      role: 'user',
+      senderId: 'u',
+      text: `m${i}`,
+      timestamp: new Date().toISOString(),
+    });
+  }
+  // Let the fire-and-forget flush settle (it's async via the flush
+  // handler). One microtask drain is sufficient for our synchronous
+  // mock handler.
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+
+  if (flushFires !== 1) fail(`2: at-cap (5 of 5) should flush exactly once, fired ${flushFires}`);
+  if (flushedMessages.length !== 5) {
+    fail(`2: flush should receive all 5 messages, got ${flushedMessages.length}`);
+  }
+  // After flush, buffer should be empty
+  if (buf.getMessages('chat_atcap').length !== 0) {
+    fail(`2: buffer should be empty post-flush, has ${buf.getMessages('chat_atcap').length}`);
+  }
+  testNum++;
+}
+
+// 3. Over-cap pushes don't double-flush (idempotent via `flushing` guard)
+{
+  const buf = new ConversationBuffer({ maxMessages: 5 });
+  let flushFires = 0;
+  buf.setFlushHandler(async () => {
+    flushFires++;
+    // Simulate a slow flush — gives concurrent record() calls a window
+    await new Promise((r) => setTimeout(r, 50));
+  });
+  // Push 5 (triggers flush — flush handler is now in flight)
+  for (let i = 0; i < 5; i++) {
+    buf.record('chat_concurrent', {
+      role: 'user',
+      senderId: 'u',
+      text: `initial-${i}`,
+      timestamp: new Date().toISOString(),
+    });
+  }
+  // While the flush is in flight, push more — these should short-circuit
+  // at the `flushing.has` guard (line 30 in record), NOT trigger a 2nd flush
+  for (let i = 0; i < 5; i++) {
+    buf.record('chat_concurrent', {
+      role: 'user',
+      senderId: 'u',
+      text: `during-${i}`,
+      timestamp: new Date().toISOString(),
+    });
+  }
+  // Wait for the slow flush to complete
+  await new Promise((r) => setTimeout(r, 100));
+  if (flushFires !== 1) {
+    fail(`3: concurrent pushes during flush must NOT trigger second flush, fired ${flushFires}`);
+  }
+  testNum++;
+}
+
+// 4. After flush completes, new pushes accumulate fresh
+{
+  const buf = new ConversationBuffer({ maxMessages: 5 });
+  let flushFires = 0;
+  buf.setFlushHandler(async () => { flushFires++; });
+
+  // Round 1: fill to cap → flush
+  for (let i = 0; i < 5; i++) {
+    buf.record('chat_round', {
+      role: 'user',
+      senderId: 'u',
+      text: `r1-${i}`,
+      timestamp: new Date().toISOString(),
+    });
+  }
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+  if (flushFires !== 1) fail(`4: first round should flush once`);
+
+  // Round 2: push 3 more → no flush (under cap)
+  for (let i = 0; i < 3; i++) {
+    buf.record('chat_round', {
+      role: 'user',
+      senderId: 'u',
+      text: `r2-${i}`,
+      timestamp: new Date().toISOString(),
+    });
+  }
+  await new Promise((r) => setImmediate(r));
+  if (flushFires !== 1) fail(`4: under-cap second round should NOT trigger another flush`);
+  if (buf.getMessages('chat_round').length !== 3) {
+    fail(`4: second round buffer should hold 3 messages, got ${buf.getMessages('chat_round').length}`);
+  }
+  testNum++;
+}
+
+// 5. Per-chat independence: chat A at cap triggers flush, chat B unaffected
+{
+  const buf = new ConversationBuffer({ maxMessages: 5 });
+  const flushes: string[] = [];
+  buf.setFlushHandler(async (chatId) => { flushes.push(chatId); });
+
+  // Fill chat A to cap
+  for (let i = 0; i < 5; i++) {
+    buf.record('chat_A', {
+      role: 'user',
+      senderId: 'u',
+      text: `a${i}`,
+      timestamp: new Date().toISOString(),
+    });
+  }
+  // Push only 2 to chat B
+  for (let i = 0; i < 2; i++) {
+    buf.record('chat_B', {
+      role: 'user',
+      senderId: 'u',
+      text: `b${i}`,
+      timestamp: new Date().toISOString(),
+    });
+  }
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+  if (flushes.length !== 1 || flushes[0] !== 'chat_A') {
+    fail(`5: only chat_A should flush, got ${JSON.stringify(flushes)}`);
+  }
+  if (buf.getMessages('chat_B').length !== 2) {
+    fail(`5: chat_B should still hold 2 messages, got ${buf.getMessages('chat_B').length}`);
+  }
+  testNum++;
+}
+
+console.log(`buffer-cap smoke: ${testNum}/${testNum} PASS`);

--- a/scripts/reply-card-smoke.ts
+++ b/scripts/reply-card-smoke.ts
@@ -8,6 +8,7 @@ import type { MemoryStore } from '../src/memory/file.js';
 import { IdentitySession } from '../src/identity-session.js';
 import { pruneStaleAcksImpl, ACK_TTL_MS } from '../src/channel.js';
 import type { LarkChannel, AckRevokeClient } from '../src/channel.js';
+import { JOB_THREAD_PREFIX } from '../src/scheduler.js';
 
 function fail(msg: string): never {
   console.error(`FAIL: ${msg}`);
@@ -292,6 +293,52 @@ async function run() {
     (c) => c.method === 'message.create' && c.args.data.msg_type === 'text'
   );
   if (!normalCreate) fail('Test 8: plain text path should use msg_type=text');
+
+  // ── Test 8b: #110 fix — cron-originated reply does NOT record into buffer ──
+  //   Pre-fix, every reply (including prompt-type cronjob replies) was
+  //   recorded into the per-chat ConversationBuffer. A cronjob hitting
+  //   an active chat reset the buffer's inactivity timer on every fire
+  //   → auto-flush (default 3h) never triggered → buffer grew unboundedly,
+  //   cron output got mixed with real user dialogue, eventual distillation
+  //   was garbage.
+  //
+  //   Detection uses the JOB_THREAD_PREFIX synthetic id on thread_id.
+  {
+    apiCalls.length = 0;
+    buffer.recorded.length = 0;
+    const cronThread = `${JOB_THREAD_PREFIX}some-job-123`;
+    // The cronjob path binds a caller under (chat_id, cron-thread-id).
+    identitySession.setCaller('chat_cron', cronThread, 'ou_cron_owner');
+
+    await replyHandler({
+      chat_id: 'chat_cron',
+      thread_id: cronThread,
+      text: 'hourly status update from cron',
+    });
+
+    if (buffer.recorded.length !== 0) {
+      fail(`8b: cron-thread reply must NOT record into buffer, got ${buffer.recorded.length} entries`);
+    }
+
+    // Sanity: the same reply WITHOUT the cron prefix DOES record.
+    buffer.recorded.length = 0;
+    await replyHandler({
+      chat_id: 'chat_cron',
+      thread_id: 'thr_real_user',
+      text: 'user-driven reply',
+    });
+    // Need an identity binding for the non-cron path too
+    identitySession.setCaller('chat_cron', 'thr_real_user', 'ou_real_user');
+    buffer.recorded.length = 0;
+    await replyHandler({
+      chat_id: 'chat_cron',
+      thread_id: 'thr_real_user',
+      text: 'user-driven reply',
+    });
+    if (buffer.recorded.length !== 1) {
+      fail(`8b sanity: non-cron-thread reply MUST record into buffer, got ${buffer.recorded.length}`);
+    }
+  }
 
   // ── Test 9: partial-failure leak — ack STILL revoked when send throws (#85) ──
   //   Pre-v1.0.30: recordAndRevokeAck was called ONLY after every send

--- a/scripts/reply-card-smoke.ts
+++ b/scripts/reply-card-smoke.ts
@@ -312,7 +312,12 @@ async function run() {
     identitySession.setCaller('chat_cron', cronThread, 'ou_cron_owner');
     identitySession.setCaller('chat_cron', 'thr_real_user', 'ou_real_user');
 
-    // Sub-case a: cron-thread → buffer.recorded stays at 0
+    // Sub-case a: cron-thread → buffer.recorded stays at 0, BUT the
+    // Feishu send still happens (we're only suppressing the buffer
+    // record, not the actual reply delivery — cron users still see
+    // the message). R2-followup: assert apiCalls confirms send
+    // happened so a future regression that disables both the record
+    // AND the send is caught here.
     apiCalls.length = 0;
     buffer.recorded.length = 0;
     await replyHandler({
@@ -323,8 +328,11 @@ async function run() {
     if (buffer.recorded.length !== 0) {
       fail(`8b-cron: cron-thread reply must NOT record (got ${buffer.recorded.length})`);
     }
+    if (apiCalls.length === 0) {
+      fail(`8b-cron: cron-thread reply must still SEND to Feishu (got 0 API calls)`);
+    }
 
-    // Sub-case b: non-cron thread → buffer.recorded === 1
+    // Sub-case b: non-cron thread → buffer.recorded === 1 AND send happens
     apiCalls.length = 0;
     buffer.recorded.length = 0;
     await replyHandler({
@@ -334,6 +342,9 @@ async function run() {
     });
     if (buffer.recorded.length !== 1) {
       fail(`8b-sanity: non-cron-thread reply MUST record (got ${buffer.recorded.length})`);
+    }
+    if (apiCalls.length === 0) {
+      fail(`8b-sanity: non-cron-thread reply must SEND (got 0 API calls)`);
     }
   }
 

--- a/scripts/reply-card-smoke.ts
+++ b/scripts/reply-card-smoke.ts
@@ -303,32 +303,29 @@ async function run() {
   //   was garbage.
   //
   //   Detection uses the JOB_THREAD_PREFIX synthetic id on thread_id.
+  //   R1-followup: bind identities for BOTH threads up front so the
+  //   sanity-check non-cron call has a valid caller; pre-fix the test
+  //   had a stale ordering that made the sanity check effectively dead
+  //   code (the first non-cron call was discarded before assertion).
   {
+    const cronThread = `${JOB_THREAD_PREFIX}some-job-123`;
+    identitySession.setCaller('chat_cron', cronThread, 'ou_cron_owner');
+    identitySession.setCaller('chat_cron', 'thr_real_user', 'ou_real_user');
+
+    // Sub-case a: cron-thread → buffer.recorded stays at 0
     apiCalls.length = 0;
     buffer.recorded.length = 0;
-    const cronThread = `${JOB_THREAD_PREFIX}some-job-123`;
-    // The cronjob path binds a caller under (chat_id, cron-thread-id).
-    identitySession.setCaller('chat_cron', cronThread, 'ou_cron_owner');
-
     await replyHandler({
       chat_id: 'chat_cron',
       thread_id: cronThread,
       text: 'hourly status update from cron',
     });
-
     if (buffer.recorded.length !== 0) {
-      fail(`8b: cron-thread reply must NOT record into buffer, got ${buffer.recorded.length} entries`);
+      fail(`8b-cron: cron-thread reply must NOT record (got ${buffer.recorded.length})`);
     }
 
-    // Sanity: the same reply WITHOUT the cron prefix DOES record.
-    buffer.recorded.length = 0;
-    await replyHandler({
-      chat_id: 'chat_cron',
-      thread_id: 'thr_real_user',
-      text: 'user-driven reply',
-    });
-    // Need an identity binding for the non-cron path too
-    identitySession.setCaller('chat_cron', 'thr_real_user', 'ou_real_user');
+    // Sub-case b: non-cron thread → buffer.recorded === 1
+    apiCalls.length = 0;
     buffer.recorded.length = 0;
     await replyHandler({
       chat_id: 'chat_cron',
@@ -336,7 +333,7 @@ async function run() {
       text: 'user-driven reply',
     });
     if (buffer.recorded.length !== 1) {
-      fail(`8b sanity: non-cron-thread reply MUST record into buffer, got ${buffer.recorded.length}`);
+      fail(`8b-sanity: non-cron-thread reply MUST record (got ${buffer.recorded.length})`);
     }
   }
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -134,4 +134,8 @@ echo "=== Feishu retry helper unit checks ==="
 npx tsx scripts/feishu-retry-smoke.ts
 
 echo ""
+echo "=== Buffer hard-cap unit checks ==="
+npx tsx scripts/buffer-cap-smoke.ts
+
+echo ""
 echo "All tests passed."

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,6 +124,14 @@ export const appConfig = {
   minSearchScore: optionalNumber('LARK_MIN_SEARCH_SCORE', 0.3),
   maxSearchResults: optionalNumber('LARK_MAX_SEARCH_RESULTS', 2),
   inactivityHours: optionalNumber('LARK_INACTIVITY_HOURS', 3),
+  // #110 fix: hard cap on per-chat buffer entries. The inactivity
+  // timer was the only pre-fix bound; a chat that produced events
+  // faster than the timer could fire (or a cronjob that kept
+  // resetting the timer) would grow the buffer without limit. This
+  // is the belt-and-suspenders backstop — once a buffer reaches the
+  // cap, force-flush regardless of timer state. 200 entries × ~1KB
+  // each ≈ 200KB per chat — comfortably bounded.
+  bufferMaxMessages: optionalPositiveNumber('LARK_BUFFER_MAX_MESSAGES', 200),
 
   // Identity / privacy
   ownerOpenId: ownerOpenId(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.37' },
+    { name: 'claude-lark-plugin', version: '1.0.38' },
     {
       capabilities: {
         logging: {},

--- a/src/memory/buffer.ts
+++ b/src/memory/buffer.ts
@@ -20,6 +20,19 @@ export class ConversationBuffer {
   private timers = new Map<string, NodeJS.Timeout>();
   private flushing = new Set<string>(); // guard against re-entry during flush
   private flushHandler: FlushHandler | null = null;
+  /**
+   * Hard cap on per-chat buffer entries (#110). Pre-fix only the
+   * inactivity timer bounded the buffer; cron output (or any high-
+   * cadence writer) could keep resetting the timer indefinitely and
+   * grow the buffer unbounded. Cap defaults to `appConfig.bufferMaxMessages`;
+   * constructor override exists for tests (ESM hoisting prevents the
+   * smoke test from changing the env-derived default at script start).
+   */
+  private readonly maxMessages: number;
+
+  constructor(opts?: { maxMessages?: number }) {
+    this.maxMessages = opts?.maxMessages ?? appConfig.bufferMaxMessages;
+  }
 
   setFlushHandler(handler: FlushHandler): void {
     this.flushHandler = handler;
@@ -34,6 +47,24 @@ export class ConversationBuffer {
     }
     this.buffers.get(chatId)!.push(message);
     this.resetTimer(chatId);
+
+    // #110 fix: hard-cap backstop. The inactivity-timer-based flush
+    // is the primary trigger, but anything that keeps resetting the
+    // timer (e.g. a regression that re-introduces cron-into-buffer
+    // bleed, or a chat with sub-inactivity-window cadence) would
+    // otherwise let the buffer grow unbounded. Once we hit the cap,
+    // force-flush even if the timer hasn't expired. Best-effort —
+    // triggerFlush is async + idempotent against `this.flushing`
+    // guard, so calling it here doesn't double-fire.
+    const buf = this.buffers.get(chatId)!;
+    if (buf.length >= this.maxMessages) {
+      // Fire-and-forget — record() is sync (downstream callers don't
+      // await it). The flush sets `this.flushing` synchronously
+      // inside triggerFlush before the first await, so concurrent
+      // record() calls during the flush will short-circuit at the
+      // `flushing.has` check at the top of this method.
+      void this.triggerFlush(chatId);
+    }
   }
 
   getMessages(chatId: string): BufferedMessage[] {

--- a/src/memory/buffer.ts
+++ b/src/memory/buffer.ts
@@ -31,7 +31,17 @@ export class ConversationBuffer {
   private readonly maxMessages: number;
 
   constructor(opts?: { maxMessages?: number }) {
-    this.maxMessages = opts?.maxMessages ?? appConfig.bufferMaxMessages;
+    // R2-followup: nullish-coalescing accepts 0 (false-ish but not
+    // null), which would make `length >= 0` true on the very first
+    // push — force-flush on every record. The env path is guarded by
+    // `optionalPositiveNumber` (#109 hardening), but the constructor
+    // override path bypassed that. Reject non-positive override here
+    // and snap back to the env-default with the same shape.
+    const override = opts?.maxMessages;
+    if (override != null && override <= 0) {
+      throw new Error(`ConversationBuffer: maxMessages must be > 0, got ${override}`);
+    }
+    this.maxMessages = override ?? appConfig.bufferMaxMessages;
   }
 
   setFlushHandler(handler: FlushHandler): void {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -469,10 +469,17 @@ export function registerTools(
         // shouldn't summarize "the bot's hourly cron status update"
         // as part of the user's conversation history.
         //
-        // Detection uses the same `isSyntheticThread` flag computed
-        // above (line ~411): cronjob threads carry the
-        // JOB_THREAD_PREFIX synthetic id.
-        if (isSyntheticThread) return;
+        // Alias the `isSyntheticThread` flag (R1-followup): it's load-
+        // bearing for TWO unrelated decisions in this handler — thread
+        // routing (line ~411) and buffer skip (here). If a future
+        // change narrows the routing flag (e.g. "only treat as
+        // synthetic if also has reply_to"), the buffer-skip behavior
+        // would silently change too. The local alias signals "this
+        // value is consumed here for a different reason — preserve
+        // semantics or split the flag if either consumer's intent
+        // changes."
+        const isCronOriginated = isSyntheticThread;
+        if (isCronOriginated) return;
 
         conversationBuffer?.record(chat_id, {
           role: 'assistant',

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -455,6 +455,25 @@ export function registerTools(
       // re-emission, but storing the sanitized form is cleaner and
       // avoids audit-trail confusion (R2-audit followup on #96).
       function recordReply(replyText: string) {
+        // #110 fix: skip buffer recording for cronjob-originated replies.
+        // Pre-fix, every reply (including those produced by prompt-type
+        // cronjobs) was unconditionally recorded into the per-chat
+        // ConversationBuffer. A cronjob targeting an active chat
+        // (e.g. hourly "status update") reset the buffer's inactivity
+        // timer on every fire — auto-flush (default 3h) NEVER fired
+        // as long as the cron kept hitting. Buffer grew unboundedly
+        // AND cron output got mixed with real user dialogue, so when
+        // a flush did eventually happen the distillation was garbage.
+        //
+        // Semantically: cron output is NOT user dialogue. Distillation
+        // shouldn't summarize "the bot's hourly cron status update"
+        // as part of the user's conversation history.
+        //
+        // Detection uses the same `isSyntheticThread` flag computed
+        // above (line ~411): cronjob threads carry the
+        // JOB_THREAD_PREFIX synthetic id.
+        if (isSyntheticThread) return;
+
         conversationBuffer?.record(chat_id, {
           role: 'assistant',
           senderId: 'bot',


### PR DESCRIPTION
## Summary

Closes #110. The `reply` tool unconditionally recorded every reply (including prompt-type cronjob outputs) into the per-chat `ConversationBuffer`. A cronjob targeting an active chat (typical: hourly "team status update") reset the buffer's inactivity timer on every fire — auto-flush (default 3h) **NEVER** triggered as long as the cron kept hitting. Effects:

- **Memory leak**: per-chat buffer grew unboundedly across days/weeks.
- **Episode garbage**: when a flush eventually happened (cron paused, chat truly idle), the distillation prompt saw a mixed stream of cron output + real user dialogue; resulting episode `.md` blended "the bot's hourly status update" with "what users actually said."
- **No memory enrichment for the affected chat**: distillation effectively disabled.

## Fix (two layers)

**1. Skip buffer-record for cron-originated replies** (`src/tools.ts:recordReply`)
Detection reuses the `isSyntheticThread` flag (`thread_id.startsWith(JOB_THREAD_PREFIX)`) already computed earlier in the same handler. One-line root-cause fix:
```ts
if (isSyntheticThread) return; // cron output is not user dialogue
```
Semantically correct: a cronjob's reply is not part of the conversation history that should be distilled.

**2. Hard-cap backstop on `ConversationBuffer`**
New `LARK_BUFFER_MAX_MESSAGES` env (default 200). At-cap push triggers force-flush regardless of timer state. Idempotent via the existing `flushing.has(chatId)` guard — concurrent records during the flush short-circuit. Constructor now takes optional `{ maxMessages }` override for testability (ESM hoisting prevents env-at-top-of-smoke-test from reaching config.ts's capture point).

## Tests

`scripts/buffer-cap-smoke.ts` (5 tests, wired into `scripts/test.sh`):

| # | Behavior |
|---|---|
| 1 | Under-cap pushes do NOT trigger flush |
| 2 | At-cap push (5th of 5) triggers exactly one force-flush; buffer emptied |
| 3 | Concurrent pushes during in-flight slow flush do NOT double-flush |
| 4 | After flush completes, fresh pushes accumulate normally |
| 5 | Per-chat independence — chat A flush, chat B unaffected |

Plus `reply-card-smoke.ts` test 8b — cron-thread reply NOT recorded, non-cron-thread reply DOES record (sanity check the detection isn't over-eager).

`buffer-cap smoke: 5/5`, `reply-card smoke: PASS` (existing + 8b), full suite green.

## Operator notes

- No data-format or config changes; existing in-memory buffers drop on restart (no on-disk impact).
- Pre-#110 deployments may have accumulated large in-memory buffers for chats with active cronjobs — those drop on restart. Future flushes produce cleaner episodes since cron output is no longer recorded.
- If you've been relying on cronjob outputs appearing in episode history, that's no longer the case post-fix. The `[scheduler] Job X executed ...` stderr line remains the canonical audit trail.
- `LARK_BUFFER_MAX_MESSAGES=0` rejected by `optionalPositiveNumber` and snapped to default 200 with a breadcrumb (matches env-hardening pattern from #109).

## Test plan

- [x] `npm run typecheck` clean
- [x] `bash scripts/test.sh` all green (`buffer-cap smoke: 5/5`, all pre-existing pass)
- [x] Version bumped to 1.0.38 across 5 locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)