### PR TITLE
chore: cleanup batch — drain LOW-severity audit followups (v1.0.45)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.44",
+      "version": "1.0.45",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.45] - 2026-05-25
+
+### Cleanup batch — LOW-severity followups
+
+Per-release housekeeping pass to drain accumulated audit-followup queue. All four items below were filed during prior R1/R2 audits of v1.0.42–v1.0.44; none affect production behavior at default settings. Batched into a single PR to keep individual fixes reviewable while closing real noise.
+
+- **#154 — `appConfig` lifecycle documented in `src/config.ts`**. Several prior audits flagged comments at use sites that implied `appConfig.<key>` reads were "live" (would pick up runtime `process.env` mutations). They are not — `appConfig` is built once at module load and effectively frozen. Added a top-of-file docstring spelling this out, plus testing-pattern guidance (set env BEFORE the first import, or subprocess) so future contributors don't trip on the same footgun.
+
+- **#153 — `MemoryStore.capByBytes` returns `''` for sub-codepoint caps instead of a content-free tag**. Pre-fix, `capByBytes('人abc', 1)` returned `'\n... [truncated]'` — 16 bytes of "this got cut" with zero payload. Now returns `''` so callers can detect "nothing fit" cleanly. Production caps (defaults 2KB / 8KB) never hit this branch; the change matters only for pathological / hand-tuned tiny caps. Smoke test 6b added to `scripts/episode-cap-smoke.ts`.
+
+- **#161 — channel-side `.then()` consume integration is now smoke-covered**. The race-resolution body (consume the pending-revoke mark + immediately delete the just-created reaction OR store with timestamp) was previously inlined in `handleMessageEvent`'s `.then()`. Refactored into a new `LarkChannel.onAckCreated(messageId, reactionId): void` method (one-line call from the `.then()`); two new smoke tests in `scripts/ack-reaction-batch-smoke.ts`:
+  - Test 11: late-revoke race path — pre-marks pending, fires `onAckCreated`, asserts delete fires with right `reaction_id` and ack entry is NOT stored.
+  - Test 11b control: normal storage path — no pending mark → ack entry stored with `addedAt`, no delete fires.
+
+  Without these, a refactor flipping the consume/store order, dropping the early return, or removing the consume branch would have passed all 10 of the prior tests.
+
+- **#157 — closed as documented-already**. The TOCTOU between `isRecycledJob` check and `writeJob` is already covered by v1.0.43's CHANGELOG operator note ("If you're scripting rapid delete_job + create_job cycles ... sleep ≥100ms between calls"). Requires sub-ms timing of two operator-level actions; can re-open if a real repro surfaces. No code change; issue closed with cross-reference.
+
+### Deferred to a future cleanup batch
+
+- **#156** — `recoverMissedJobs` boot-time recycle window. Needs a real code change (re-read before `executeJob` in the recovery loop) + test; pulled out of this batch to keep scope tight.
+- **#159 / #160** — race protection for `react` and `reply.reply_to` validation. Both need a shared `recentInboundIds: TTLCache<messageId, true>` on `LarkChannel`. Pairing them into one infrastructure PR.
+
+### Process note
+
+This batch is the first deliberate "drain the LOW queue" PR after recognizing that each main-loop PR was averaging ~1 audit-followup filed per issue closed (net zero on the queue depth). Going forward: every 3-4 main-loop PRs, run one of these cleanup batches; raise the file-followup bar in R1/R2 audits (file only what could plausibly affect a user within ~1 month). Issue count itself isn't the metric — severity-weighted real-risk is — but the deliberate drain keeps the followup list reflective of actual residual work.
+
+---
+
 ## [1.0.44] - 2026-05-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.44",
+      "version": "1.0.45",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/ack-reaction-batch-smoke.ts
+++ b/scripts/ack-reaction-batch-smoke.ts
@@ -309,4 +309,94 @@ function setupHandlers(opts: { failOnMethod?: string } = {}) {
   passed++;
 }
 
+// 11. #161 followup: channel-side .then() consume integration. The
+//     pure-helper contract (tests 1-4) and the reply-call-site mark
+//     (tests 5, 10) cover the input side. This test exercises the
+//     OUTPUT side — `onAckCreated` (the extracted .then() body)
+//     consumes the mark and triggers a late-revoke delete instead
+//     of storing in the Map. Without this test, a refactor that
+//     flipped the consume/store order, dropped the early return, or
+//     removed the consume branch would pass tests 1-10.
+{
+  const ch = new LarkChannel();
+  const deleteCalls: any[] = [];
+  // Swap the client with a deletion-recording mock. messageReaction.delete
+  // is the only call onAckCreated makes on the late-revoke path.
+  (ch as any).client = {
+    im: { v1: { messageReaction: {
+      delete: async (args: any) => {
+        deleteCalls.push(args);
+        return { data: {} };
+      },
+    } } },
+  };
+
+  // Pre-mark pending — simulates `reply.revokeAckFor` having run
+  // before the ack-create's .then() landed.
+  ch.markPendingAckRevoke('om_late_revoke');
+  if (!(ch as any).pendingAckRevokes.has('om_late_revoke')) {
+    fail(`11a: setup — pending mark should be set`);
+  }
+
+  // Fire onAckCreated as the .then() would. Synchronous body, but
+  // the inner withFeishuRetry().catch() is async — give it a tick.
+  ch.onAckCreated('om_late_revoke', 'rxn_late');
+  await new Promise(r => setTimeout(r, 30));
+
+  // Verify:
+  //  - delete fired with the right reaction_id
+  //  - ack entry NOT stored (the race-protection point)
+  //  - pending mark consumed
+  if (deleteCalls.length !== 1) {
+    fail(`11b: late-revoke delete should fire exactly once, got ${deleteCalls.length}`);
+  }
+  if (deleteCalls[0].path.message_id !== 'om_late_revoke') {
+    fail(`11b: wrong message_id in delete, got ${deleteCalls[0].path.message_id}`);
+  }
+  if (deleteCalls[0].path.reaction_id !== 'rxn_late') {
+    fail(`11b: wrong reaction_id in delete, got ${deleteCalls[0].path.reaction_id}`);
+  }
+  if (ch.getAckReactions().has('om_late_revoke')) {
+    fail(`11c: ack entry should NOT be stored on the race path — got entry, race protection failed`);
+  }
+  if (ch.consumePendingAckRevoke('om_late_revoke')) {
+    fail(`11d: pending mark should have been consumed by onAckCreated`);
+  }
+  passed++;
+}
+
+// 11b. #161 followup: control case — onAckCreated WITHOUT a pending
+//      mark stores normally (no late-revoke, ack entry persists).
+//      This pins the "non-race" path so a regression that always
+//      took the late-revoke branch would be caught.
+{
+  const ch = new LarkChannel();
+  const deleteCalls: any[] = [];
+  (ch as any).client = {
+    im: { v1: { messageReaction: {
+      delete: async (args: any) => {
+        deleteCalls.push(args);
+        return { data: {} };
+      },
+    } } },
+  };
+
+  // No pending mark — normal storage path
+  ch.onAckCreated('om_normal_ack', 'rxn_normal');
+  await new Promise(r => setTimeout(r, 30));
+
+  if (deleteCalls.length !== 0) {
+    fail(`11b-control: delete must NOT fire without a pending mark, got ${deleteCalls.length} calls`);
+  }
+  const entry = ch.getAckReactions().get('om_normal_ack');
+  if (!entry) fail(`11b-control: ack entry MUST be stored on the normal path`);
+  if (entry!.reactionId !== 'rxn_normal') {
+    fail(`11b-control: wrong reactionId stored, got ${entry!.reactionId}`);
+  }
+  if (typeof entry!.addedAt !== 'number') {
+    fail(`11b-control: addedAt must be set (powers TTL backstop)`);
+  }
+  passed++;
+}
+
 console.log(`ack-reaction batch smoke: ${passed}/${passed} PASS`);

--- a/scripts/episode-cap-smoke.ts
+++ b/scripts/episode-cap-smoke.ts
@@ -99,6 +99,28 @@ let testNum = 0;
   testNum++;
 }
 
+// 6b. #153 followup: sub-codepoint cap with multi-byte leading char
+//     returns '' (NOT a content-free '\n... [truncated]' tag).
+//     '人abc' starts with a 3-byte CJK char; cap=1 walks end back
+//     to 0 → body would be empty → skip tag, return ''.
+{
+  if (MemoryStore.capByBytes('人abc', 1) !== '') {
+    fail(`6b: sub-codepoint cap on CJK lead should return '', got: ${JSON.stringify(MemoryStore.capByBytes('人abc', 1))}`);
+  }
+  if (MemoryStore.capByBytes('人abc', 2) !== '') {
+    fail(`6b: cap=2 on 3-byte lead should still return '' (need 3 bytes for first char)`);
+  }
+  // cap=3 fits exactly the first CJK char with no tag (no truncation needed beyond it)
+  // Actually wait: '人abc' = 3+1+1+1 = 6 bytes. cap=3 → buf.length=6 > 3 → truncate.
+  // end=3 → walk back: buf[3] = 'a' = 0x61 = NOT continuation (high bits 01xx) → end stays 3.
+  // body = '人' (3 bytes) → return '人\n... [truncated]'.
+  const out3 = MemoryStore.capByBytes('人abc', 3);
+  if (!out3.startsWith('人') || !out3.endsWith('\n... [truncated]')) {
+    fail(`6b: cap=3 on 3-byte lead should return '人' + tag, got: ${JSON.stringify(out3)}`);
+  }
+  testNum++;
+}
+
 // ── Part B: saveEpisode round-trip enforces the (default) cap ──
 
 // 7. Write a pathologically large episode at the DEFAULT cap, read

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -501,6 +501,47 @@ export class LarkChannel {
     return this.pendingAckRevokes.size;
   }
 
+  /**
+   * #161 followup: race-resolution body lifted out of the inline
+   * `.then()` in `handleMessageEvent` so the channel-side wiring
+   * is directly testable. Called when an ack-create resolves.
+   *
+   * If `consumePendingAckRevoke(messageId)` returns true (revoke
+   * was requested while the ack-create was still in flight),
+   * immediately delete the just-created reaction instead of
+   * storing it — closes #136 race. Otherwise store with timestamp
+   * so the TTL backstop (`pruneStaleAcks`, #85) can sweep orphans.
+   *
+   * Returns void; errors from the late-revoke delete are swallowed
+   * after a `debugLog` (best-effort; the TTL backstop would catch
+   * a leaked entry anyway).
+   *
+   * Marked `internal` in spirit — production caller is the inline
+   * `.then()` only. Tests call it directly.
+   */
+  onAckCreated(messageId: string, reactionId: string): void {
+    // Check pending-revoke FIRST. Order is critical (#161): if we
+    // set the Map before checking the Set, a race-protected
+    // revoke would silently lose. The test pins this ordering.
+    if (this.consumePendingAckRevoke(messageId)) {
+      debugLog(`[channel] ack for ${messageId} landed after revoke was requested; deleting immediately`);
+      withFeishuRetry(
+        () => this.client.im.v1.messageReaction.delete({
+          path: { message_id: messageId, reaction_id: reactionId },
+        }),
+        { label: 'ack.late-revoke' },
+      ).catch((err: any) => {
+        debugLog(`[channel] late-revoke gave up for ${messageId}: ${err?.message ?? err}`);
+      });
+      return;
+    }
+    // addedAt timestamp powers the TTL backstop (#85): pruneStaleAcks
+    // sweeps entries older than ACK_TTL_MS so anything that escaped
+    // the normal revoke path doesn't sit on the user's message
+    // forever or leak Map memory.
+    this.ackReactions.set(messageId, { reactionId, addedAt: Date.now() });
+  }
+
   getBotMessageTracker(): BotMessageTracker {
     return this.botMessageTracker;
   }
@@ -710,30 +751,11 @@ export class LarkChannel {
       ).then((resp: any) => {
         const reactionId = resp?.data?.reaction_id;
         if (reactionId) {
-          // #136 fix: check the pending-revoke Set FIRST. If
-          // `revokeAckFor` already ran (fast bot reply outraced the
-          // ack-create round-trip), the messageId is marked here —
-          // immediately delete the reaction we just created instead
-          // of storing in the Map (where it would sit until the TTL
-          // backstop swept it up to 6 min later, leaving the MeMeMe
-          // emoji visibly stuck on the user's message).
-          if (this.consumePendingAckRevoke(messageId)) {
-            debugLog(`[channel] ack for ${messageId} landed after revoke was requested; deleting immediately`);
-            withFeishuRetry(
-              () => this.client.im.v1.messageReaction.delete({
-                path: { message_id: messageId, reaction_id: reactionId },
-              }),
-              { label: 'ack.late-revoke' },
-            ).catch((err: any) => {
-              debugLog(`[channel] late-revoke gave up for ${messageId}: ${err?.message ?? err}`);
-            });
-            return;
-          }
-          // addedAt timestamp powers the TTL backstop (#85): pruneStaleAcks
-          // sweeps entries older than ACK_TTL_MS so anything that escaped
-          // the normal revoke path doesn't sit on the user's message
-          // forever or leak Map memory.
-          this.ackReactions.set(messageId, { reactionId, addedAt: Date.now() });
+          // #161 followup: race-resolution body lifted into a
+          // private `onAckCreated` method so the smoke test can
+          // exercise the consume-vs-store branch directly without
+          // SDK / WebSocket plumbing.
+          this.onAckCreated(messageId, reactionId);
         }
       }).catch((err) => {
         // #112: at least log on final exhaustion so an operator can see

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,29 @@ import { config } from 'dotenv';
 import path from 'node:path';
 import os from 'node:os';
 
+/**
+ * Config lifecycle (#154):
+ *
+ * `appConfig` (exported below) is built ONCE at module load time —
+ * `dotenv` reads `~/.claude/channels/lark/.env`, every `optional*`
+ * helper captures `process.env[KEY]` into the literal, and the
+ * resulting object is frozen-ish (no setter discipline beyond
+ * "don't write to it"). **There is no hot-reload.** Mutating
+ * `process.env.LARK_*` at runtime has NO effect on `appConfig.*`
+ * reads from anywhere in the codebase.
+ *
+ * If a test or future use site needs to verify env-override
+ * behavior, it must either (a) set `process.env.LARK_*` BEFORE the
+ * first `import './config.js'` in the entry point, or (b) spawn a
+ * subprocess with the env preset. Setting env after `appConfig` is
+ * imported and expecting the change to land is a known footgun.
+ *
+ * Hot-path use sites that read `appConfig.someKey` per-call (e.g.
+ * `src/memory/file.ts` cap reads, `src/scheduler.ts` retry knobs)
+ * do so for code-organization reasons — NOT to allow runtime
+ * retuning. The reads are constant after module load.
+ */
+
 const envPath = path.join(os.homedir(), '.claude', 'channels', 'lark', '.env');
 config({ path: envPath });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.44' },
+    { name: 'claude-lark-plugin', version: '1.0.45' },
     {
       capabilities: {
         logging: {},

--- a/src/memory/file.ts
+++ b/src/memory/file.ts
@@ -1342,12 +1342,15 @@ export class MemoryStore {
    * fits"). Returns the original string for any input whose UTF-8
    * byte length is already within the cap (including empty string).
    *
-   * Edge note: with `maxBytes` smaller than the first character's
-   * UTF-8 length (e.g. `maxBytes=1` and a 3-byte CJK lead), the body
-   * truncates to empty and the result is just the truncation tag.
-   * Production caps (defaults 2KB / 8KB) never hit this corner; if a
-   * future caller sets a sub-codepoint cap they get the tag only —
-   * accept that as the intended "cap was unreasonably small" signal.
+   * Edge note (#153 followup): with `maxBytes` smaller than the
+   * first character's UTF-8 length (e.g. `maxBytes=1` and a 3-byte
+   * CJK lead), the body would truncate to empty. Pre-followup we
+   * returned just the truncation tag (16 bytes of "this got cut"
+   * with 0 bytes of payload — conveys nothing useful). Post-
+   * followup we return `''` so the caller can detect "nothing fit"
+   * cleanly. Production caps (defaults 2KB / 8KB) never hit this
+   * corner; the change matters only for pathological / hand-tuned
+   * tiny caps.
    *
    * Implementation note: UTF-8 continuation bytes are `10xxxxxx`
    * (`0x80–0xBF`). After a candidate cutoff, walk backward past any
@@ -1365,6 +1368,15 @@ export class MemoryStore {
     // bisect a multi-byte codepoint. Bounded by 4 iterations max
     // (UTF-8 chars are at most 4 bytes).
     while (end > 0 && (buf[end] & 0xc0) === 0x80) end--;
+    // #153 followup: skip the truncation tag when the body would be
+    // empty (sub-codepoint cap on a multi-byte-leading string).
+    // Pre-followup `capByBytes('人abc', 1)` returned
+    // `'\n... [truncated]'` — 16 bytes of tag for 0 bytes of body,
+    // which conveys nothing useful to Claude or to a human reading
+    // a truncated episode. Now: empty body → return `''` so the
+    // caller can detect "nothing fit" cleanly. Production caps
+    // (defaults 2KB / 8KB) never hit this branch.
+    if (end === 0) return '';
     return buf.subarray(0, end).toString('utf-8') + '\n... [truncated]';
   }
 


### PR DESCRIPTION
## Summary

Closes #153, closes #154, closes #161. (#157 already closed as documented-already in v1.0.43 CHANGELOG.)

First deliberate "drain the LOW queue" pass. Main-loop PRs have been averaging ~1 audit followup filed per issue closed (net flat queue). This batch picks the truly small, low-risk items to demonstrate the cadence going forward.

## What's in

- **#154** (doc-only): `src/config.ts` top-of-file lifecycle docstring stating `appConfig` is frozen at module load. Closes the documentation gap that previous test footguns hit.
- **#153** (one-liner + test): `MemoryStore.capByBytes` returns `''` instead of a content-free truncation tag when sub-codepoint cap forces empty body. Production unreachable at default 2KB/8KB caps.
- **#161** (refactor + 2 tests): race-resolution body extracted from `handleMessageEvent`'s inline `.then()` into `LarkChannel.onAckCreated(messageId, reactionId)`. Smoke tests 11 + 11b directly pin the consume-before-store contract — a future refactor flipping the order or dropping the early return would now fail immediately.
- **#157** already closed (documented in v1.0.43 operator notes; reference comment posted).

## What's deferred (kept scope tight)

- **#156** — `recoverMissedJobs` boot-time recycle window. Needs real code change + test.
- **#159 / #160** — race protection for `react` and `reply.reply_to` validation. Need shared `recentInboundIds` TTL infra; better to pair them.

## Process note

CHANGELOG includes a "Process note" section explaining the new cadence: cleanup batches every 3-4 main-loop PRs; R1/R2 file-followup bar raised to "could plausibly affect a user within ~1 month." Issue count isn't the metric — severity-weighted real-risk is — but the deliberate drain keeps the followup list reflective of actual residual work.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `bash scripts/test.sh` — full gate including new tests:
  - `episode-cap smoke: 13/13 PASS` (was 12; +1 for #153 case)
  - `ack-reaction batch smoke: 12/12 PASS` (was 10; +2 for #161 onAckCreated coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)