### PR TITLE
fix(privacy): word-boundary L1 keyword matcher (v1.0.52)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.52] - 2026-05-25
+
+### Fixed
+- **L1 privacy keyword classifier substring-matched aggressively on short ASCII keywords** (#129). Pre-fix, `applyL1` used `lower.includes(kw.toLowerCase())` for both blacklist and whitelist keyword loops. Short keywords like `Go` (the language), `PM`, `TL`, `CEO` would substring-match any word containing those characters: `algorithm` (al**go**rithm) matched `Go`, `amp` (a**mp**) matched `PM`, `title` and `settle` matched `TL`. Result: distillation classifier silently marked any fact line containing those substrings as `public`, regardless of actual content. Real privacy exposure: a private fact containing the word "algorithm" or "category" got auto-classified as public via the misfired `Go` match.
+
+  This is the mirror-image of the #90 problem (over-broad PRIVATE rule via substring) but on the PUBLIC side — and it was pre-existing, just surfaced by PR #128's R1 audit. The smoke file even had a workaround comment noting the bug ("avoid words containing 'go'...") for tests that needed to assert `gray` cleanly.
+
+  Fix shape — new `matchesKeyword(text, kw): boolean` helper with three branches by keyword shape:
+  1. **Non-ASCII (CJK etc.)** → substring fallback (pre-fix behavior). `\b` is ASCII-defined and would never fire correctly for Chinese.
+  2. **ASCII with non-word chars (e.g. `C++`)** → custom boundary `(?:^|[^A-Za-z0-9_])${kw}(?=$|[^A-Za-z0-9_])`. Standard `\b...\b` doesn't work for symbol-suffix keywords because `\W→\W` doesn't trigger a boundary at the trailing `+`.
+  3. **Pure-word ASCII** → standard `\b...\b` regex with `i` flag.
+
+  Both L1_BLACKLIST_KEYWORDS and L1_WHITELIST_KEYWORDS loops now go through `matchesKeyword`. `applyL1`'s public contract is unchanged.
+
+### Added
+- New `matchesKeyword(text, kw): boolean` exported from `src/privacy-rules.ts`. Pure helper, exported for direct unit testing of each branch without round-tripping through `applyL1`'s full classification.
+- Privacy smoke now 79 cases total (was 44): +13 new L1 cases (#129 regression guards for `algorithm` / `ago` / `amp` / `title` / `settle` / `golang`, plus positive controls for `Go` / `PM` / `TL` / `CEO` / `C++` / `Java` standalone) + 21 `matchesKeyword` direct cases (three branches × edge cases).
+- The smoke's pre-existing workaround comment that noted the bug ("avoid words containing 'go'") is now an explicit regression guard with a #129 cross-reference.
+
+### Behavior changes worth flagging
+- **`golang` (single word) no longer auto-matches `Go` as public.** Pre-fix substring matched `Go` inside `golang`. Post-fix word-boundary requires `Go` as a standalone token. Affected fact lines fall through to `gray` (then L2/L3 classifies). Operators wanting `golang`-as-public can add `'golang'` to `L1_WHITELIST_KEYWORDS`.
+- **`JavaScripts` (plural with `s` suffix) no longer matches `JavaScript`.** Same trade-off as `golang`. The base singular `JavaScript` still matches as before.
+- **`Java` inside `JavaScript` doesn't match `Java`.** Pre-fix this was incidentally harmless (both whitelisted to `public`); post-fix the contract is cleaner — each keyword matches independently.
+
+### Operator notes
+- **No data-format or storage changes.** Existing profile tier files are unchanged. Only `applyL1`'s decision logic changes.
+- **No retroactive re-classification.** Facts already on disk under their pre-#129 classification stay there. Only NEW saves go through the corrected classifier.
+- **L2/L3 still catch anything that falls through to gray.** L1 was always advisory; L2 (user-edited `privacy-rules.md`) and L3 (LLM judgment) remain the final classifiers. The fix narrows L1's over-broad public auto-promotions.
+
+---
+
 ## [1.0.51] - 2026-05-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/privacy-rules-smoke.ts
+++ b/scripts/privacy-rules-smoke.ts
@@ -5,7 +5,7 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { applyL1, loadL2Rules, addL2Rule, extractL2PrivatePhrases } from '../src/privacy-rules.js';
+import { applyL1, matchesKeyword, loadL2Rules, addL2Rule, extractL2PrivatePhrases } from '../src/privacy-rules.js';
 
 function fail(msg: string): never {
   console.error(`FAIL: ${msg}`);
@@ -62,17 +62,52 @@ const l1Cases: [string, 'private' | 'public' | 'gray'][] = [
   // have flagged sk-ant-<English> as private. After tightening
   // (digit-or-underscore required in token-like body; sk-ant-
   // requires role+digits prefix), these stay gray.
-  // Note on input choice: avoid words containing "go" (e.g. algorithm,
-  // category, golang) because the pre-existing L1 whitelist keyword
-  // `Go` (the language) substring-matches them as `public`, masking
-  // the actual `token-like` decision we want to assert. Worth a
-  // separate cleanup PR — the whitelist substring matcher is too
-  // greedy on the short keyword `Go`. Filed for triage.
+  //
+  // #129 fix (v1.0.52): pre-fix the L1 WHITELIST substring-matched
+  // short keywords like `Go`, `PM`, `TL` against any word containing
+  // those characters — `algorithm` (al**go**rithm), `amp` (a**mp**),
+  // `title` (**tl**, kind of). Mask: the test cases below ORIGINALLY
+  // had to avoid "go"-words to assert their token-like behavior
+  // cleanly (see commit history of this file for the old workaround
+  // comment). Post-#129 the cases can use "go"-words freely.
   ['See the api-documentation-string for details', 'gray'],
   ['the token-bucket-rate-limit-pattern', 'gray'],
   ['read the secret-management-best-practices', 'gray'],
   ['sk-ant-cipated-future-events-here', 'gray'],          // English -ipated suffix
   ['sk-ant-arctic-temperature-anomaly', 'gray'],          // English geography phrase
+
+  // ── #129 direct regression guards — words containing whitelisted
+  // short keywords as substrings MUST stay `gray` (not auto-public).
+  // Pre-fix all returned `public` via aggressive substring match.
+  ['the token-bucket-rate-limit-algorithm', 'gray'],      // al**go**rithm — pre-fix matched "Go"
+  ['the category of bugs', 'gray'],                       // cate**go**ry — pre-fix matched "Go"
+  ['ago we discussed this', 'gray'],                      // a**go** — pre-fix matched "Go"
+  ['the amp circuit', 'gray'],                            // a**mp** — pre-fix matched "PM"
+  ['settle the title dispute', 'gray'],                   // title / settle — pre-fix matched "TL"
+  // Behavior change worth noting: "golang" (single word) no longer
+  // matches Go (word boundary required). Pre-fix matched via substring.
+  // Operators wanting golang-as-public can add 'golang' to L1_WHITELIST_KEYWORDS.
+  ['golang code review', 'gray'],
+
+  // ── #129 positive controls — short keywords MUST still match when
+  // they appear as standalone words (the fix didn't over-block).
+  ['I use Go daily', 'public'],                           // "Go" standalone
+  ['team lead PM here', 'public'],                        // "PM" standalone
+  ['as a TL on the project', 'public'],                   // "TL" standalone
+  ['CEO discussion', 'public'],                           // "CEO"
+  ['C++ programmer', 'public'],                           // "C++" — custom non-word boundary
+  ['I write Java for living', 'public'],                  // "Java" standalone
+
+  // ── #129 prefix-collision guards — "Java" must not match inside
+  // "JavaScript". Pre-fix substring would match "Java" in
+  // "JavaScript" too (harmless since both are whitelisted, but
+  // worth pinning the contract). Post-fix: "JavaScript" matches
+  // its own keyword via \b, no Java-collision.
+  ['JavaScript is fun', 'public'],                        // matches "JavaScript" directly
+  // `\bJavaScript\b` against "JavaScripts" (plural with `s` suffix):
+  // after "JavaScript", next char is `s` (\w), so `\b` doesn't match
+  // → gray. Same trade-off as "golang" above.
+  ['only JavaScripts allowed here', 'gray'],
 ];
 
 let l1Passed = 0;
@@ -175,4 +210,46 @@ extractPassed++;
 if (extractL2PrivatePhrases('## Always public\n- x\n').length !== 0) fail('extract.6');
 extractPassed++;
 
-console.log(`privacy-rules smoke: L1 ${l1Passed}/${l1Cases.length}, L2 ${l2Passed}/5, extract ${extractPassed}/6 — PASS`);
+// ── #129 direct unit tests on `matchesKeyword` (without round-tripping
+// through applyL1). Pins each branch of the three-way kind dispatch
+// explicitly so a future refactor can't drop one of them silently.
+let mkPassed = 0;
+const mkCases: [string, string, boolean][] = [
+  // ── Branch 1: non-ASCII keyword → substring (CJK has no \b semantics)
+  ['我有家庭矛盾要解决', '家庭矛盾', true],
+  ['这只是一个家庭故事', '家庭矛盾', false],     // CJK substring: "家庭故事" ≠ "家庭矛盾"
+  ['公司有矛盾', '矛盾', true],                  // single CJK char as substring
+  ['我喜欢这首歌', '矛盾', false],
+
+  // ── Branch 2: ASCII with non-word char (e.g. C++)
+  ['I write C++ code', 'C++', true],
+  ['I write C+ code', 'C++', false],
+  ['incrementing c++var', 'C++', false],        // "c++" inside "c++var" — c++ NOT followed by [^A-Za-z0-9_]
+  ['It is C++.', 'C++', true],                  // followed by punctuation
+  ['C++ at start', 'C++', true],
+  ['ends with C++', 'C++', true],
+
+  // ── Branch 3: pure-word ASCII → standard \b...\b
+  ['I use Go daily', 'Go', true],
+  ['the algorithm overview', 'Go', false],      // al**go**rithm — substring must NOT fire
+  ['ago we discussed', 'Go', false],            // a**go** — substring must NOT fire
+  ['team lead PM', 'PM', true],
+  ['amp circuit', 'PM', false],
+  ['as a TL on the project', 'TL', true],
+  ['settle the title', 'TL', false],
+  ['I use Java daily', 'Java', true],
+  ['JavaScript is fun', 'Java', false],         // Java inside JavaScript — \b prevents match
+
+  // ── Edge cases
+  ['', 'Go', false],                            // empty text
+  ['anything', '', false],                      // empty keyword (defense-in-depth)
+];
+for (const [text, kw, expected] of mkCases) {
+  const got = matchesKeyword(text, kw);
+  if (got !== expected) {
+    fail(`matchesKeyword(${JSON.stringify(text)}, ${JSON.stringify(kw)}) expected ${expected} got ${got}`);
+  }
+  mkPassed++;
+}
+
+console.log(`privacy-rules smoke: L1 ${l1Passed}/${l1Cases.length}, L2 ${l2Passed}/5, extract ${extractPassed}/6, matchesKeyword ${mkPassed}/${mkCases.length} — PASS`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.51' },
+    { name: 'claude-lark-plugin', version: '1.0.52' },
     {
       capabilities: {
         logging: {},

--- a/src/privacy-rules.ts
+++ b/src/privacy-rules.ts
@@ -106,17 +106,53 @@ export const L1_WHITELIST_KEYWORDS: string[] = [
 
 export type TierDecision = 'private' | 'public' | 'gray';
 
+/**
+ * #129 fix: keyword-boundary match. Pre-fix `lower.includes(kw)` would
+ * substring-match short ASCII keywords like `Go` (matches `algorithm` —
+ * al**go**rithm), `PM` (matches `amp`, `imp`, `pump`), `TL` (matches
+ * `title`, `settle`), aggressively misclassifying unrelated fact lines.
+ *
+ * Three branches by keyword shape:
+ *   1. Non-ASCII (CJK etc.) → substring (pre-fix behavior). `\b` is
+ *      ASCII-defined and would never fire for Chinese — every char
+ *      position is or isn't a boundary based on neighbor's script,
+ *      producing surprising semantics.
+ *   2. ASCII with non-word chars (e.g. `C++`) → custom boundary check
+ *      using `(?:^|[^A-Za-z0-9_])` + lookahead. `\b...\b` doesn't work
+ *      here because the trailing `+` is a non-word char and `\W→\W`
+ *      doesn't trigger a boundary.
+ *   3. Pure-word ASCII (KPI, PM, TL, CEO, Go, etc.) → standard
+ *      `\b...\b` regex with `i` flag for case-insensitivity.
+ *
+ * Exported for unit-test access — the test pins the contract directly
+ * rather than going through `applyL1`'s full classification logic.
+ */
+export function matchesKeyword(text: string, kw: string): boolean {
+  if (!kw) return false; // defense-in-depth (caller filters but exported API hardened)
+  // 1. Non-ASCII → substring fallback
+  // eslint-disable-next-line no-control-regex
+  if (!/^[\x20-\x7e]+$/.test(kw)) {
+    return text.toLowerCase().includes(kw.toLowerCase());
+  }
+  const escaped = kw.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // 2. ASCII with non-word char (e.g. `C++`) → custom boundary
+  if (!/^\w+$/.test(kw)) {
+    return new RegExp(`(?:^|[^A-Za-z0-9_])${escaped}(?=$|[^A-Za-z0-9_])`, 'i').test(text);
+  }
+  // 3. Pure-word ASCII → standard \b...\b
+  return new RegExp(`\\b${escaped}\\b`, 'i').test(text);
+}
+
 /** Apply L1 only. Returns a decision or `gray` when L1 gives no signal. */
 export function applyL1(fact: string): TierDecision {
   for (const { regex } of L1_BLACKLIST_REGEX) {
     if (regex.test(fact)) return 'private';
   }
-  const lower = fact.toLowerCase();
   for (const kw of L1_BLACKLIST_KEYWORDS) {
-    if (lower.includes(kw.toLowerCase())) return 'private';
+    if (matchesKeyword(fact, kw)) return 'private';
   }
   for (const kw of L1_WHITELIST_KEYWORDS) {
-    if (lower.includes(kw.toLowerCase())) return 'public';
+    if (matchesKeyword(fact, kw)) return 'public';
   }
   return 'gray';
 }


### PR DESCRIPTION
## Summary

Closes #129. L1 privacy classifier substring-matched short ASCII keywords (Go / PM / TL / CEO) against any word containing those substrings — `algorithm` (al**go**rithm) auto-classified as public via misfired `Go` match. Real privacy exposure: any fact line containing 'algorithm', 'category', 'amp', 'title', 'ago' etc. got incorrectly auto-public-promoted by L1.

Pre-existing bug surfaced by PR #128's R1 audit; the privacy smoke even had a workaround comment ("avoid words containing 'go'...") noting it.

## Implementation

New `matchesKeyword(text, kw)` helper with three branches:
1. **Non-ASCII (CJK)** → substring (pre-fix; `\b` is ASCII-defined).
2. **ASCII with non-word chars** (`C++`) → custom `(?:^|[^A-Za-z0-9_])` boundary; `\b...\b` doesn't work for trailing `+`.
3. **Pure-word ASCII** → standard `\b...\b` with `i` flag.

Both L1_BLACKLIST and L1_WHITELIST loops now go through `matchesKeyword`. `applyL1`'s public contract unchanged.

## Behavior changes (in CHANGELOG)

- `golang` (single word) no longer auto-matches `Go`. Falls through to gray. Operators can add `'golang'` to L1_WHITELIST.
- `JavaScripts` (plural) similar.
- `Java` inside `JavaScript` no longer cross-matches (cleaner contract).

## Test plan

- [x] `npm run typecheck` clean
- [x] `bash scripts/test.sh` full gate including `privacy-rules smoke: L1 47/47, L2 5/5, extract 6/6, matchesKeyword 21/21 — PASS`
- [x] +13 L1 cases (#129 guards + positive controls + prefix-collision)
- [x] +21 direct `matchesKeyword` cases pinning all three branches + edge cases

## Operator impact

- No retroactive re-classification — facts already on disk stay where they are.
- L2/L3 still catch anything that falls through to gray.

🤖 Generated with [Claude Code](https://claude.com/claude-code)