### PR TITLE
fix(buffer): mirror edit_message into conversation buffer (v1.0.39)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.38",
+      "version": "1.0.39",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.39] - 2026-05-25
+
+### Fixed
+- **`edit_message` left ConversationBuffer holding pre-edit text → distillation flushed stale content into episodes** (#111 — **MEDIUM memory-correctness, hard to trace**). The `reply` tool recorded its assistant text into the per-chat buffer (so distillation has user-visible context). `edit_message`, however, only patched Feishu's stored card/text — the buffer still held the pre-edit version. Effect: when the auto-flush eventually fired, the distiller saw "bot said 3pm" instead of the edited "bot said 4pm", and wrote the wrong fact into the chat's episode `.md`. Users later querying `what_do_you_know` saw the stale fact with no obvious trace back to the original wrong reply.
+
+  Concrete scenario: user asks "what time is the meeting"; Claude replies "3pm"; user corrects "it's 4pm"; Claude `edit_message`s its prior reply to "4pm"; 3h later the buffer flushes, episode says "meeting is at 3pm" — permanently wrong.
+
+  Fix (per the issue's suggested order: C → A, B deferred):
+
+  **Fix C — `chat_id` (+ `thread_id`) added to `edit_message` schema**. Optional fields so existing callers without them continue to work (the patch lands on Feishu; only the buffer-alignment is skipped). Descriptions tell Claude to pass them verbatim from the current notification's metadata.
+
+  **Fix A — new `ConversationBuffer.replaceLastAssistant(chatId, newText)`**. Walks backwards from the end of the chat's buffer; replaces the text + timestamp of the most-recent assistant entry. Returns `true` on success, `false` for: no buffer for chat / no assistant entries / mid-flush (skipped to avoid the edit landing in a buffer about to be wiped by `triggerFlush`'s post-await cleanup).
+
+  `edit_message` handler now (after a successful patch) calls `replaceLastAssistant` with the sanitized + 500-char-prefix text — same shape as the `reply`-path `recordReply` for consistency. Cron-originated edits (thread_id starts with `JOB_THREAD_PREFIX`) skip the mirror, same as #110's cron-skip in `recordReply`.
+
+  **NOTE on simplicity**: this only covers the "edit the bot's most recent message" case. Editing an earlier message (e.g. patching a card from 50 turns ago) won't find the right entry. Per-message-id tracking would require widening `BufferedMessage` with a `messageId` field — deferred unless real user-reported cases surface.
+
+### Added
+- New `ConversationBuffer.replaceLastAssistant(chatId, newText): boolean` method.
+- New `edit_message` schema fields: `chat_id?` + `thread_id?` (both optional; documented for Claude to pass verbatim from notification meta).
+- 4 new tests in `scripts/buffer-cap-smoke.ts` (tests 6–9):
+  - 6: latest assistant replaced; user entries above untouched
+  - 7: multi-turn — only the LATEST assistant gets replaced, earlier ones preserved
+  - 8: no-op cases (missing chat, user-only buffer) return false without mutation
+  - 9: mid-flush short-circuit (returns false; edit doesn't land in soon-to-be-wiped buffer)
+- 3 new tests in `scripts/reply-card-smoke.ts` (8c–8e):
+  - 8c: end-to-end edit_message → buffer entry reflects new text
+  - 8d: backward compat — edit_message WITHOUT `chat_id` still patches Feishu, buffer untouched (pre-fix behavior preserved)
+  - 8e: cron-thread edit skips buffer mirror (same shape as #110 cron-skip in reply)
+
+### Operator notes
+- No data-format changes; no env vars added.
+- Pre-#111 episodes may contain stale facts from edits that never reached the buffer. There's no automated way to find these — operator can spot-check by comparing the Feishu chat history against the distilled episode `.md`.
+- Existing `edit_message` callers (Claude code that doesn't pass `chat_id`) keep working — only the buffer-mirror is skipped. To get the fix's benefit, Claude needs to start passing `chat_id`; the schema description nudges this.
+
 ## [1.0.38] - 2026-05-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.38",
+      "version": "1.0.39",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/buffer-cap-smoke.ts
+++ b/scripts/buffer-cap-smoke.ts
@@ -187,4 +187,90 @@ let testNum = 0;
   testNum++;
 }
 
+// ── Part B: replaceLastAssistant (#111 fix) ──────────────────────
+
+// 6. Replace latest assistant entry; user entries above untouched
+{
+  const buf = new ConversationBuffer({ maxMessages: 100 });
+  buf.record('chat_r', { role: 'user', senderId: 'u', text: 'q', timestamp: 't1' });
+  buf.record('chat_r', { role: 'assistant', senderId: 'bot', text: 'old answer', timestamp: 't2' });
+
+  const ok = buf.replaceLastAssistant('chat_r', 'new answer');
+  if (!ok) fail(`6: replaceLastAssistant should return true on success`);
+
+  const msgs = buf.getMessages('chat_r');
+  if (msgs.length !== 2) fail(`6: count unchanged, got ${msgs.length}`);
+  if (msgs[0].text !== 'q') fail(`6: user entry must be untouched`);
+  if (msgs[1].text !== 'new answer') fail(`6: assistant entry should be updated, got ${msgs[1].text}`);
+  if (msgs[1].role !== 'assistant') fail(`6: role preserved`);
+  if (msgs[1].timestamp === 't2') fail(`6: timestamp should be refreshed`);
+  testNum++;
+}
+
+// 7. Multi-turn — replace only the LATEST assistant, earlier assistants untouched
+{
+  const buf = new ConversationBuffer({ maxMessages: 100 });
+  buf.record('chat_m', { role: 'user', senderId: 'u', text: 'q1', timestamp: 't1' });
+  buf.record('chat_m', { role: 'assistant', senderId: 'bot', text: 'a1', timestamp: 't2' });
+  buf.record('chat_m', { role: 'user', senderId: 'u', text: 'q2', timestamp: 't3' });
+  buf.record('chat_m', { role: 'assistant', senderId: 'bot', text: 'a2', timestamp: 't4' });
+
+  buf.replaceLastAssistant('chat_m', 'a2-edited');
+  const msgs = buf.getMessages('chat_m');
+  if (msgs[1].text !== 'a1') fail(`7: earlier assistant 'a1' must be untouched, got ${msgs[1].text}`);
+  if (msgs[3].text !== 'a2-edited') fail(`7: latest assistant should be edited`);
+  testNum++;
+}
+
+// 8. No-op cases return false
+{
+  const buf = new ConversationBuffer({ maxMessages: 100 });
+  // 8a: chat with no buffer
+  if (buf.replaceLastAssistant('chat_none', 'whatever')) {
+    fail(`8a: missing chat → false`);
+  }
+  // 8b: buffer with only user entries
+  buf.record('chat_user_only', { role: 'user', senderId: 'u', text: 'q', timestamp: 't' });
+  if (buf.replaceLastAssistant('chat_user_only', 'whatever')) {
+    fail(`8b: user-only buffer → false`);
+  }
+  // Verify user entry was NOT mutated
+  const msgs = buf.getMessages('chat_user_only');
+  if (msgs[0].text !== 'q') fail(`8b: user entry must stay`);
+  testNum++;
+}
+
+// 9. Mid-flush short-circuit — edit must not land in a buffer that's
+//    about to be wiped by triggerFlush's post-await cleanup. This is
+//    the explicit safety the implementation documents.
+{
+  const buf = new ConversationBuffer({ maxMessages: 100 });
+  let flushStarted = false;
+  let flushResume!: () => void;
+  const flushBlock = new Promise<void>((r) => { flushResume = r; });
+  buf.setFlushHandler(async () => {
+    flushStarted = true;
+    await flushBlock; // hold the flush so we can edit mid-flight
+  });
+
+  buf.record('chat_flush', { role: 'user', senderId: 'u', text: 'q', timestamp: 't1' });
+  buf.record('chat_flush', { role: 'assistant', senderId: 'bot', text: 'old', timestamp: 't2' });
+
+  // Trigger flush via the private method (force a deterministic test).
+  // We can't use cap here without filling 100 entries; use direct call.
+  const flushP = (buf as any).triggerFlush('chat_flush');
+  // Let the flush handler enter (sets flushStarted = true)
+  await new Promise((r) => setImmediate(r));
+  if (!flushStarted) fail(`9: flush should have started`);
+
+  // While mid-flush, try replaceLastAssistant — must return false
+  const ok = buf.replaceLastAssistant('chat_flush', 'edited');
+  if (ok) fail(`9: replaceLastAssistant during flush must return false`);
+
+  // Release the flush
+  flushResume();
+  await flushP;
+  testNum++;
+}
+
 console.log(`buffer-cap smoke: ${testNum}/${testNum} PASS`);

--- a/scripts/reply-card-smoke.ts
+++ b/scripts/reply-card-smoke.ts
@@ -33,6 +33,12 @@ function mockLarkClient() {
             apiCalls.push({ method: 'message.reply', args });
             return { data: { message_id: 'mock_msg_002' } };
           },
+          patch: async (args: any) => {
+            // #111: edit_message uses message.patch. Mock returns empty
+            // data (Feishu's actual response shape per SDK types).
+            apiCalls.push({ method: 'message.patch', args });
+            return { data: {} };
+          },
         },
         messageReaction: {
           create: async (args: any) => {
@@ -79,6 +85,21 @@ function makeBuffer() {
     flush: async () => {},
     startAutoFlush: () => {},
     stopAutoFlush: () => {},
+    // #111: mock replaceLastAssistant — mutates the most recent assistant
+    // entry in `recorded` for the given chatId. Production ConversationBuffer
+    // walks its own internal buffer; we mirror the semantics on `recorded`
+    // so the smoke test can observe the buffer-mirror behavior.
+    replaceLastAssistant(chatId: string, newText: string): boolean {
+      for (let i = recorded.length - 1; i >= 0; i--) {
+        const r = recorded[i];
+        if (r.chatId === chatId && r.entry.role === 'assistant') {
+          r.entry.text = newText;
+          r.entry.timestamp = new Date().toISOString();
+          return true;
+        }
+      }
+      return false;
+    },
   };
 }
 
@@ -345,6 +366,116 @@ async function run() {
     }
     if (apiCalls.length === 0) {
       fail(`8b-sanity: non-cron-thread reply must SEND (got 0 API calls)`);
+    }
+  }
+
+  // ── Test 8c: #111 — edit_message mirrors edit into ConversationBuffer ──
+  //   Pre-fix, edit_message only patched Feishu and left the buffer
+  //   holding pre-edit text → distillation flushed stale content into
+  //   episodes. Fix: pass chat_id (and thread_id) to edit_message, and
+  //   the handler calls conversationBuffer.replaceLastAssistant.
+  {
+    const editHandler = handlers.get('edit_message');
+    if (!editHandler) fail('8c: edit_message handler not registered');
+    identitySession.setCaller('chat_edit', undefined, 'ou_edit_user');
+
+    // Seed: simulate a prior reply having recorded an assistant entry.
+    buffer.recorded.length = 0;
+    apiCalls.length = 0;
+    await replyHandler({
+      chat_id: 'chat_edit',
+      text: '会议在 3 点',
+    });
+    if (buffer.recorded.length !== 1) {
+      fail(`8c-seed: prior reply should have recorded an assistant entry (got ${buffer.recorded.length})`);
+    }
+    if (buffer.recorded[0].entry.text !== '会议在 3 点') {
+      fail(`8c-seed: seeded text mismatch (got ${buffer.recorded[0].entry.text})`);
+    }
+
+    // Now edit — pass chat_id so the fix takes effect
+    apiCalls.length = 0;
+    const r = await editHandler({
+      message_id: 'om_bot_card_001',
+      text: '会议在 4 点',
+      chat_id: 'chat_edit',
+    });
+    // Patch call landed
+    const patchCall = apiCalls.find((c) => c.method === 'message.patch');
+    if (!patchCall) fail(`8c: edit_message must call message.patch`);
+    // Buffer's stored assistant entry should now reflect the edited text.
+    // The mock's `record` pushes objects into `buffer.recorded`; the
+    // backing entries are the same references (no defensive copy in
+    // makeBuffer). So mutation via replaceLastAssistant should be visible.
+    const latest = buffer.recorded[buffer.recorded.length - 1].entry;
+    if (latest.text !== '会议在 4 点') {
+      fail(`8c: buffer entry must reflect edited text (got ${latest.text})`);
+    }
+  }
+
+  // ── Test 8d: #111 — edit_message WITHOUT chat_id silently no-ops on buffer ──
+  //   Backward compat: existing callers that don't pass chat_id should
+  //   still see the patch land on Feishu, just without buffer-mirroring
+  //   (falls back to pre-fix behavior; no worse than before).
+  {
+    const editHandler = handlers.get('edit_message');
+    identitySession.setCaller('chat_edit_nocid', undefined, 'ou_edit_user');
+
+    buffer.recorded.length = 0;
+    await replyHandler({
+      chat_id: 'chat_edit_nocid',
+      text: 'original text',
+    });
+    const beforeText = buffer.recorded[0].entry.text;
+    if (beforeText !== 'original text') fail(`8d-seed: text mismatch`);
+
+    apiCalls.length = 0;
+    await editHandler({
+      message_id: 'om_card_002',
+      text: 'attempted edit',
+      // chat_id intentionally omitted
+    });
+    const patchCall = apiCalls.find((c) => c.method === 'message.patch');
+    if (!patchCall) fail(`8d: edit_message must still patch even without chat_id`);
+    // Buffer unchanged
+    if (buffer.recorded[0].entry.text !== 'original text') {
+      fail(`8d: no chat_id → buffer must not be mirrored (got ${buffer.recorded[0].entry.text})`);
+    }
+  }
+
+  // ── Test 8e: #111 — edit_message with cron-thread skips buffer mirror ──
+  //   Same shape as 8b for the reply tool: cron-originated edits are
+  //   not user dialogue and must not pollute the buffer.
+  {
+    const editHandler = handlers.get('edit_message');
+    const cronThread = `${JOB_THREAD_PREFIX}edit-job-1`;
+    identitySession.setCaller('chat_edit_cron', cronThread, 'ou_cron_owner');
+
+    buffer.recorded.length = 0;
+    // Seed a prior NON-cron assistant entry in this chat so we can
+    // detect if the cron-edit incorrectly mutates it.
+    identitySession.setCaller('chat_edit_cron', 'thr_real', 'ou_real');
+    await replyHandler({
+      chat_id: 'chat_edit_cron',
+      thread_id: 'thr_real',
+      text: 'real user reply',
+    });
+    if (buffer.recorded[0].entry.text !== 'real user reply') fail(`8e-seed: setup failed`);
+
+    apiCalls.length = 0;
+    await editHandler({
+      message_id: 'om_card_003',
+      text: 'cron-edit attempt',
+      chat_id: 'chat_edit_cron',
+      thread_id: cronThread,
+    });
+    // Patch landed
+    if (!apiCalls.find((c) => c.method === 'message.patch')) {
+      fail(`8e: cron edit must still patch Feishu`);
+    }
+    // Buffer's real-user entry MUST be untouched
+    if (buffer.recorded[0].entry.text !== 'real user reply') {
+      fail(`8e: cron-thread edit must NOT mutate real-user buffer entry (got ${buffer.recorded[0].entry.text})`);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.38' },
+    { name: 'claude-lark-plugin', version: '1.0.39' },
     {
       capabilities: {
         logging: {},

--- a/src/memory/buffer.ts
+++ b/src/memory/buffer.ts
@@ -81,6 +81,48 @@ export class ConversationBuffer {
     return this.buffers.get(chatId) ?? [];
   }
 
+  /**
+   * Replace the most-recent assistant entry's text in the given chat's
+   * buffer (#111). Walks backwards from the end of the buffer.
+   *
+   * Use case: `edit_message` tool — when Claude patches a previously
+   * sent bot message, the buffer's stored assistant text becomes
+   * stale; this keeps distillation aligned with what the user
+   * actually saw.
+   *
+   * Returns true iff an assistant entry was found and updated. Returns
+   * false for:
+   *  - chat has no buffer (nothing was ever recorded)
+   *  - buffer exists but has no assistant entries (only user messages)
+   *  - the buffer is mid-flush (skipped — the distillation snapshot was
+   *    already taken via `[...messages]` before the await; mutating
+   *    afterwards would land in a buffer that's about to be wiped by
+   *    `triggerFlush`'s cleanup, so the edit would be silently lost)
+   *
+   * NOTE: this is the simplest possible fix shape — only catches the
+   * most-recent assistant entry. If Claude edits a much-earlier
+   * message (e.g. patching a card from 50 turns ago), this won't
+   * find it. The common case (correct-the-mistake-Claude-just-made)
+   * is covered; precise per-message-id tracking is filed as a future
+   * improvement if needed.
+   */
+  replaceLastAssistant(chatId: string, newText: string): boolean {
+    if (this.flushing.has(chatId)) return false;
+    const arr = this.buffers.get(chatId);
+    if (!arr) return false;
+    for (let i = arr.length - 1; i >= 0; i--) {
+      if (arr[i].role === 'assistant') {
+        arr[i] = {
+          ...arr[i],
+          text: newText,
+          timestamp: new Date().toISOString(),
+        };
+        return true;
+      }
+    }
+    return false;
+  }
+
   clear(chatId: string): void {
     this.buffers.delete(chatId);
     this.clearTimer(chatId);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -781,9 +781,23 @@ export function registerTools(
           .enum(['text', 'card_markdown'])
           .default('text')
           .describe('Format of the content'),
+        // #111 fix: optional chat_id + thread_id so the edit can be
+        // mirrored into the in-memory conversation buffer. Pre-fix,
+        // edit_message left the buffer holding pre-edit text; the next
+        // distillation flushed wrong content into the chat's episode
+        // history. Pass these verbatim from the current notification's
+        // metadata. If omitted, the edit still works (Feishu side is
+        // patched); only the buffer-alignment is skipped, falling back
+        // to pre-fix behavior.
+        chat_id: larkIdSchema('chat_id').optional().describe(
+          'Chat ID where the edited message lives. Pass this verbatim from the current notification\'s metadata so the in-memory conversation buffer stays aligned with the user-visible text — otherwise distillation may produce stale episodes from the pre-edit content.',
+        ),
+        thread_id: larkIdSchema('thread_id').optional().describe(
+          'Thread ID — pass when present in the notification metadata. Used to detect cron-originated edits (which are skipped from buffer alignment for the same reason cron-originated replies are skipped: cron output is not user dialogue).',
+        ),
       }),
     },
-    async ({ message_id, text, format }) => {
+    async ({ message_id, text, format, chat_id, thread_id }) => {
       // Strip <at> tags before send (#96). Apply to BOTH variants because
       // Lark.messageCard.defaultCard wraps the text in a markdown block,
       // and Feishu's card markdown renderer ALSO interprets <at> as
@@ -836,6 +850,32 @@ export function registerTools(
         }
         console.error(`[tools] edit_message failed:`, err?.message ?? String(err));
         throw err;
+      }
+
+      // #111 fix: mirror the edit into the in-memory ConversationBuffer
+      // so distillation sees the user-visible text, not the pre-edit
+      // version. Skips on:
+      //  - missing chat_id (caller didn't pass — falls back to pre-fix
+      //    behavior, buffer stays stale, just no worse than before)
+      //  - cron-originated edits (same shape as recordReply skip in
+      //    #110 — cron output is not user dialogue)
+      //  - no buffer wired (unlikely in production; defensive)
+      //  - no recent assistant entry in the buffer (e.g. edit_message
+      //    called before any reply landed for this chat — buffer is
+      //    empty for the assistant role; the edit's content has no
+      //    pre-edit version to replace, so the skip is harmless)
+      if (chat_id && conversationBuffer) {
+        const isCronOriginated =
+          !!thread_id && thread_id.startsWith(JOB_THREAD_PREFIX);
+        if (!isCronOriginated) {
+          // Use the same 500-char prefix + sanitize-on-record rule as
+          // reply's recordReply for consistency (the buffer stores
+          // what the user actually saw — sanitized, length-capped).
+          conversationBuffer.replaceLastAssistant(
+            chat_id,
+            safeText.slice(0, 500),
+          );
+        }
       }
 
       return {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -871,6 +871,14 @@ export function registerTools(
           // Use the same 500-char prefix + sanitize-on-record rule as
           // reply's recordReply for consistency (the buffer stores
           // what the user actually saw — sanitized, length-capped).
+          //
+          // Both format paths mirror `safeText` (R1-followup note):
+          // - format='text': safeText IS what the user sees, directly.
+          // - format='card_markdown': edit_message wraps via
+          //   `Lark.messageCard.defaultCard({title:'', content:safeText})`;
+          //   the card chrome adds no user-visible body content, so
+          //   `safeText` is still what the user reads. Mirroring the
+          //   raw input is accurate for both.
           conversationBuffer.replaceLastAssistant(
             chat_id,
             safeText.slice(0, 500),


### PR DESCRIPTION
## Summary

Closes #111. The `reply` tool recorded its assistant text into the per-chat `ConversationBuffer` (so distillation has user-visible context). `edit_message`, however, only patched Feishu — the buffer still held the pre-edit version. Auto-flush then distilled stale text into episodes; users later querying `what_do_you_know` saw wrong facts they thought they'd corrected.

Concrete scenario: user asks meeting time → Claude says "3pm" → user corrects "4pm" → Claude `edit_message`s to "4pm" → 3h flush → episode `.md` says "meeting at 3pm" — permanently wrong.

## Fix (three parts per the issue's suggested order: C → A; B deferred)

### Fix C — schema gains `chat_id?` + `thread_id?`
Both optional so existing callers without them keep working (the patch lands; only buffer-mirror is skipped). Descriptions tell Claude to pass them verbatim from the current notification's metadata.

### Fix A — `ConversationBuffer.replaceLastAssistant(chatId, newText)`
Walks backwards from the end of the chat's buffer; replaces text + timestamp on the most-recent assistant entry. Returns `true` on success, `false` for: no buffer for chat / no assistant entries / mid-flush (skipped to avoid the edit landing in a buffer about to be wiped by `triggerFlush`'s post-await cleanup).

`edit_message` handler (after a successful patch) calls `replaceLastAssistant` with the sanitized + 500-char-prefix text — same shape as `recordReply` for consistency. Cron-originated edits (thread_id starts with `JOB_THREAD_PREFIX`) skip the mirror, same shape as #110's cron-skip.

### Fix B deferred
Precise per-message-id tracking would require widening `BufferedMessage` with a `messageId` field. This PR only covers "edit the bot's most recent reply" — earlier-message edits (rare in practice) won't find the right entry. Filed implicitly as a future improvement if real cases surface.

## Tests

**`scripts/buffer-cap-smoke.ts`** (4 new — tests 6–9):

| # | Behavior |
|---|---|
| 6 | Latest assistant entry replaced; user entries above untouched |
| 7 | Multi-turn — only the LATEST assistant gets replaced, earlier ones preserved |
| 8 | No-op cases (missing chat, user-only buffer) return false without mutation |
| 9 | Mid-flush short-circuit (returns false; doesn't land in buffer about to be wiped) |

**`scripts/reply-card-smoke.ts`** (3 new — tests 8c–8e):

| # | Behavior |
|---|---|
| 8c | End-to-end: edit_message → buffer entry reflects new text |
| 8d | Backward compat — edit_message WITHOUT `chat_id` still patches Feishu, buffer untouched (pre-fix behavior preserved) |
| 8e | Cron-thread edit skips buffer mirror (same shape as #110 cron-skip in reply) |

Plus the mock-buffer in reply-card-smoke gains a `replaceLastAssistant` implementation mirroring the production semantics (walk-backwards over `recorded`).

`buffer-cap smoke: 9/9 PASS`, `reply-card smoke: PASS`, full suite green.

## Operator notes

- No data-format changes; no env vars added.
- Pre-#111 episodes may contain stale facts from edits that never reached the buffer. No automated remediation; operator can spot-check by comparing Feishu chat history against the distilled episode `.md`.
- Existing `edit_message` callers (Claude code that doesn't pass `chat_id`) keep working — only the buffer-mirror is skipped. To get the fix's benefit, Claude needs to start passing `chat_id`; the schema description nudges this.

## Test plan

- [x] `npm run typecheck` clean
- [x] `bash scripts/test.sh` all green (buffer-cap 9/9 + reply-card PASS + all pre-existing)
- [x] Version bumped to 1.0.39 across 5 locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)