### PR TITLE
fix(memory): close migrateIfNeeded race in unmutexed read paths (v1.0.48)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.47",
+      "version": "1.0.48",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.48] - 2026-05-25
+
+### Fixed
+- **`migrateIfNeeded` race between mutex-wrapped `saveProfile` and unmutexed `getProfile` / `listProfileLines`** (#143). On a legacy user's first concurrent touch after upgrade, the read paths called `migrateIfNeeded` without acquiring the per-user mutex (`withProfileMutex`, #54 fix). A `getProfile` and `saveProfile` racing on the same legacy user could both pass the `existsSync(legacy)` check before either had `mkdir`'d the new tier layout, then both write L1-split content to `public.md` — and the unmutexed read's L1-split could LAND LAST, clobbering the save's NEW content. Silent data loss on first-touch concurrency.
+
+  Fix: `getProfile` and `listProfileLines` now wrap their `migrateIfNeeded` call in `withProfileMutex(ownerId, ...)`. The reads themselves stay outside the mutex (eventual-consistency on tier reads is fine for enrichment; locking every read would serialize the hot path for no benefit post-migration). When the read's migrate step fires, any in-flight `saveProfile` on the same user has already completed and unlinked the legacy file → the existing `if (existsSync(dir))` short-circuit at the top of `migrateIfNeeded` takes the safe unlink-only branch.
+
+  **Deadlock pitfall caught in implementation**: `removeProfileLine` (already inside its own `withProfileMutex`) calls `listProfileLines` from inside the lock. The naive fix (just adding `withProfileMutex` to `listProfileLines`'s body) would deadlock — the inner mutex acquisition chains behind the outer's tail, which never resolves. Solved by extracting a private `_listProfileLinesLocked(ownerId, tier)` that skips the migrate step + mutex; `removeProfileLine` calls `migrateIfNeeded` directly (already in mutex) then `_listProfileLinesLocked`. Public `listProfileLines` is the migrate-then-list wrapper for outside-mutex callers. Test 11 in `scripts/profile-toctou-smoke.ts` locks the contract — a future refactor that reverts to calling the public variant from inside the mutex would hang the smoke immediately (Promise.race with a 2s deadlock detector).
+
+### Added
+- New private `MemoryStore._listProfileLinesLocked(ownerId, tier)` — internal variant for callers ALREADY inside `withProfileMutex` on the same userId.
+- Two new tests in `scripts/profile-toctou-smoke.ts` (now 11 total):
+  - **Test 10**: legacy-first-touch race — seed legacy file, run `saveProfile` + `getProfile` concurrently, assert the save's NEW content survives in `public.md` AND legacy content is preserved AND legacy file is unlinked.
+  - **Test 11**: deadlock guard — `removeProfileLine` still completes within 2s (Promise.race deadlock detector). Pins the public-vs-locked variant invariant.
+
+### Operator notes
+- **No behavior change for non-legacy users.** Migration only runs on profiles that pre-date v0.10's tiered layout; once migrated, `migrateIfNeeded` short-circuits at `!existsSync(legacy)` and the mutex acquisition is a no-op chained-tail (microseconds).
+- **First-touch reads on a legacy profile now queue briefly behind any in-flight save on the same user.** The mutex tail is empty in steady state, so the overhead is only paid on the actual first-touch race scenario.
+- **No data-format changes.** Tier file layout, legacy file shape, and the migration's L1 classification logic are unchanged.
+
+---
+
 ## [1.0.47] - 2026-05-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.47",
+      "version": "1.0.48",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/profile-toctou-smoke.ts
+++ b/scripts/profile-toctou-smoke.ts
@@ -307,6 +307,81 @@ try {
     }
     testNum++;
   }
+  // ── 10. #143 migrateIfNeeded race (legacy-first-touch concurrency) ──
+  //   Pre-fix `getProfile` / `listProfileLines` called `migrateIfNeeded`
+  //   without the mutex. On a legacy user's first concurrent touch,
+  //   getProfile and saveProfile could BOTH pass the legacy-exists
+  //   check before either had mkdir'd the new layout, both write L1-
+  //   split content to public.md, and the unmutexed read's L1-split
+  //   could clobber the save's NEW content. Post-fix, getProfile +
+  //   listProfileLines wrap the migrate call in withProfileMutex; the
+  //   save's mutex acquisition serializes against it.
+  //
+  //   Deterministic reproduction: seed a legacy file, kick off
+  //   getProfile + saveProfile concurrently, verify the save's NEW
+  //   line survives in public.md (instead of being clobbered by an
+  //   unmutexed legacy-split write).
+  {
+    const fsAsync = await import('node:fs/promises');
+    const user = 'ou_migrate_race';
+    const legacyPath = join(tmp, 'profiles', `${user}.md`);
+    await fsAsync.mkdir(join(tmp, 'profiles'), { recursive: true });
+    // Seed legacy file with mundane content (L1 will classify as public)
+    await fsAsync.writeFile(legacyPath, '- legacy fact one\n- legacy fact two\n', 'utf-8');
+
+    // Concurrent: a save AND a read on the legacy user
+    const [, profile] = await Promise.all([
+      store.saveProfile(user, 'BRAND NEW saved fact', 'public', 'append'),
+      store.getProfile(user, 'someone-else'),
+    ]);
+
+    // After both complete, the save's NEW content must be present.
+    // Pre-fix bug: the unmutexed read's migrate would clobber public.md
+    // with just the L1-split legacy (no "BRAND NEW saved fact").
+    const finalPub = tierLines(user, 'public');
+    if (!finalPub.includes('BRAND NEW saved fact')) {
+      fail(`10: save's NEW content must survive concurrent migrate, got ${JSON.stringify(finalPub)}`);
+    }
+    // Legacy lines should also be present (migrated by either path)
+    if (!finalPub.includes('legacy fact one')) {
+      fail(`10: legacy content must survive migration, got ${JSON.stringify(finalPub)}`);
+    }
+    // Legacy file should be unlinked
+    if (existsSync(legacyPath)) {
+      fail(`10: legacy file must be unlinked after migration completes`);
+    }
+    // getProfile returned the post-save state (since it serialized behind the save)
+    if (!profile || !profile.includes('BRAND NEW saved fact')) {
+      fail(`10: getProfile result should reflect post-save state, got ${JSON.stringify(profile)}`);
+    }
+    testNum++;
+  }
+
+  // ── 11. #143 fix preserved: removeProfileLine still works (no deadlock) ──
+  //   The fix's risk: making listProfileLines internally take the mutex
+  //   could deadlock removeProfileLine's existing mutex acquisition
+  //   that calls listProfileLines from inside. Caught + fixed during
+  //   implementation via _listProfileLinesLocked. This test pins the
+  //   contract — if a future refactor reverts to calling the public
+  //   variant from inside the mutex, removeProfileLine would hang.
+  {
+    const user = 'ou_no_deadlock';
+    await store.saveProfile(user, 'line one', 'public', 'append');
+    await store.saveProfile(user, 'line two', 'public', 'append');
+    const lines = await store.listProfileLines(user, 'public');
+    const targetHash = lines.find((l) => l.text === 'line one')?.hash;
+    if (!targetHash) fail(`11: setup — line one should be present`);
+    // This call would hang pre-followup-fix
+    const result = await Promise.race([
+      store.removeProfileLine(user, 'public', targetHash!),
+      new Promise<never>((_, rej) => setTimeout(() => rej(new Error('removeProfileLine deadlock')), 2000)),
+    ]);
+    if (result.removed !== 1) fail(`11: removeProfileLine should remove 1 line, got ${result.removed}`);
+    const after = tierLines(user, 'public');
+    if (after.includes('line one')) fail(`11: line one should be removed`);
+    if (!after.includes('line two')) fail(`11: line two should be preserved`);
+    testNum++;
+  }
 } finally {
   rmSync(tmp, { recursive: true, force: true });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.47' },
+    { name: 'claude-lark-plugin', version: '1.0.48' },
     {
       capabilities: {
         logging: {},

--- a/src/memory/file.ts
+++ b/src/memory/file.ts
@@ -353,7 +353,23 @@ export class MemoryStore {
    * intentionally different, and their consumers are disjoint.
    */
   async getProfile(ownerId: string, caller: string): Promise<string | null> {
-    await this.migrateIfNeeded(ownerId);
+    // #143 fix: serialize the migration step under the per-user mutex
+    // so a concurrent `saveProfile`'s migration cannot race against
+    // our migration. Pre-fix the read paths called `migrateIfNeeded`
+    // unmutexed; on a legacy user's first touch, getProfile + a racing
+    // saveProfile could both pass the legacy-exists check before
+    // either had mkdir'd the new layout, then both write their L1-
+    // split content to public.md — the read's L1-split would clobber
+    // the save's NEW content. Post-fix, getProfile's migrate chains
+    // behind any in-flight saveProfile on the same userId via
+    // `withProfileMutex`; when our migrate fires, the new layout is
+    // already authoritative and the existing `if (existsSync(dir))`
+    // short-circuit at the top of `migrateIfNeeded` takes the safe
+    // unlink-only branch. Reads themselves (below) stay outside the
+    // mutex — eventual-consistency on tier reads is fine for
+    // enrichment, and locking every read would serialize the hot
+    // path for no benefit post-migration.
+    await this.withProfileMutex(ownerId, () => this.migrateIfNeeded(ownerId));
 
     const readOpt = async (p: string): Promise<string> => {
       if (!existsSync(p)) return '';
@@ -582,7 +598,26 @@ export class MemoryStore {
    * in `what_do_you_know`.
    */
   async listProfileLines(ownerId: string, tier: Tier): Promise<ProfileLine[]> {
-    await this.migrateIfNeeded(ownerId);
+    // #143 fix: same as getProfile — wrap migrate in per-user mutex
+    // so legacy-first-touch concurrency can't have an unmutexed read
+    // path's L1-split clobber an in-flight save's NEW content.
+    await this.withProfileMutex(ownerId, () => this.migrateIfNeeded(ownerId));
+    return this._listProfileLinesLocked(ownerId, tier);
+  }
+
+  /**
+   * Internal: read + parse a profile tier file, NO migration step,
+   * NO mutex. Callers that are ALREADY inside `withProfileMutex` on
+   * the same userId (e.g. `removeProfileLine`'s closure) must use
+   * this variant — calling the public `listProfileLines` from inside
+   * a held mutex would deadlock (the inner `withProfileMutex` chains
+   * behind the outer's still-unresolved tail).
+   *
+   * Public callers from OUTSIDE any mutex should use `listProfileLines`
+   * instead; this method skips the migration step which is required
+   * for legacy users' first read.
+   */
+  private async _listProfileLinesLocked(ownerId: string, tier: Tier): Promise<ProfileLine[]> {
     const p = this.profileTierPath(ownerId, tier);
     if (!existsSync(p)) return [];
     const content = await fs.readFile(p, 'utf-8');
@@ -626,7 +661,12 @@ export class MemoryStore {
     // saveProfile / saveProfileTiered / removeProfileLine for the same
     // ownerId — would deadlock the per-user mutex.
     return this.withProfileMutex(ownerId, async () => {
-      const lines = await this.listProfileLines(ownerId, tier);
+      // #143 fix: must call the _Locked variants from inside the
+      // mutex. Calling the public listProfileLines (which now also
+      // takes the mutex internally) would deadlock — its chain would
+      // queue behind our still-unresolved tail.
+      await this.migrateIfNeeded(ownerId);
+      const lines = await this._listProfileLinesLocked(ownerId, tier);
       const targets = lines.filter((l) => l.hash === hash);
       if (targets.length === 0) return { removed: 0, sample: null, allTexts: [] };
       const kept = lines.filter((l) => l.hash !== hash);


### PR DESCRIPTION
## Summary

Closes #143. On a legacy user's first concurrent touch after upgrade, `getProfile` / `listProfileLines` called `migrateIfNeeded` WITHOUT the per-user mutex (`withProfileMutex`, #54 fix). A `saveProfile` + `getProfile` race could both pass the legacy-exists check before either had mkdir'd the new layout, both write L1-split content to `public.md` — and the unmutexed read's L1-split could LAND LAST, clobbering the save's NEW content.

## Implementation

`getProfile` and `listProfileLines` now wrap the `migrateIfNeeded` call in `withProfileMutex(ownerId, ...)`. Reads themselves stay outside the mutex (eventual-consistency on tier reads is fine for enrichment).

**Deadlock pitfall caught + fixed during implementation**: `removeProfileLine` (already inside its own `withProfileMutex`) calls `listProfileLines` from inside the lock — naive fix would deadlock. Solved by extracting `_listProfileLinesLocked` private variant; `removeProfileLine` calls it directly. Public `listProfileLines` is the migrate-then-list wrapper.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `bash scripts/test.sh` — full gate including `profile-toctou smoke: 11/11 PASS`
- [x] Two new tests:
  - Test 10: legacy-first-touch race — save's NEW content survives concurrent migrate; legacy content preserved; legacy file unlinked
  - Test 11: deadlock guard — `removeProfileLine` completes within 2s (Promise.race detector); pins the public-vs-locked invariant

## Operator impact

No behavior change for non-legacy users. Migration only runs on pre-v0.10 single-file profiles; once migrated, `migrateIfNeeded` short-circuits and the mutex is a no-op chained-tail (microseconds). First-touch reads on a legacy profile now queue briefly behind any in-flight save on the same user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)