### PR TITLE
fix(buffer): atomic cleanup-and-release in triggerFlush (v1.0.47)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.46",
+      "version": "1.0.47",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.47] - 2026-05-25
+
+### Fixed
+- **`ConversationBuffer.triggerFlush` cleanup-and-release ordering made atomic** (#148). Pre-fix the cleanup steps lived OUTSIDE the `finally` block:
+
+  ```ts
+  this.flushing.add(chatId);
+  try { await this.flushHandler(chatId, [...messages]); }
+  catch (err) { ... }
+  finally { this.flushing.delete(chatId); }  // gate released here
+  this.buffers.delete(chatId);               // …but cleanup runs AFTER
+  this.timers.delete(chatId);
+  ```
+
+  Theoretical race: between `flushing.delete` (gate released) and `buffers.delete`, a concurrent `record()` could pass the `flushing.has` guard, push to the still-live buffer, then have its push silently wiped by `buffers.delete`. **In practice, V8's single-threaded execution model means there is no real yield window between two consecutive sync statements** — once the await resumes, the finally block and the cleanup lines run as one atomic JS turn. The race is not exploitable today.
+
+  **So why fix it?** The contract is fragile. Any future refactor that adds an `await` between gate-release and cleanup (or a sync hook integration that observes mid-block state) would reopen a real window — and the failure mode is silent data loss, the hardest class to debug. Moving cleanup INSIDE `finally` makes the contract explicit and refactor-safe:
+
+  ```ts
+  finally {
+    this.buffers.delete(chatId);   // 1. wipe old buffer
+    this.clearTimer(chatId);        // 2. cancel + clear old timer
+    this.flushing.delete(chatId);   // 3. release gate LAST
+  }
+  ```
+
+  Also switched bare `this.timers.delete(chatId)` to `this.clearTimer(chatId)` — the helper additionally calls `clearTimeout`, so the underlying setTimeout is properly cancelled rather than leaked-then-self-no-op'd.
+
+### Added
+- Two new smoke tests in `scripts/buffer-cap-smoke.ts` (now 11 total):
+  - **Test 10**: post-flush state verification — `flushing` gate released, `buffers` entry wiped, `timers` entry cleared. A new `record()` post-flush lands cleanly in a fresh buffer+timer pair.
+  - **Test 11**: pre-existing re-entry guard preserved — `record()` during a held flush is dropped (the cleanup reorder didn't accidentally relax the during-flush drop semantics, since the gate is still released LAST).
+
+### Operator notes
+- **No behavior change in any reachable scenario.** This is a code-clarity / refactor-safety fix, not a bug fix for an observed symptom. Existing flush behavior — drop during flush, fresh state after — is identical.
+- **Marginal cleanup**: timers that previously self-no-op'd are now cancelled, saving a small amount of event-loop work in chats that flush via the cap-trigger path.
+- No data-format or storage changes.
+
+---
+
 ## [1.0.46] - 2026-05-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.46",
+      "version": "1.0.47",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/buffer-cap-smoke.ts
+++ b/scripts/buffer-cap-smoke.ts
@@ -273,4 +273,89 @@ let testNum = 0;
   testNum++;
 }
 
+// 10. #148 fix: atomic cleanup-and-release ordering. The pre-fix
+//     shape moved buffers.delete OUTSIDE the finally block, so a
+//     theoretical interleaving between gate-release and cleanup
+//     could lose a concurrent record(). V8 single-threaded JS makes
+//     this not exploitable today, but the fix codifies the contract:
+//     after triggerFlush returns, a fresh record() lands cleanly in
+//     a NEW buffer/timer pair (proves cleanup-then-release was
+//     atomic). Test exercises the full lifecycle.
+{
+  const buf = new ConversationBuffer({ maxMessages: 100 });
+  let flushCount = 0;
+  buf.setFlushHandler(async () => { flushCount++; });
+
+  buf.record('chat_cleanup', { role: 'user', senderId: 'u', text: 'a', timestamp: 't1' });
+  buf.record('chat_cleanup', { role: 'user', senderId: 'u', text: 'b', timestamp: 't2' });
+
+  await (buf as any).triggerFlush('chat_cleanup');
+  if (flushCount !== 1) fail(`10: flush should fire exactly once, got ${flushCount}`);
+
+  // Post-flush state: old buffer wiped, gate released
+  if (buf.getMessages('chat_cleanup').length !== 0) {
+    fail(`10: buffer should be empty post-flush, got ${buf.getMessages('chat_cleanup').length}`);
+  }
+  if ((buf as any).flushing.has('chat_cleanup')) {
+    fail(`10: flushing gate must be released post-flush`);
+  }
+  if ((buf as any).timers.has('chat_cleanup')) {
+    fail(`10: timer entry must be cleared post-flush`);
+  }
+
+  // A new record() now should land cleanly in a fresh buffer + arm a new timer.
+  buf.record('chat_cleanup', { role: 'user', senderId: 'u', text: 'fresh', timestamp: 't3' });
+  if (buf.getMessages('chat_cleanup').length !== 1) {
+    fail(`10: post-flush record() must create fresh entry, got ${buf.getMessages('chat_cleanup').length}`);
+  }
+  if (!(buf as any).timers.has('chat_cleanup')) {
+    fail(`10: post-flush record() must arm new timer`);
+  }
+
+  testNum++;
+}
+
+// 11. #148 fix: record() DURING a held flush is still dropped (the
+//     pre-existing re-entry guard preserved). Confirms the cleanup
+//     reordering didn't accidentally relax the during-flush drop
+//     semantics — flushing.delete is still LAST, so any record()
+//     before the finally completes hits the `flushing.has` guard.
+{
+  const buf = new ConversationBuffer({ maxMessages: 100 });
+  let flushResume!: () => void;
+  const flushBlock = new Promise<void>((r) => { flushResume = r; });
+  let flushHandlerEntered = false;
+  buf.setFlushHandler(async () => {
+    flushHandlerEntered = true;
+    await flushBlock;
+  });
+
+  buf.record('chat_drop', { role: 'user', senderId: 'u', text: 'a', timestamp: 't1' });
+
+  const flushP = (buf as any).triggerFlush('chat_drop');
+  await new Promise((r) => setImmediate(r));
+  if (!flushHandlerEntered) fail(`11: flush should have entered handler`);
+
+  // While the flush is held, record() must be dropped (existing contract).
+  buf.record('chat_drop', { role: 'user', senderId: 'u', text: 'during-flush', timestamp: 't2' });
+  // The dropped message must NOT appear in the buffer (still empty during flush)
+  if (buf.getMessages('chat_drop').length !== 1) {
+    // Note: buffer still has the ORIGINAL 'a' since cleanup hasn't fired yet
+    fail(`11: buffer should still have original during flush, got ${buf.getMessages('chat_drop').length}`);
+  }
+  if (buf.getMessages('chat_drop').some(m => m.text === 'during-flush')) {
+    fail(`11: during-flush record() must be dropped (not appear in buffer)`);
+  }
+
+  flushResume();
+  await flushP;
+
+  // Post-flush: original wiped, drop confirmed never landed
+  if (buf.getMessages('chat_drop').length !== 0) {
+    fail(`11: post-flush buffer should be empty, got ${buf.getMessages('chat_drop').length}`);
+  }
+
+  testNum++;
+}
+
 console.log(`buffer-cap smoke: ${testNum}/${testNum} PASS`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.46' },
+    { name: 'claude-lark-plugin', version: '1.0.47' },
     {
       capabilities: {
         logging: {},

--- a/src/memory/buffer.ts
+++ b/src/memory/buffer.ts
@@ -205,10 +205,32 @@ export class ConversationBuffer {
     } catch (err) {
       console.error(`[buffer] Flush failed for chat ${chatId}:`, err);
     } finally {
+      // #148 fix: cleanup INSIDE the finally so the gate-release is
+      // strictly the LAST step. Pre-fix shape was:
+      //   finally { flushing.delete }; buffers.delete; timers.delete
+      // The current V8 single-threaded execution model means there's
+      // no real yield window between `flushing.delete` and the next
+      // sync statement, so the race the issue describes is not
+      // exploitable today — BUT the contract is fragile. Any future
+      // refactor that adds an `await` between gate-release and
+      // cleanup (or a sync hook that fires during sync execution,
+      // e.g. a future async-hooks integration) would reopen a real
+      // window where a concurrent `record()` could pass the
+      // `flushing.has` guard, push to the live buffer, and then have
+      // its push wiped by the about-to-fire `buffers.delete`.
+      //
+      // Moving cleanup INSIDE finally makes the contract explicit:
+      // (1) wipe old buffer, (2) clear old timer, (3) release gate —
+      // strictly in that order, atomically as one sync block. A
+      // concurrent `record()` AFTER step 3 sees an empty Map and
+      // creates a fresh buffer/timer pair; its message survives.
+      // Also use `clearTimer()` instead of bare `timers.delete()` so
+      // the underlying setTimeout is actually cancelled (pre-fix the
+      // Map entry was dropped but the timeout fired and self-no-op'd,
+      // wasting a small amount of work).
+      this.buffers.delete(chatId);
+      this.clearTimer(chatId);
       this.flushing.delete(chatId);
     }
-
-    this.buffers.delete(chatId);
-    this.timers.delete(chatId);
   }
 }


### PR DESCRIPTION
## Summary

Closes #148. `ConversationBuffer.triggerFlush` had cleanup steps OUTSIDE the `finally` block, with the `flushing` gate released INSIDE. The audit-described race (concurrent `record()` landing between gate-release and buffer-cleanup, getting silently wiped) is theoretical on V8 single-threaded JS — no real yield window exists between two consecutive sync statements. But the contract is fragile: any future refactor adding an `await` between gate-release and cleanup would open a real silent-data-loss window.

## Implementation

Move cleanup INSIDE `finally` in explicit order: (1) `buffers.delete`, (2) `clearTimer` (was bare `timers.delete` — now also cancels the underlying setTimeout), (3) `flushing.delete` LAST.

A concurrent `record()` AFTER step 3 sees an empty Map and creates a fresh buffer/timer pair. A `record()` during steps 1-3 hits the existing `flushing.has` guard and drops.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `bash scripts/test.sh` — full gate including `buffer-cap smoke: 11/11 PASS`
- [x] New tests (added to existing buffer-cap-smoke.ts):
  - Test 10: post-flush state — gate released, buffer wiped, timer cleared; new record() lands in fresh state
  - Test 11: during-flush drop still works (gate-last invariant preserved)

## Operator impact

No behavior change in any reachable scenario today. This is a code-clarity / refactor-safety fix. Marginal cleanup: timers that previously self-no-op'd are now cancelled, saving a small amount of event-loop work in cap-flush-heavy chats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)