### PR TITLE
fix(hook): scan lark tool_result for [LARK_DEFER] (v1.0.54)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.54] - 2026-05-26
+
+### Fixed
+- **Stop hook required Claude to voluntarily echo `[LARK_DEFER]` in assistant text — `tool_result` containing the sentinel was ignored** (#122). PR #120 (v1.0.21, #106 Case 2) added `handlePermanentTargetError` which returns `isError: true` with `[LARK_DEFER]` inline in the tool_result text + an instruction asking Claude to echo the sentinel in its assistant turn. The hook's defer bypass only scanned **assistant text + thinking blocks** — `tool_result` blocks were unscanned. So when Claude ignored the instruction (busy generating an action plan that called `reply` again) the loop resurfaced. Best-effort cooperation; not a mechanical guarantee.
+
+  Fix: hook now ALSO scans `tool_result` blocks for the sentinel, scoped to lark-plugin tool_uses (`reply` / `react` / `edit_message`). When the tool itself emits `[LARK_DEFER]` in its result, the hook bypasses mechanically — no Claude cooperation required.
+
+  Implementation:
+  - New `collectLarkToolUseIds(entries, fromIndex)` — pre-pass that collects tool_use_id Set for lark-plugin tools in the scan window.
+  - New `collectLarkToolResultText(entries, fromIndex, larkIds)` — extracts text from `tool_result` blocks whose `tool_use_id` matches the lark set. Handles both content shapes: `string` and `array of {type:'text',text}` blocks.
+  - `main()` checks `hasDeferSentinel(toolResultText)` after `hasDeferSentinel(assistantText)`. New audit reason: `defer-tool-result`.
+
+  **Scope rationale**: scoping to lark-plugin tools prevents an unrelated MCP plugin returning the literal `[LARK_DEFER]` string from spuriously bypassing the unanswered-message block. Test 47 explicitly pins this.
+
+  **Sentinel-line contract preserved**: the existing `^\s*[LARK_DEFER]\s*$` `m`-flag regex (and the `stripCodeContent` pre-pass) applies identically to `toolResultText`. An inline mention like `For docs see [LARK_DEFER] usage notes.` in tool_result does NOT trigger bypass. Test 48 pins this.
+
+### Added
+- New `LARK_TOOLS_WITH_DEFER` Set in `hooks/enforce-lark-reply.mjs` — lark tools that can emit defer signals (distinct from `REPLY_TOOLS` which is "tools that fulfill a reply obligation"). Includes `reply`, `react`, `edit_message`.
+- Hook tests grow from 83 → 91 (+8 for #122):
+  - **Test 45**: reply tool_result with `[LARK_DEFER]` (Claude does NOT echo) → defers (mechanical guarantee).
+  - **Test 46**: reply tool_result without sentinel → still blocks (control).
+  - **Test 47**: non-lark plugin's tool_result with `[LARK_DEFER]` → still blocks (scope check).
+  - **Test 48**: inline `[LARK_DEFER]` mention in lark tool_result (not on own line) → still blocks (sentinel-line contract preserved).
+  - **Test 49**: lark tool_result with array-of-text content shape + sentinel on own line → defers (both content shapes supported).
+  - **Test helpers**: `makeAssistantToolUseWithId(name, id, input)` + `makeUserToolResult(toolUseId, text)` for paired tool_use ↔ tool_result fixtures.
+
+### Operator notes
+- **No behavior change in the cooperation path.** If Claude already echoes the sentinel in assistant text, the hook still bypasses via the existing assistantText scan. The new tool_result scan is an ADDITIONAL bypass condition — strictly more lenient.
+- **Audit log new value**: `reason=defer-tool-result` (vs the existing `reason=defer-sentinel` for assistant-text bypass). Operators grepping audit log can distinguish the two paths.
+- **Adversarial concern addressed**: a malicious Lark user can't trigger the tool_result bypass — it only fires from lark-plugin tool_uses Claude actually made. Non-lark MCP outputs are scope-filtered out.
+
+---
+
 ## [1.0.53] - 2026-05-26
 
 ### Fixed

--- a/hooks/enforce-lark-reply.mjs
+++ b/hooks/enforce-lark-reply.mjs
@@ -382,6 +382,71 @@ function collectAssistantText(entries, fromIndex) {
   return combined;
 }
 
+// #122 fix: collect IDs of lark-plugin tool_use blocks in this turn,
+// so the matching tool_result blocks can be scoped-scanned for the
+// defer sentinel. Pre-#122 the sentinel was only honored if Claude
+// VOLUNTARILY echoed it in assistant text — best-effort, prompt-
+// fragile across LLM versions. Post-fix, when `handlePermanentTargetError`
+// returns `[LARK_DEFER]` in a `reply` / `react` / `edit_message`
+// tool_result, the hook scans that block directly and bypasses
+// mechanically.
+//
+// Scoped to lark-plugin tools so an unrelated MCP plugin returning
+// the literal "[LARK_DEFER]" string in its output can't spuriously
+// bypass the unanswered-message block. Includes `edit_message`
+// (which is NOT in REPLY_TOOLS — those are "tools that fulfill a
+// reply obligation"; here we're collecting "tools that can emit a
+// defer signal," a different concept).
+const LARK_TOOLS_WITH_DEFER = new Set([
+  'mcp__plugin_lark_lark__reply',
+  'mcp__plugin_lark_lark__react',
+  'mcp__plugin_lark_lark__edit_message',
+]);
+
+function collectLarkToolUseIds(entries, fromIndex) {
+  const ids = new Set();
+  for (let i = fromIndex; i < entries.length; i++) {
+    const entry = entries[i];
+    if (entry?.type !== 'assistant') continue;
+    const tools = extractToolUses(entry.message?.content);
+    for (const t of tools) {
+      if (LARK_TOOLS_WITH_DEFER.has(t.name) && t.id) ids.add(t.id);
+    }
+  }
+  return ids;
+}
+
+// #122: extract text from tool_result blocks whose tool_use_id was a
+// lark-plugin tool (per `collectLarkToolUseIds`). Anthropic API
+// shape: tool_result.content is either a string OR an array of
+// {type:'text',text} / string entries. Walk both shapes defensively.
+function collectLarkToolResultText(entries, fromIndex, larkIds) {
+  let combined = '';
+  for (let i = fromIndex; i < entries.length; i++) {
+    const entry = entries[i];
+    if (entry?.type !== 'user') continue;
+    const content = entry.message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block?.type !== 'tool_result') continue;
+      if (!larkIds.has(block.tool_use_id)) continue;
+      const blockContent = block.content;
+      if (typeof blockContent === 'string') {
+        combined += blockContent + '\n';
+      } else if (Array.isArray(blockContent)) {
+        for (const sub of blockContent) {
+          if (typeof sub === 'string') {
+            combined += sub + '\n';
+          } else if (sub?.type === 'text' && typeof sub.text === 'string') {
+            combined += sub.text + '\n';
+          }
+        }
+      }
+    }
+  }
+  return combined;
+}
+
 // Defer sentinel must appear on its own line (allowing leading/trailing
 // whitespace) — guards against echo attacks where a Lark user asks the
 // bot to print the literal token inline (Round 2 hardening of #11).
@@ -606,11 +671,16 @@ function main() {
     process.exit(0);
   }
 
-  let pending, replies, assistantText;
+  let pending, replies, assistantText, larkToolUseIds, toolResultText;
   try {
     pending = collectPendingLarkMessages(entries, turn.realUserIndices);
     replies = collectReplies(entries, turn.scanFromIndex);
     assistantText = collectAssistantText(entries, turn.scanFromIndex);
+    // #122 fix: also gather tool_result text from lark-plugin tools.
+    // Lets the defer signal be mechanical (the tool itself emits the
+    // sentinel) rather than depending on Claude voluntarily echoing it.
+    larkToolUseIds = collectLarkToolUseIds(entries, turn.scanFromIndex);
+    toolResultText = collectLarkToolResultText(entries, turn.scanFromIndex, larkToolUseIds);
   } catch (e) {
     audit(`Stop  status=fail-safe  reason=parse-error  err=${String(e).slice(0, 100)}`);
     process.exit(0);
@@ -631,6 +701,13 @@ function main() {
   if (hasDeferSentinel(assistantText)) {
     audit(
       `Stop  status=deferred  pending=${pending.length}  unanswered=${unanswered.length}  reason=defer-sentinel`
+    );
+    process.exit(0);
+  }
+  // #122: tool_result defer — mechanical fallback when Claude didn't echo.
+  if (hasDeferSentinel(toolResultText)) {
+    audit(
+      `Stop  status=deferred  pending=${pending.length}  unanswered=${unanswered.length}  reason=defer-tool-result`
     );
     process.exit(0);
   }

--- a/hooks/test-enforce-lark-reply.mjs
+++ b/hooks/test-enforce-lark-reply.mjs
@@ -1031,6 +1031,173 @@ console.log('\n[41] column-0 unclosed ``` + [LARK_DEFER] (legit code-block open)
   assertContains(r.stderr, 'om_col0', 'still flagged');
 }
 
+// --- #122 helpers — paired tool_use + tool_result for the mechanical defer ---
+function makeAssistantToolUseWithId(name, id, input) {
+  return {
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      content: [{ type: 'tool_use', id, name, input }],
+    },
+  };
+}
+
+function makeUserToolResult(toolUseId, text) {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: toolUseId, content: text },
+      ],
+    },
+  };
+}
+
+// --- Test 45: #122 mechanical defer via tool_result (lark tool) ---
+console.log('\n[45] reply tool_result contains [LARK_DEFER] (Claude did NOT echo) → defers (#122)');
+{
+  // PR #120's handlePermanentTargetError returns a defer payload in
+  // tool_result. Pre-#122, the Stop hook only bypassed when Claude
+  // VOLUNTARILY echoed [LARK_DEFER] in assistant text. Post-fix the
+  // tool_result itself bypasses the hook — mechanical guarantee.
+  const userContent =
+    '<channel source="plugin:lark:lark" chat_id="oc_122" message_id="om_122" user="kk" chat_type="group">\nq\n</channel>';
+  const toolUseId = 'tu_122_test';
+  const path = writeTranscript('tool-result-defer', [
+    makeUserMsg(userContent),
+    makeAssistantToolUseWithId('mcp__plugin_lark_lark__reply', toolUseId, {
+      chat_id: 'oc_122',
+      reply_to: 'om_122',
+      text: 'attempting reply',
+    }),
+    // Simulate handlePermanentTargetError's return: isError=true with
+    // [LARK_DEFER] inline. Tool result content is a string here.
+    makeUserToolResult(
+      toolUseId,
+      'Target unreachable [230002]: chat_not_found.\n\n[LARK_DEFER]\n\nDo not retry.',
+    ),
+    // Claude does NOT echo the sentinel in assistant text
+    makeAssistantText('I tried but the chat is unreachable. Moving on.'),
+  ]);
+  const r = runHook({ transcriptPath: path });
+  assertEq(r.exitCode, 0, 'tool_result defer must bypass even without assistant echo');
+}
+
+// --- Test 46: #122 tool_result without sentinel → still blocks ---
+console.log('\n[46] reply tool_result WITHOUT [LARK_DEFER] → still blocks (control)');
+{
+  const userContent =
+    '<channel source="plugin:lark:lark" chat_id="oc_122b" message_id="om_122b" user="kk" chat_type="group">\nq\n</channel>';
+  const toolUseId = 'tu_122b';
+  const path = writeTranscript('tool-result-no-defer', [
+    makeUserMsg(userContent),
+    makeAssistantToolUseWithId('mcp__plugin_lark_lark__reply', toolUseId, {
+      chat_id: 'oc_122b',
+      reply_to: 'om_other',  // wrong reply_to — doesn't satisfy
+      text: 'reply',
+    }),
+    makeUserToolResult(toolUseId, 'Sent 1 message(s)'),
+    makeAssistantText('Done.'),
+  ]);
+  const r = runHook({ transcriptPath: path });
+  assertEq(r.exitCode, 2, 'no defer + wrong reply_to → blocks');
+  assertContains(r.stderr, 'om_122b', 'still flagged');
+}
+
+// --- Test 47: #122 non-lark tool_result with [LARK_DEFER] → still blocks ---
+console.log('\n[47] OTHER plugin tool_result with [LARK_DEFER] → still blocks (scope check)');
+{
+  // An unrelated MCP plugin returning the literal "[LARK_DEFER]" string
+  // in its output must NOT spuriously bypass the hook. The scope check
+  // gates on tool_use_id matching a lark-plugin tool.
+  const userContent =
+    '<channel source="plugin:lark:lark" chat_id="oc_122c" message_id="om_122c" user="kk" chat_type="group">\nq\n</channel>';
+  const path = writeTranscript('non-lark-tool-result-defer', [
+    makeUserMsg(userContent),
+    makeAssistantToolUseWithId('mcp__plugin_other_other__some_tool', 'tu_other', { x: 1 }),
+    makeUserToolResult('tu_other', 'unrelated output that mentions [LARK_DEFER] in text'),
+    makeAssistantText('Done.'),
+  ]);
+  const r = runHook({ transcriptPath: path });
+  assertEq(r.exitCode, 2, 'unrelated plugin\'s [LARK_DEFER] string must NOT bypass');
+  assertContains(r.stderr, 'om_122c', 'still flagged');
+}
+
+// --- Test 48: #122 inline sentinel in tool_result (not on own line) → still blocks ---
+console.log('\n[48] reply tool_result with INLINE [LARK_DEFER] mention (not on own line) → still blocks');
+{
+  // Even when the lark tool_result is scoped-scanned, the sentinel
+  // regex still requires the literal token to be on its OWN LINE.
+  // An inline mention (e.g. tool returning "see [LARK_DEFER] doc")
+  // must NOT trigger a bypass — preserves the v1.0.31 #82 contract.
+  // Pair with a non-matching reply_to so the inbound is unanswered.
+  const userContent =
+    '<channel source="plugin:lark:lark" chat_id="oc_122d" message_id="om_122d" user="kk" chat_type="group">\nq\n</channel>';
+  const toolUseId = 'tu_122d';
+  const path = writeTranscript('tool-result-inline-sentinel', [
+    makeUserMsg(userContent),
+    makeAssistantToolUseWithId('mcp__plugin_lark_lark__reply', toolUseId, {
+      chat_id: 'oc_122d',
+      reply_to: 'om_other',  // doesn't satisfy om_122d
+      text: 'attempting',
+    }),
+    {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: toolUseId,
+            content: [
+              { type: 'text', text: 'For docs see [LARK_DEFER] usage notes.' },
+            ],
+          },
+        ],
+      },
+    },
+    makeAssistantText('Done.'),
+  ]);
+  const r = runHook({ transcriptPath: path });
+  assertEq(r.exitCode, 2, 'inline [LARK_DEFER] mention does NOT bypass');
+  assertContains(r.stderr, 'om_122d', 'still flagged');
+}
+
+// --- Test 49: #122 tool_result with sentinel on its own line in array content ---
+console.log('\n[49] reply tool_result array-content with [LARK_DEFER] on own line → defers');
+{
+  const userContent =
+    '<channel source="plugin:lark:lark" chat_id="oc_122e" message_id="om_122e" user="kk" chat_type="group">\nq\n</channel>';
+  const toolUseId = 'tu_122e';
+  const path = writeTranscript('tool-result-array-defer-real', [
+    makeUserMsg(userContent),
+    makeAssistantToolUseWithId('mcp__plugin_lark_lark__reply', toolUseId, {
+      chat_id: 'oc_122e',
+      reply_to: 'om_122e',
+      text: 'attempting',
+    }),
+    {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: toolUseId,
+            content: [
+              { type: 'text', text: 'Target unreachable [230002].\n\n[LARK_DEFER]\n\nDo not retry.' },
+            ],
+          },
+        ],
+      },
+    },
+    makeAssistantText('Done.'),
+  ]);
+  const r = runHook({ transcriptPath: path });
+  assertEq(r.exitCode, 0, 'array-content sentinel on own line bypasses');
+}
+
 // --- Test 42: #139 unmatched-backtick + sentinel → must NOT defer ---
 console.log('\n[42] unmatched ` followed by [LARK_DEFER] on next line → must NOT defer (#139)');
 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.53' },
+    { name: 'claude-lark-plugin', version: '1.0.54' },
     {
       capabilities: {
         logging: {},


### PR DESCRIPTION
## Summary

Closes #122. PR #120's `handlePermanentTargetError` returns `[LARK_DEFER]` in `tool_result` text + instructs Claude to echo it in assistant text. Pre-fix, the Stop hook only scanned assistant text/thinking → required Claude cooperation. When Claude ignored the instruction (busy planning next action), the loop resurfaced.

Fix: hook now ALSO scans `tool_result` blocks for the sentinel, scoped to lark-plugin tool_uses (`reply` / `react` / `edit_message`). Mechanical guarantee — no Claude cooperation required.

## Implementation

- `collectLarkToolUseIds(entries, fromIndex)` — pre-pass collecting tool_use_id Set for lark tools.
- `collectLarkToolResultText(entries, fromIndex, larkIds)` — extracts text from matching tool_result blocks. Handles both content shapes: `string` AND `array of {type:'text',text}`.
- `main()` adds `hasDeferSentinel(toolResultText)` check after the assistant-text check. New audit reason: `defer-tool-result`.

**Scope rationale**: scoping prevents unrelated MCP plugins returning literal `[LARK_DEFER]` from spuriously bypassing.

**Sentinel-line contract preserved**: the `^\s*[LARK_DEFER]\s*$` `m`-flag regex still requires the token on its own line.

## Test plan

- [x] `npm run typecheck` clean
- [x] `bash scripts/test.sh` full gate — hook tests 91/91 PASS (+8)
- [x] Test 45: lark tool_result with sentinel → defers (mechanical)
- [x] Test 46: lark tool_result without sentinel → blocks (control)
- [x] Test 47: non-lark plugin's `[LARK_DEFER]` → blocks (scope check)
- [x] Test 48: inline sentinel in lark tool_result → blocks (line contract)
- [x] Test 49: array-of-text content shape + sentinel → defers (shape coverage)

## Operator impact

No behavior change in the cooperation path. The tool_result scan is an ADDITIONAL bypass — strictly more lenient. New audit reason `reason=defer-tool-result` distinguishes from the existing `reason=defer-sentinel` for assistant-text bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)