### PR TITLE
fix(channel,tools): recent-inbound TTL gate for ack-revoke mark (v1.0.53)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.52",
+      "version": "1.0.53",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.53] - 2026-05-26
+
+### Fixed
+- **`revokeAckFor`'s `markIfMissing` path leaked into the FIFO-capped pending-revoke Set on non-inbound message ids** (#159 + #160 — paired-fix, both touching the same `markIfMissing` decision). PR #158 (v1.0.44) added the `markIfMissing` mechanic for the set-vs-revoke race (#136) but two residual leaks remained:
+
+  - **#160**: `reply` opts in to `markIfMissing=true` on the rationale that `reply_to` is the inbound user message id. That's true in the common case but not validated — Claude can legally call `reply(reply_to=<stale/non-inbound>)` (quoting an older message or a bot card). Each such call would mark a non-inbound id as pending-revoke → leaked Set entry.
+  - **#159**: `react` / `download_attachment` couldn't safely opt in because their `message_id` parameter is even less inbound-correlated (Claude reacting to a bot message, downloading a file from an older message). So they defaulted to `markIfMissing=false`, losing race protection for the rare case when react/download IS the sole response to an inbound.
+
+  Shared fix shape — new `recentInboundIds: TTLCache<messageId, true>` on `LarkChannel` (cap 500, TTL 60s, FIFO eviction via the existing `TTLCache` helper):
+  - **`LarkChannel.recordInboundId(messageId)`** — populated in `handleMessageEvent` on every accepted inbound, alongside the existing `latestMessageTracker.record(...)` call. Idempotent (TTLCache.set bumps insertion order).
+  - **`LarkChannel.isRecentInbound(messageId)`** — gate check used by `revokeAckFor` in `src/tools.ts`. Returns true only if the id was recorded within the 60s window.
+  - **`revokeAckFor`'s `markIfMissing` path now ALSO gates on `channel.isRecentInbound(messageId)`**. If the channel doesn't recognize the id, skip the mark. This is fail-closed — race protection is lost for unrecognized ids, but no leak. The TTL backstop (`channel.pruneStaleAcks`) handles any orphaned ack that the missed mark would have caught.
+
+  Trade-offs:
+  - **TTL window 60s** covers the slowest plausible reply turn (Claude generation + Feishu round-trips + retries). Shorter would race the slowest legitimate path; longer would weakly dilute the "recent" signal.
+  - **Cap 500** — same as `pendingAckRevokes`, well above any realistic per-minute inbound rate. FIFO eviction via TTLCache's built-in `maxSize`.
+  - **`react` / `download_attachment` keep `markIfMissing=false` by default**. They could safely opt in now (the gate would filter out non-inbound ids), but the LOW-frequency benefit doesn't justify the schema change. If a future deployment exhibits stuck-MeMeMe on react-only responses, flipping the default is now safe.
+
+### Added
+- New `LarkChannel.recordInboundId(messageId)` + `LarkChannel.isRecentInbound(messageId): boolean` public methods.
+- New `recentInboundIds: TTLCache<string, true>` private field (500 entries, 60s TTL).
+- `scripts/ack-reaction-batch-smoke.ts` grows from 12 → 15 cases:
+  - **Test 5b**: reply with non-inbound `reply_to` (Claude quoting a bot card) must NOT mark pending — closes #160 leak.
+  - **Test 12**: `recordInboundId` + `isRecentInbound` round-trip + empty-id rejection.
+  - **Test 13**: end-to-end through the reply tool — recorded inbound marks pending, unrecorded does not.
+- Test 5 + Test 10 (positive control) updated to `recordInboundId` before reply (verifies the new gate fires correctly on the success path).
+- Existing smoke stubs (reply-card / reply-thread / download-attachment / auto-flush) extended with `isRecentInbound` stub method.
+
+### Operator notes
+- **Default `markIfMissing=true` callers (only `reply` today)** now silently no-op the pending-revoke mark when `reply_to` is not a recent inbound. Pre-fix this would have marked anyway, sometimes leaking. Post-fix, the MeMeMe on a non-inbound reply_to falls back to the ~6 min TTL backstop — which is the SAME fallback that existed pre-#136 for the not-yet-landed ack scenario. No new failure modes, just a closed leak surface.
+- **No data-format or storage changes.** All new state is in-memory on `LarkChannel`; restart clears everything.
+- **The followup queue is now empty of deferred items.** Pre-PR: 2 deferred-by-design followups (#159 #160). Post-PR: 0. The session's net followup queue movement is 0 — discipline held.
+
+---
+
 ## [1.0.52] - 2026-05-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.52",
+      "version": "1.0.53",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/ack-reaction-batch-smoke.ts
+++ b/scripts/ack-reaction-batch-smoke.ts
@@ -163,16 +163,21 @@ function setupHandlers(opts: { failOnMethod?: string } = {}) {
 
 // ── Part C: revokeAckFor marks pending when Map empty ──
 
-// 5. Reply tool with reply_to to a message that has NO ack yet (race
-//    scenario): revokeAckFor logs and marks pending. Subsequent
+// 5. Reply tool with reply_to to a RECORDED inbound message that has
+//    NO ack yet (race scenario): revokeAckFor's markIfMissing gate
+//    (#159/#160) checks isRecentInbound — true here because we
+//    explicitly record before reply — and marks pending. Subsequent
 //    consume returns true.
 {
   const { channel } = setupHandlers();
   const reply = handlers.get('reply');
   if (!reply) fail(`5: reply handler missing`);
 
-  // Send a reply with reply_to but no pre-existing ack — should mark
-  // pending (consume returns true after) instead of silently no-op.
+  // v1.0.53 #159/#160: register the message as a recent inbound first.
+  // Pre-fix, reply would have marked unconditionally — now it gates
+  // on isRecentInbound.
+  channel.recordInboundId('om_no_ack_yet');
+
   await reply({
     chat_id: 'chat_test',
     text: 'hi',
@@ -180,7 +185,31 @@ function setupHandlers(opts: { failOnMethod?: string } = {}) {
   });
 
   if (!channel.consumePendingAckRevoke('om_no_ack_yet')) {
-    fail(`5: revokeAckFor should have marked 'om_no_ack_yet' as pending-revoke`);
+    fail(`5: revokeAckFor should have marked 'om_no_ack_yet' as pending-revoke (recent-inbound path)`);
+  }
+  passed++;
+}
+
+// 5b. #159/#160 fix: reply with reply_to to a NON-INBOUND id (e.g.
+//     Claude quoting a bot card or stale message) must NOT mark
+//     pending. The gate fails closed → no Set leak.
+{
+  const { channel } = setupHandlers();
+  const reply = handlers.get('reply');
+  if (!reply) fail(`5b: reply handler missing`);
+
+  // Do NOT recordInboundId. The id isn't a known inbound.
+  await reply({
+    chat_id: 'chat_test',
+    text: 'hi',
+    reply_to: 'om_stale_bot_msg',
+  });
+
+  if (channel.consumePendingAckRevoke('om_stale_bot_msg')) {
+    fail(`5b: non-inbound reply_to MUST NOT mark pending (closes #160 leak)`);
+  }
+  if (channel.getPendingAckRevokeSize() !== 0) {
+    fail(`5b: pendingAckRevokes should stay empty, got size ${channel.getPendingAckRevokeSize()}`);
   }
   passed++;
 }
@@ -290,12 +319,17 @@ function setupHandlers(opts: { failOnMethod?: string } = {}) {
   passed++;
 }
 
-// 10. Positive control: reply DOES mark pending (race protection
-//     correctly opted in via markIfMissing=true).
+// 10. Positive control: reply DOES mark pending when the reply_to
+//     IS a recently-recorded inbound (race protection correctly
+//     opted in via markIfMissing=true + isRecentInbound=true).
 {
   const { channel } = setupHandlers();
   const reply = handlers.get('reply');
   if (!reply) fail(`10: reply handler missing`);
+
+  // v1.0.53 #159/#160: register the inbound first so the
+  // isRecentInbound gate fires true.
+  channel.recordInboundId('om_race_target');
 
   await reply({
     chat_id: 'chat_test',
@@ -304,7 +338,7 @@ function setupHandlers(opts: { failOnMethod?: string } = {}) {
   });
 
   if (!channel.consumePendingAckRevoke('om_race_target')) {
-    fail(`10: reply with no matching ack MUST mark pending-revoke (race protection)`);
+    fail(`10: reply with recorded inbound MUST mark pending-revoke (race protection)`);
   }
   passed++;
 }
@@ -395,6 +429,52 @@ function setupHandlers(opts: { failOnMethod?: string } = {}) {
   }
   if (typeof entry!.addedAt !== 'number') {
     fail(`11b-control: addedAt must be set (powers TTL backstop)`);
+  }
+  passed++;
+}
+
+// ── Part F: #159 + #160 — recentInboundIds TTL cache + isRecentInbound ──
+
+// 12. recordInboundId + isRecentInbound contract: roundtrip true.
+{
+  const ch = new LarkChannel();
+  ch.recordInboundId('om_inbound_1');
+  if (!ch.isRecentInbound('om_inbound_1')) {
+    fail(`12: recorded id MUST be recent`);
+  }
+  if (ch.isRecentInbound('om_never_recorded')) {
+    fail(`12: unrecorded id MUST NOT be recent`);
+  }
+  // Empty id defensively rejected
+  if (ch.isRecentInbound('')) fail(`12: empty id must be rejected`);
+  passed++;
+}
+
+// 13. #159 fix end-to-end: react with markIfMissing=true (hypothetical
+//     future caller — current react still uses default false). But the
+//     gate's contract is testable directly: if a tool DID pass
+//     markIfMissing=true with a non-inbound id, the gate fails closed.
+//     Simulate by calling revokeAckFor's contract via reply with a
+//     non-inbound reply_to (test 5b above also covers this).
+//
+//     Here we directly verify the channel.isRecentInbound branch
+//     against a known non-inbound id and a known inbound id, end-to-end
+//     through the gate path.
+{
+  const { channel } = setupHandlers();
+  const reply = handlers.get('reply');
+
+  // Recorded inbound — marks pending
+  channel.recordInboundId('om_inbound_e2e');
+  await reply!({ chat_id: 'chat_test', text: 'x', reply_to: 'om_inbound_e2e' });
+  if (!channel.consumePendingAckRevoke('om_inbound_e2e')) {
+    fail(`13: recorded inbound MUST mark pending`);
+  }
+
+  // Not recorded — does NOT mark
+  await reply!({ chat_id: 'chat_test', text: 'y', reply_to: 'om_unknown' });
+  if (channel.consumePendingAckRevoke('om_unknown')) {
+    fail(`13: unrecorded id MUST NOT mark pending`);
   }
   passed++;
 }

--- a/scripts/auto-flush-smoke.ts
+++ b/scripts/auto-flush-smoke.ts
@@ -67,6 +67,8 @@ const fakeChannel = {
   isPrivateChat: () => false,
   markPendingAckRevoke: (_: string) => {},
   consumePendingAckRevoke: (_: string) => false,
+  // v1.0.53 #159/#160: stub (not exercised by auto-flush tests)
+  isRecentInbound: (_: string) => false,
 } as unknown as LarkChannel;
 
 // Minimal mock Lark client — save_memory doesn't actually use it but

--- a/scripts/download-attachment-smoke.ts
+++ b/scripts/download-attachment-smoke.ts
@@ -149,6 +149,9 @@ const fakeChannel = {
   isPrivateChat: () => true,
   markPendingAckRevoke: (_: string) => {},
   consumePendingAckRevoke: (_: string) => false,
+  // v1.0.53 #159/#160: stub (download doesn't use markIfMissing but
+  // the function reference must exist on the channel object)
+  isRecentInbound: (_: string) => false,
 } as unknown as LarkChannel;
 const handlers = new Map<string, (args: any) => Promise<any>>();
 const fakeServer = {

--- a/scripts/reply-card-smoke.ts
+++ b/scripts/reply-card-smoke.ts
@@ -150,6 +150,11 @@ async function run() {
     isPrivateChat: () => true,
     markPendingAckRevoke: (_: string) => {},
     consumePendingAckRevoke: (_: string) => false,
+    // v1.0.53 #159/#160: revokeAckFor's markIfMissing path now also
+    // calls channel.isRecentInbound. Stub true so reply tool tests
+    // that exercise the mark path keep working (they test reply's
+    // ack-revoke contract, not the inbound-id gate).
+    isRecentInbound: (_: string) => true,
   } as unknown as LarkChannel;
 
   registerTools(

--- a/scripts/reply-thread-smoke.ts
+++ b/scripts/reply-thread-smoke.ts
@@ -105,6 +105,8 @@ async function setup() {
     isPrivateChat: () => true,
     markPendingAckRevoke: (_: string) => {},
     consumePendingAckRevoke: (_: string) => false,
+    // v1.0.53 #159/#160: stub true so reply mark-pending path fires
+    isRecentInbound: (_: string) => true,
   } as unknown as LarkChannel;
 
   registerTools(

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -391,6 +391,39 @@ export class LarkChannel {
    * eviction expectation). Treat as `readonly` from external code.
    */
   static readonly PENDING_REVOKE_CAP = 500;
+
+  /**
+   * #159 + #160 fix: TTL cache of recent inbound user message_ids.
+   * Populated by `handleMessageEvent` on every accepted inbound;
+   * `revokeAckFor` in src/tools.ts checks `isRecentInbound(id)` to
+   * decide whether to call `markPendingAckRevoke` when the Map has
+   * no entry.
+   *
+   * Pre-#159/#160: reply unconditionally marked pending (its
+   * `reply_to` was assumed to be inbound — usually but not always
+   * true). React / download_attachment never marked at all because
+   * their `message_id` parameter is even less inbound-correlated.
+   *
+   * Post-fix: any tool's `revokeAckFor` call with `markIfMissing=true`
+   * additionally gates on `channel.isRecentInbound(messageId)`.
+   * If true, mark pending (race-protect the late-landing ack).
+   * If false, skip the mark — the id isn't a known inbound, so
+   * marking would leak Set entries on bot-message reacts /
+   * stale-reply quotes (the original #159 and #160 attack shapes).
+   *
+   * TTL window: 60s — covers the slowest plausible reply turn
+   * (Claude generation + Feishu round-trips + retries). Shorter
+   * would race the slowest legitimate path; longer would weakly
+   * dilute the "recent" signal.
+   *
+   * Cap: 500 — same as `pendingAckRevokes` cap, well above any
+   * realistic per-minute inbound rate. FIFO eviction via TTLCache's
+   * built-in `maxSize` enforcement.
+   */
+  private recentInboundIds = new TTLCache<string, true>({
+    maxSize: 500,
+    ttlMs: 60_000,
+  });
   private ackPruneTimer: NodeJS.Timeout | null = null;
   /** Guards `start()` against double-invocation (R1-followup on #85). */
   private started = false;
@@ -499,6 +532,30 @@ export class LarkChannel {
    */
   getPendingAckRevokeSize(): number {
     return this.pendingAckRevokes.size;
+  }
+
+  /**
+   * #159 + #160: record an inbound user message_id in the recent-inbound
+   * TTL cache. Called once from `handleMessageEvent` per accepted message.
+   * Idempotent on re-record (TTLCache.set bumps insertion order, refreshing
+   * the entry's TTL window).
+   */
+  recordInboundId(messageId: string): void {
+    if (!messageId) return;
+    this.recentInboundIds.set(messageId, true);
+  }
+
+  /**
+   * #159 + #160: gate for `revokeAckFor`'s `markIfMissing` path.
+   * Returns true iff the given message_id is in the recent-inbound
+   * TTL cache (i.e. was an accepted user message within the last
+   * 60s). Tools use this to avoid marking pending-revoke for
+   * non-inbound ids (bot messages, stale quotes, etc.) — which
+   * would leak entries into the FIFO-capped pendingAckRevokes Set.
+   */
+  isRecentInbound(messageId: string): boolean {
+    if (!messageId) return false;
+    return this.recentInboundIds.get(messageId) === true;
   }
 
   /**
@@ -725,6 +782,14 @@ export class LarkChannel {
       threadId,
       timestamp: Date.now(),
     });
+
+    // #159 + #160 fix: also record into the recent-inbound TTL cache so
+    // tools' `revokeAckFor(messageId, ..., markIfMissing=true)` can gate
+    // the pending-revoke mark on `channel.isRecentInbound(messageId)`.
+    // Without this gate, reply with a stale `reply_to` (Claude quoting
+    // an older message / bot card) or react/download with a non-inbound
+    // message_id would leak entries into pendingAckRevokes Set.
+    this.recordInboundId(messageId);
 
     // Fire-and-forget ack reaction (Typing for P2P, MeMeMe for group @bot)
     const ackEmoji = chatType === 'p2p' ? 'Typing' : appConfig.ackEmoji;

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.52' },
+    { name: 'claude-lark-plugin', version: '1.0.53' },
     {
       capabilities: {
         logging: {},

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -399,17 +399,26 @@ export function registerTools(
    * race for fast bots whose reply turn outpaces the ack-create HTTP
    * round-trip.
    *
-   * `markIfMissing` is FALSE by default and is opted into ONLY by
-   * `reply` (where `reply_to` is guaranteed to be the inbound user
-   * message id — race protection is correctly targeted). React and
-   * download_attachment leave it OFF: their `message_id` parameter
-   * can legitimately point at a BOT message (Claude reacting to its
-   * own previous card) or any other id, and marking those pending
-   * would leak entries into the FIFO-capped Set — under sustained
-   * react-to-bot workload the legit reply-side marks would get
-   * evicted before their ack-create `.then()` lands, re-opening
-   * the original #136 stuck-MeMeMe symptom. R1-followup tracked in
-   * #159 for a smarter inbound-id-aware variant.
+   * `markIfMissing` is FALSE by default. Callers opt in when they
+   * have high confidence the `messageId` IS the inbound user message
+   * id (e.g. `reply` passing `reply_to`). Even when opted in,
+   * `markIfMissing` is GATED by `channel.isRecentInbound(messageId)`
+   * (#159 + #160 fix) — only marks pending if the channel confirms
+   * the id was recently seen as an inbound user message (60s TTL).
+   *
+   * Why the gate matters:
+   *   - #160: Claude can legally pass `reply_to=<stale or non-inbound>`
+   *     (quoting an older message or a bot card). Marking that id as
+   *     pending-revoke would leak into the FIFO-capped Set.
+   *   - #159: `react` / `download_attachment` can now safely pass
+   *     `markIfMissing=true` if they want race protection — the gate
+   *     filters out bot-message reacts and arbitrary file downloads,
+   *     so the leak path the original #159 R1 audit caught is closed.
+   *
+   * The gate is "fail-closed": if the id ISN'T a known inbound,
+   * skip the mark. Race protection is lost for that path, but no
+   * leak. The TTL backstop (channel.pruneStaleAcks) handles any
+   * orphaned ack the missed mark would have caught.
    */
   function revokeAckFor(
     messageId: string,
@@ -432,14 +441,20 @@ export function registerTools(
     const entry = ackReactions.get(messageId);
     if (!entry) {
       if (markIfMissing) {
-        // #136: mark as pending so a deferred ack lands → delete, not store.
-        // Only fires when caller has high confidence that `messageId` IS
-        // the inbound user message id (currently: reply only).
-        channel.markPendingAckRevoke(messageId);
-        console.error(
-          `[${callerLabel}] revokeAckFor: no ack for message_id=${messageId} yet ` +
-          `(marked pending-revoke; ${ackReactions.size} other ack(s) left intact)`,
-        );
+        // #136 + #159 + #160: mark only when channel confirms the id
+        // was a recently-seen inbound. Otherwise skip — see docstring
+        // for the leak prevention rationale.
+        if (channel.isRecentInbound(messageId)) {
+          channel.markPendingAckRevoke(messageId);
+          console.error(
+            `[${callerLabel}] revokeAckFor: no ack for message_id=${messageId} yet ` +
+            `(confirmed recent inbound, marked pending-revoke; ${ackReactions.size} other ack(s) left intact)`,
+          );
+        } else {
+          // Not a known inbound (stale quote, bot message reply_to, etc.).
+          // Quiet — over-logging would be noise on legitimate non-inbound
+          // ids (Claude quoting older cards is a common pattern).
+        }
       } else {
         // Quiet: react/download_attachment may legitimately pass a
         // non-inbound id (Claude reacting to a bot message; download


### PR DESCRIPTION
## Summary

Closes #159, #160. Paired-fix using shared `recentInboundIds: TTLCache<messageId, true>` on `LarkChannel`. Drains the last 2 followups from the audit queue.

- **#160**: `reply(reply_to=<non-inbound>)` (Claude quoting a bot card / stale message) was marking the non-inbound id as pending-revoke → leak into the FIFO-capped Set.
- **#159**: `react` / `download_attachment` couldn't safely opt in to `markIfMissing=true` because their `message_id` is even less inbound-correlated. Defaulted to `false`, losing race protection for react/download-only responses.

## Implementation

- `LarkChannel.recordInboundId(messageId)` — populated in `handleMessageEvent` on every accepted inbound.
- `LarkChannel.isRecentInbound(messageId): boolean` — gate.
- `revokeAckFor`'s `markIfMissing` path now also gates on `channel.isRecentInbound(messageId)`. Fail-closed: if not recognized, skip the mark. Race protection lost for unrecognized ids, but no leak. TTL backstop (`channel.pruneStaleAcks`) handles any orphan.

`react` / `download_attachment` keep `markIfMissing=false` by default — LOW-freq benefit doesn't justify schema change, but the gate makes flipping safe in the future.

## Test plan

- [x] `npm run typecheck` clean
- [x] `bash scripts/test.sh` full gate — `ack-reaction batch smoke: 15/15 PASS` (+3)
- [x] New tests:
  - 5b: non-inbound `reply_to` does NOT mark pending (closes #160 leak)
  - 12: `recordInboundId` / `isRecentInbound` round-trip + empty-id reject
  - 13: e2e through reply tool — recorded inbound marks, unrecorded does not
- [x] Tests 5 + 10 (positive controls) updated to `recordInboundId` before reply

## Followup queue status

Pre-PR: 2 deferred-by-design followups (#159 #160). **Post-PR: 0.** This session's followup-queue net movement: **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)