### PR TITLE
fix(memory): word-boundary aware keyword matching for search (v1.0.41)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.40",
+      "version": "1.0.41",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   - Part C (3): non-ASCII (CJK + Cyrillic) keywords preserve substring semantics.
   - Part D (4): edge cases — empty haystack, case-insensitivity, regex-metachar escape, end-to-end "Raspberry Pi vs pipeline-deploy" scenario from the issue.
 
+### R2-audit followups (closed in this PR)
+- **`matchKeyword('', '')` empty-kw guard** — pre-followup, empty kw matched everything (`\b` regex matches at any word boundary; `''.includes('')` is always true). Production-unreachable via `extractKeywords` (filters `length > 1`), but the static API is exported. Added explicit `if (!kw) return false;` at the top — trivial cost, eliminates the failure mode regardless of caller hygiene. Test 14 codifies.
+- **Underscore-as-separator asymmetry** — `\b` treats `_` as a word char in regex, so `\bapi\b` matched `api-gateway` but NOT `api_gateway`. Skill slugs are sanitized to hyphens, but LLM-distilled episode prose often contains underscore-separated identifiers (`api_gateway_setup`, `my_var`). Fixed by pre-normalizing `_` → ` ` at both search sites (NOT in `matchKeyword` — keeps the static-API contract pure). Test 15 codifies both layers.
+
+### Known limitations / forward links
+- **`searchEpisodes` has no `score > 0` gate** (pre-existing): all scored episodes are pushed, sorted, sliced. With `recencyScore = max(0, 1 - ageDays/30)`, a 9-day-old episode scores 0.7 on recency — clearing `LARK_MIN_SEARCH_SCORE` (default 0.3) **with zero keyword overlap**. Post-#102 this is materially more pronounced because the stricter matcher zeros out more keyword scores, leaving recency to dominate. This is the symptom tracked by **#100** (memory enrichment empty-keyword recency-only injection + no per-episode size cap); #102 amplifies it without introducing the underlying bug. #100 is the natural next target.
+
 ### Operator notes
 - No data-format or config changes; the cache/storage shape is identical. Only the search-time scoring changes.
 - Pre-#102 behavior: a chat where the user asks technical questions sees more skill/episode recalls because of the loose substring match. Post-fix: fewer false-positives → cleaner enrichment context → less token waste → less Claude misdirection.
 - If a previously-recalled skill stops being recalled after upgrade, check whether the keyword overlap was actually meaningful or was a spurious substring hit. Operators with legitimate stem-matching needs (keyword `deploy`, want to match `deployment-*`) keep working because the length-≥4 path preserves prefix matching.
+- **Underscore identifiers**: search-site normalization makes `api_gateway` searchable as `api gateway`. If you had skills relying on the OLD `\b`-blocked-by-underscore behavior (rare — would require deliberately wanting `api` to NOT match `api_gateway`), they'll surface differently.
 
 ## [1.0.40] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.41] - 2026-05-25
+
+### Fixed
+- **`searchSkills` / `searchEpisodes` matched keywords via bare substring → spurious recall** (#102 — **MEDIUM context pollution, invisible to user**). Both functions scored a hit via `haystack.includes(kw)` with no word-boundary check. Short keywords like `pi` matched `pipeline-deploy`, `api-gateway`, `apiary`; `go` matched `google`, `argo`; `api` matched `rapid-fix`. Result: unrelated skills/episodes injected into Claude's memory enrichment, wasting tokens AND misdirecting Claude's reasoning. Users couldn't see this — they only saw Claude reference a workflow that had no relation to their question.
+
+  Fix (length-threshold word-boundary, threading "too lenient" vs "too strict"):
+  - **ASCII keyword length ≤ 3** → require word boundary on BOTH sides (`\b...\b`). Catches the "pi vs pipeline" case the issue cited. Short tokens are noise-prone; demand exact word match.
+  - **ASCII keyword length ≥ 4** → require word boundary at start only (`\b...`). Preserves legitimate stem/prefix matches: `deploy` still matches `deployment-script`, `config` still matches `configuration`. Without this, the fix would have regressed user-meaningful stems.
+  - **Non-ASCII keyword (CJK, Cyrillic, etc.)** → substring match preserves existing behavior. `\b` is ASCII-defined; using it on Chinese chars would produce surprising results (no inter-character boundaries the way English has).
+
+  Also (Fix C in the issue's suggested approach): drop `file` / `filename` from the search haystack. `searchSkills` was scoring against `name + description + file` where `file` is just `sanitizeSkillSlug(name) + ".md"` — a derivative of `name` that doubles the surface and adds the literal token `md`. `searchEpisodes` was scoring against `firstLines + filename` where `filename` is a timestamp like `2026-05-25T14-30-00-000Z.md` — pure noise for keyword matching. Both surfaces now use semantic fields only.
+
+  Implemented as a new `MemoryStore.matchKeyword(haystack, kw): boolean` static method (pure, no `this` dependency) so tests can pin the contract directly. Both `searchSkills` and `searchEpisodes` call it instead of inlining `includes`.
+
+### Added
+- New `MemoryStore.matchKeyword` static method — pure word-boundary-aware keyword matcher with the length-threshold + ASCII/CJK split documented above.
+- New `scripts/search-precision-smoke.ts` (13 tests, wired into `scripts/test.sh`):
+  - Part A (4): short ASCII keywords no longer false-match (the bug — `pi` ≠ `pipeline`, `go` ≠ `google`, `api` ≠ `apiary`), but DO match genuine word boundaries (`raspberry pi`, `go programming`, `api-gateway`, `rapid-api`).
+  - Part B (2): long ASCII keywords PRESERVE prefix/stem match (`deploy` matches `deployment-script` / `deployable` / `deployment`; `config` matches `configuration` / `configurable` / `configfile`). Plus negative guards: no boundary-leading prefix match (`deploy` ≠ `redeploy`, `config` ≠ `misconfig`).
+  - Part C (3): non-ASCII (CJK + Cyrillic) keywords preserve substring semantics.
+  - Part D (4): edge cases — empty haystack, case-insensitivity, regex-metachar escape, end-to-end "Raspberry Pi vs pipeline-deploy" scenario from the issue.
+
+### Operator notes
+- No data-format or config changes; the cache/storage shape is identical. Only the search-time scoring changes.
+- Pre-#102 behavior: a chat where the user asks technical questions sees more skill/episode recalls because of the loose substring match. Post-fix: fewer false-positives → cleaner enrichment context → less token waste → less Claude misdirection.
+- If a previously-recalled skill stops being recalled after upgrade, check whether the keyword overlap was actually meaningful or was a spurious substring hit. Operators with legitimate stem-matching needs (keyword `deploy`, want to match `deployment-*`) keep working because the length-≥4 path preserves prefix matching.
+
 ## [1.0.40] - 2026-05-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.40",
+      "version": "1.0.41",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/search-precision-smoke.ts
+++ b/scripts/search-precision-smoke.ts
@@ -191,4 +191,38 @@ let testNum = 0;
   testNum++;
 }
 
+// ── Part E: R2-followup hardening ──
+
+// 14. Empty keyword returns false (was true pre-followup: regex `\b\b`
+//     matches everything; `''.includes('')` is true). Production
+//     unreachable via extractKeywords' length>1 filter, but the
+//     exported static API gets an explicit guard.
+{
+  if (MemoryStore.matchKeyword('any haystack here', '')) {
+    fail(`14: empty kw must return false (defense-in-depth)`);
+  }
+  if (MemoryStore.matchKeyword('', '')) {
+    fail(`14b: empty kw + empty haystack must return false`);
+  }
+  testNum++;
+}
+
+// 15. Underscore semantics — matchKeyword itself does NOT normalize
+//     `_` (the search SITES do); this codifies that contract.
+//     `\bapi\b` against `api_gateway` → false (underscore is a word
+//     char in regex). Search sites pre-normalize via `.replace(/_/g, ' ')`
+//     so production calls see `api gateway` and match correctly.
+{
+  // Raw matchKeyword: underscore is word char → no boundary inside
+  if (MemoryStore.matchKeyword('api_gateway flow', 'api')) {
+    fail(`15: raw matchKeyword does NOT cross underscore (this is documented)`);
+  }
+  // After search-site normalization, the haystack becomes `api gateway flow`
+  const normalized = 'api_gateway flow'.replace(/_/g, ' ');
+  if (!MemoryStore.matchKeyword(normalized, 'api')) {
+    fail(`15: after underscore→space normalization, api matches api_gateway`);
+  }
+  testNum++;
+}
+
 console.log(`search-precision smoke: ${testNum}/${testNum} PASS`);

--- a/scripts/search-precision-smoke.ts
+++ b/scripts/search-precision-smoke.ts
@@ -1,0 +1,194 @@
+/**
+ * Search precision smoke test (v1.0.41, closes #102).
+ *
+ * Directly exercises `MemoryStore.matchKeyword` (pure static) which
+ * is the core of the fix. End-to-end testing via searchSkills /
+ * searchEpisodes requires fs setup; the matchKeyword unit covers the
+ * threading-the-needle logic without that ceremony.
+ *
+ * Threading note: the issue suggested word-boundary on both sides
+ * (\b...\b), but that would regress legitimate prefix matches
+ * ("deploy" should still match "deployment-script"). Fix uses a
+ * length threshold:
+ *   - ASCII keyword ≤ 3 chars → both-sides boundary (exact word)
+ *   - ASCII keyword ≥ 4 chars → start-only boundary (prefix match)
+ *   - Non-ASCII (CJK) → substring (preserves expected Chinese behavior)
+ */
+
+import { MemoryStore } from '../src/memory/file.js';
+
+function fail(msg: string): never {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+let testNum = 0;
+
+// ── Part A: the bug — short ASCII keywords no longer false-match ──
+
+// 1. "pi" must NOT match "pipeline-deploy" (the issue's headline example)
+{
+  if (MemoryStore.matchKeyword('pipeline-deploy ci/cd deployment helper', 'pi')) {
+    fail(`1: "pi" must not match "pipeline" — the original bug`);
+  }
+  testNum++;
+}
+
+// 2. "pi" matches "raspberry pi setup notes" (genuine word boundary)
+{
+  if (!MemoryStore.matchKeyword('raspberry pi setup notes', 'pi')) {
+    fail(`1b: "pi" must match "raspberry pi" — genuine word boundary`);
+  }
+  testNum++;
+}
+
+// 3. "go" must NOT match "google", "argo", "ago"
+{
+  for (const haystack of ['google search', 'argo cd pipeline', 'three days ago']) {
+    if (MemoryStore.matchKeyword(haystack, 'go')) {
+      fail(`3: "go" must not match "${haystack}"`);
+    }
+  }
+  // But DOES match "go programming"
+  if (!MemoryStore.matchKeyword('go programming language', 'go')) {
+    fail(`3: "go" must match "go programming"`);
+  }
+  testNum++;
+}
+
+// 4. "api" exact match — DOES match "api-gateway" (hyphen is word boundary)
+{
+  if (!MemoryStore.matchKeyword('api-gateway routing rules', 'api')) {
+    fail(`4: "api" must match "api-gateway"`);
+  }
+  // Does NOT match "apiary" (no boundary inside the word)
+  if (MemoryStore.matchKeyword('apiary bee-keeping guide', 'api')) {
+    fail(`4: "api" must NOT match "apiary"`);
+  }
+  // DOES match "rapid-api" (hyphen as boundary)
+  if (!MemoryStore.matchKeyword('rapid-api integration', 'api')) {
+    fail(`4: "api" must match "rapid-api" (hyphen separates)`);
+  }
+  testNum++;
+}
+
+// ── Part B: long ASCII keywords PRESERVE prefix/stem match ──
+
+// 5. "deploy" matches "deployment-script", "deployable", "deployment plan"
+{
+  for (const haystack of [
+    'deployment-script for staging',
+    'deployable artifact builder',
+    'deployment plan for q1',
+  ]) {
+    if (!MemoryStore.matchKeyword(haystack, 'deploy')) {
+      fail(`5: "deploy" must match prefix "${haystack}"`);
+    }
+  }
+  // BUT not "redeploy" (no boundary before "deploy")
+  if (MemoryStore.matchKeyword('redeploy fast-track', 'deploy')) {
+    fail(`5: "deploy" must NOT match "redeploy" (no leading boundary)`);
+  }
+  testNum++;
+}
+
+// 6. "config" matches "configuration", "configurable", "configfile"
+{
+  for (const haystack of ['configuration helper', 'configurable cli', 'configfile parser']) {
+    if (!MemoryStore.matchKeyword(haystack, 'config')) {
+      fail(`6: "config" must match prefix "${haystack}"`);
+    }
+  }
+  // Not "misconfig" (no boundary before "config")
+  if (MemoryStore.matchKeyword('misconfig diagnosis', 'config')) {
+    fail(`6: "config" must NOT match "misconfig"`);
+  }
+  testNum++;
+}
+
+// ── Part C: non-ASCII (CJK) preserves substring semantics ──
+
+// 7. "人工" matches "人工智能" (Chinese substring, no word boundaries)
+{
+  if (!MemoryStore.matchKeyword('人工智能助手 介绍', '人工')) {
+    fail(`7: Chinese "人工" must match substring "人工智能"`);
+  }
+  testNum++;
+}
+
+// 8. "学习" matches "深度学习" (Chinese substring)
+{
+  if (!MemoryStore.matchKeyword('深度学习论文 阅读笔记', '学习')) {
+    fail(`8: Chinese "学习" must match substring "深度学习"`);
+  }
+  testNum++;
+}
+
+// 9. Cyrillic (non-ASCII) preserves substring
+{
+  if (!MemoryStore.matchKeyword('россия москва санкт', 'россия')) {
+    fail(`9: Cyrillic substring match should work`);
+  }
+  testNum++;
+}
+
+// ── Part D: edge cases ──
+
+// 10. Empty haystack — never matches
+{
+  if (MemoryStore.matchKeyword('', 'anything')) fail(`10: empty haystack`);
+  if (MemoryStore.matchKeyword('', '人工')) fail(`10: empty haystack non-ASCII`);
+  testNum++;
+}
+
+// 11. Case-insensitivity (kw is pre-lowered by extractKeywords; matcher
+//     also accepts mixed-case haystacks just in case)
+{
+  // ASCII path uses regex with `i` flag
+  if (!MemoryStore.matchKeyword('Deploy Pipeline', 'deploy')) {
+    fail(`11: ASCII case-insensitive (haystack mixed case)`);
+  }
+  // Substring path on non-ASCII doesn't lowercase — caller is expected to
+  // pre-lowercase the haystack (which searchSkills/Episodes do). This
+  // documents that behavior.
+  testNum++;
+}
+
+// 12. Special regex chars in keyword are escaped (defensive — extractKeywords
+//     splits on punctuation so this shouldn't reach the matcher, but
+//     belt-and-suspenders against a future caller bypass)
+{
+  // A keyword with a regex metachar would otherwise crash the RegExp constructor
+  // or worse, alter the match semantics. matchKeyword escapes them.
+  if (MemoryStore.matchKeyword('plain text', 'a.b')) {
+    // Should NOT match — '.' is escaped, not wildcard
+    fail(`12: dot in keyword must be literal, not wildcard`);
+  }
+  // But IF the haystack literally contains "a.b", that does NOT match either
+  // because "a.b" isn't ASCII-word (contains "."), so it falls through to
+  // substring. Actually `/^[a-z0-9_-]+$/i` rejects "a.b" → substring path.
+  if (!MemoryStore.matchKeyword('found a.b in text', 'a.b')) {
+    fail(`12: substring path matches literal "a.b" in haystack`);
+  }
+  testNum++;
+}
+
+// 13. Regression guard — the issue's "Raspberry Pi vs CI/CD" scenario
+//     end-to-end at the matcher level.
+{
+  // Scenario from the issue:
+  // skill: "pipeline-deploy" with description "CI/CD deployment helper"
+  // user query: "Raspberry Pi 怎么装 Ubuntu" → keywords [raspberry, pi, 装, ubuntu]
+  const skillHaystack = 'pipeline-deploy ci/cd deployment helper';
+  const keywords = ['raspberry', 'pi', '装', 'ubuntu'];
+  let totalScore = 0;
+  for (const kw of keywords) {
+    if (MemoryStore.matchKeyword(skillHaystack, kw)) totalScore++;
+  }
+  if (totalScore !== 0) {
+    fail(`13: pipeline-deploy must score 0 against raspberry-pi query, got ${totalScore}`);
+  }
+  testNum++;
+}
+
+console.log(`search-precision smoke: ${testNum}/${testNum} PASS`);

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -155,4 +155,8 @@ echo "=== Buffer hard-cap unit checks ==="
 npx tsx scripts/buffer-cap-smoke.ts
 
 echo ""
+echo "=== Search precision (word-boundary) unit checks ==="
+npx tsx scripts/search-precision-smoke.ts
+
+echo ""
 echo "All tests passed."

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.40' },
+    { name: 'claude-lark-plugin', version: '1.0.41' },
     {
       capabilities: {
         logging: {},

--- a/src/memory/file.ts
+++ b/src/memory/file.ts
@@ -674,12 +674,15 @@ export class MemoryStore {
         const content = await fs.readFile(filePath, 'utf-8');
         const stat = await fs.stat(filePath);
 
-        // Score: keyword match on first two lines + filename
+        // Score: keyword match on first two lines only. #102 fix
+        // (Fix C): drop filename — episode filenames are timestamps
+        // (`2026-05-25T14-30-00-000Z.md`) which can't meaningfully
+        // match human keywords; including them just adds noise tokens.
         const firstLines = content.split('\n').slice(0, 3).join(' ').toLowerCase();
-        const filenameLower = file.toLowerCase();
         let keywordScore = 0;
         for (const kw of keywords) {
-          if (firstLines.includes(kw) || filenameLower.includes(kw)) {
+          // #102 fix (Fix A): word-boundary aware via matchKeyword.
+          if (MemoryStore.matchKeyword(firstLines, kw)) {
             keywordScore++;
           }
         }
@@ -868,9 +871,16 @@ export class MemoryStore {
         const description = (lines[1] ?? '').trim();
 
         let score = 0;
-        const searchText = `${name} ${description} ${file}`.toLowerCase();
+        // #102 fix (Fix C): drop `file` from haystack. `file` is
+        // sanitizeSkillSlug(name) + ".md" — a derivative of `name`
+        // that just doubles the surface for spurious substring hits
+        // and adds the literal token "md". `name` + `description`
+        // carry all the user-meaningful signal.
+        const searchText = `${name} ${description}`.toLowerCase();
         for (const kw of keywords) {
-          if (searchText.includes(kw)) score++;
+          // #102 fix (Fix A): word-boundary aware via matchKeyword.
+          // Pre-fix `searchText.includes(kw)` matched any substring.
+          if (MemoryStore.matchKeyword(searchText, kw)) score++;
         }
 
         if (score > 0) {
@@ -1216,6 +1226,57 @@ export class MemoryStore {
   }
 
   // ── Helpers ──
+
+  /**
+   * Decide whether a single keyword matches the haystack with the
+   * precision required for memory recall (#102).
+   *
+   * Pre-fix, `searchSkills` and `searchEpisodes` used bare
+   * `haystack.includes(kw)`. That fired on any substring — keyword
+   * "pi" matched skill "pipeline-deploy", "api-gateway", "apiary";
+   * keyword "go" matched "google", "argo"; etc. Result: irrelevant
+   * skills/episodes injected into Claude's enrichment, polluting
+   * context and wasting tokens.
+   *
+   * Threading the needle between "too lenient" (substring) and
+   * "too strict" (token-equal — would lose legitimate prefix matches
+   * like "deploy" → "deployment-script"):
+   *
+   *   - ASCII keyword, length ≤ 3 → require word boundaries on BOTH
+   *     sides (\b...\b). Short tokens are noise-prone; demand exact
+   *     word match.
+   *   - ASCII keyword, length ≥ 4 → require word boundary at start
+   *     only (\b...). Allows stem/prefix matches: "deploy" matches
+   *     "deployment", "deployable", "deployment-script".
+   *   - Non-ASCII keyword (CJK etc.) → substring match preserves
+   *     existing behavior. `\b` is ASCII-defined; using it on
+   *     Chinese characters would produce surprising results
+   *     (every char position is or isn't a boundary depending on
+   *     neighbor's script).
+   *
+   * Exported `static` so the search smoke test can pin the contract
+   * directly without round-tripping through searchSkills/Episodes.
+   */
+  static matchKeyword(haystack: string, kw: string): boolean {
+    // ASCII word-like (alphanumeric + underscore + hyphen) → use
+    // word-boundary regex. The kw was already lowercased by
+    // extractKeywords; the haystack is lowercased at the search site.
+    if (/^[a-z0-9_-]+$/i.test(kw)) {
+      const escaped = kw.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      if (kw.length <= 3) {
+        // Short keyword: require both-sides boundary (exact word match).
+        // Catches the "pi" vs "pipeline" case the issue cited.
+        return new RegExp(`\\b${escaped}\\b`, 'i').test(haystack);
+      }
+      // Longer keyword: prefix match. \b at start, no end boundary.
+      // Preserves legitimate stem matches like "deploy" → "deployment".
+      return new RegExp(`\\b${escaped}`, 'i').test(haystack);
+    }
+    // Non-ASCII (CJK / cyrillic / etc.): substring preserves current
+    // behavior. `\b` boundaries are ASCII-defined and would produce
+    // surprising results on these scripts.
+    return haystack.includes(kw);
+  }
 
   private extractKeywords(query: string): string[] {
     const stopWords = new Set([

--- a/src/memory/file.ts
+++ b/src/memory/file.ts
@@ -678,7 +678,11 @@ export class MemoryStore {
         // (Fix C): drop filename — episode filenames are timestamps
         // (`2026-05-25T14-30-00-000Z.md`) which can't meaningfully
         // match human keywords; including them just adds noise tokens.
-        const firstLines = content.split('\n').slice(0, 3).join(' ').toLowerCase();
+        //
+        // R2-followup: normalize `_` → ` ` (same rationale as
+        // searchSkills) so underscore-separated identifiers in
+        // LLM-distilled episode prose surface correctly.
+        const firstLines = content.split('\n').slice(0, 3).join(' ').toLowerCase().replace(/_/g, ' ');
         let keywordScore = 0;
         for (const kw of keywords) {
           // #102 fix (Fix A): word-boundary aware via matchKeyword.
@@ -876,7 +880,16 @@ export class MemoryStore {
         // that just doubles the surface for spurious substring hits
         // and adds the literal token "md". `name` + `description`
         // carry all the user-meaningful signal.
-        const searchText = `${name} ${description}`.toLowerCase();
+        //
+        // R2-followup: normalize `_` → ` ` so identifier-style words
+        // like `api_gateway_setup` match keyword `api` the same way
+        // `api-gateway-setup` does. Pre-followup `\b` treated `_` as
+        // a word char (no boundary inside `api_gateway`), so the
+        // hyphen-vs-underscore asymmetry silently dropped recall on
+        // underscore-separated identifiers (common in Python/Go/
+        // config code that LLM-distilled skill descriptions often
+        // contain).
+        const searchText = `${name} ${description}`.toLowerCase().replace(/_/g, ' ');
         for (const kw of keywords) {
           // #102 fix (Fix A): word-boundary aware via matchKeyword.
           // Pre-fix `searchText.includes(kw)` matched any substring.
@@ -1258,6 +1271,13 @@ export class MemoryStore {
    * directly without round-tripping through searchSkills/Episodes.
    */
   static matchKeyword(haystack: string, kw: string): boolean {
+    // R2-followup defense-in-depth: extractKeywords filters length>1,
+    // so production never passes empty kw. But matchKeyword is
+    // exported as a static API contract — an external caller passing
+    // empty string would otherwise match everything (`/\b/i.test()`
+    // succeeds on any haystack with a word boundary, OR
+    // `haystack.includes('')` is always true). Reject explicitly.
+    if (!kw) return false;
     // ASCII word-like (alphanumeric + underscore + hyphen) → use
     // word-boundary regex. The kw was already lowercased by
     // extractKeywords; the haystack is lowercased at the search site.


### PR DESCRIPTION
## Summary

Closes #102. `searchSkills` and `searchEpisodes` scored hits via bare `haystack.includes(kw)` with no word-boundary check. Short keywords spuriously matched substrings:

- `pi` matched `pipeline-deploy`, `api-gateway`, `apiary`
- `go` matched `google`, `argo`, `ago`
- `api` matched `rapid-fix`

Effect: irrelevant skills/episodes injected into Claude's memory enrichment, wasting tokens AND misdirecting Claude's reasoning. **Invisible to the user** — they only notice Claude reference a workflow that has no relation to their question.

## Fix

Length-threshold word-boundary, threading "too lenient" (substring) vs "too strict" (token-equal — would lose legitimate stem matches):

| Keyword class | Match shape | Rationale |
|---|---|---|
| ASCII, ≤ 3 chars | `\b<kw>\b` (both-sides boundary) | Short = noise-prone; demand exact word |
| ASCII, ≥ 4 chars | `\b<kw>` (start-only boundary) | Preserves `deploy` → `deployment-script` |
| Non-ASCII (CJK, Cyrillic) | substring | `\b` is ASCII-defined; using it on Chinese chars surprises |

Also **drop noise from haystacks** (Fix C from the issue):
- `searchSkills`: stop including `file` — it's `sanitizeSkillSlug(name).md`, a derivative of `name` that doubles the surface and adds the literal token `md`.
- `searchEpisodes`: stop including filename — it's a timestamp like `2026-05-25T14-30-00-000Z.md`, never matches meaningful keywords.

Implemented as new `MemoryStore.matchKeyword(haystack, kw): boolean` static method (pure, no `this` dependency) for direct testability. `searchSkills` and `searchEpisodes` call it instead of inlining `includes`.

## Tests

`scripts/search-precision-smoke.ts` (13 tests, wired into `scripts/test.sh`):

| Part | # | Behavior |
|---|---|---|
| A | 1 | `pi` ≠ `pipeline-deploy` (headline bug) |
| A | 2 | `pi` matches `raspberry pi` (genuine boundary) |
| A | 3 | `go` ≠ `google`/`argo`/`ago`; matches `go programming` |
| A | 4 | `api` matches `api-gateway`/`rapid-api`; ≠ `apiary` |
| B | 5 | `deploy` matches `deployment-script`/`deployable`; ≠ `redeploy` |
| B | 6 | `config` matches `configuration`/`configurable`; ≠ `misconfig` |
| C | 7 | Chinese `人工` matches `人工智能` (substring) |
| C | 8 | Chinese `学习` matches `深度学习` |
| C | 9 | Cyrillic substring works |
| D | 10 | Empty haystack |
| D | 11 | Case-insensitivity |
| D | 12 | Regex-metachar escape (`a.b` ≠ wildcard) |
| D | 13 | End-to-end "Raspberry Pi vs pipeline-deploy" from the issue |

`search-precision smoke: 13/13 PASS`. Full suite green.

## Operator notes

- No data-format or config changes; storage shape unchanged. Only search-time scoring changes.
- Pre-#102 had more recalls due to loose substring; post-fix has fewer false-positives → cleaner enrichment context → less token waste.
- Legitimate stem matching (`deploy` → `deployment-*`) preserved by the length-≥4 path. If a previously-recalled skill stops surfacing after upgrade, check whether the keyword overlap was actually meaningful vs spurious substring.

## Test plan

- [x] `npm run typecheck` clean
- [x] `bash scripts/test.sh` all green (`search-precision smoke: 13/13` + all pre-existing)
- [x] Version bumped to 1.0.41 across 5 locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)