### PR TITLE
fix(tools): sanitize <at> inside Schema 2.0 card markdown elements (v1.0.55)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.54",
+      "version": "1.0.55",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.54",
+  "version": "1.0.55",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   - **Heuristic card path**: `buildCards(sanitizeOutboundText(text), { footer })` — sanitize at the boundary into `buildCards` so all generated markdown elements are clean.
   - **`sanitizeOutboundText` docstring corrected**: the pre-fix "card paths are NOT sanitized — Feishu's Schema 2.0 card renderer does NOT interpret `<at>`" claim was wrong. Updated to reflect both paths are now sanitized via the appropriate boundary.
 
+### R1-audit followup (closed in this PR)
+- **`footer` parameter was an identical-shape vector that bypassed the initial fix.** R1 caught that `buildCards(text, { footer })` embeds `footer` in its OWN `tag: 'markdown'` Schema 2.0 element (`src/feishu-card.ts:52-58`) — same renderer that processes the body text. Pre-followup the initial fix only sanitized `text`; an adversarial Claude could smuggle `<at user_id="all">` via `footer` and bypass it entirely. Patched in-PR per discipline rule #4 (R1 trivial defect → in-PR fix): added `const safeFooter = footer ? sanitizeOutboundText(footer) : footer;` before `buildCards`. New test 18 in `reply-card-smoke.ts` exercises the footer-injection vector end-to-end.
+
 ### Added
 - New `sanitizeCardJson(obj): unknown` exported helper in `src/tools.ts`. Pure, in-place walker. Exported for direct unit testing.
 - `scripts/at-tag-sanitization-smoke.ts` grows from 18 → 26 cases:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.55] - 2026-05-26
+
+### Fixed
+- **`<at>` tag injection survived through the reply tool's card paths** (#105, R2 residual from #96 / v1.0.16). The pre-fix docstring on `sanitizeOutboundText` claimed cards were safe because Schema 2.0's plain elements (`div` / `text` / `plain_text`) don't render `<at>`. That was HALF-TRUE — Schema 2.0 `markdown` and `lark_md` element blocks go through Feishu's card-markdown renderer which DOES interpret `<at>`. Two exposed paths:
+
+  1. **Raw-card path** (`reply` tool with `card` param): Claude submits arbitrary Schema 2.0 JSON. An adversarial Claude (prompt-injected) could craft a payload with `{tag:'markdown', content:'<at user_id="all">all</at>'}` → Feishu renders an @-all in the card. Untrivial-but-real injection target.
+
+  2. **Heuristic card path** (`reply` tool with text auto-detected as card via length or markdown features): `buildCards(text, ...)` wraps `text` in `tag: 'markdown'` Schema 2.0 elements. Pre-fix, `text` was passed in UN-sanitized — any `<at>` in the user-supplied text ended up inside the markdown element and rendered as a real mention. Same vector, lower bar (no JSON construction needed).
+
+  Fix:
+  - **New `sanitizeCardJson(obj)`** walks a parsed Feishu card tree in place, applying `sanitizeOutboundText` to `content` of any `{tag: 'markdown' | 'lark_md', content}` element. Other element types (`plain_text`, `div`, `column_set`, `hr`, etc.) are recursed into but their content fields are left alone — Feishu doesn't render `<at>` in those tags. Deeply recursive, tolerates unknown shapes (operator-built / future-format cards).
+  - **Raw-card path** in `reply`: `JSON.parse → sanitizeCardJson → JSON.stringify` before send.
+  - **Heuristic card path**: `buildCards(sanitizeOutboundText(text), { footer })` — sanitize at the boundary into `buildCards` so all generated markdown elements are clean.
+  - **`sanitizeOutboundText` docstring corrected**: the pre-fix "card paths are NOT sanitized — Feishu's Schema 2.0 card renderer does NOT interpret `<at>`" claim was wrong. Updated to reflect both paths are now sanitized via the appropriate boundary.
+
+### Added
+- New `sanitizeCardJson(obj): unknown` exported helper in `src/tools.ts`. Pure, in-place walker. Exported for direct unit testing.
+- `scripts/at-tag-sanitization-smoke.ts` grows from 18 → 26 cases:
+  - **19**: markdown element content sanitized
+  - **20**: lark_md (legacy alias) sanitized identically
+  - **21**: plain_text element NOT touched (Feishu doesn't render `<at>` there)
+  - **22**: nested `column_set` recurses correctly — only markdown columns sanitized
+  - **23**: defensive on unknown structure (no throw)
+  - **24**: null / undefined / non-object inputs degrade gracefully + array-top-level
+  - **25**: self-closing `<at/>` inside markdown
+  - **26**: multi-element body — only markdown sanitized, plain_text and other tags untouched
+- `scripts/reply-card-smoke.ts` grows from 15 → 17 cases:
+  - **16**: end-to-end raw-card path with adversarial `<at user_id="all">` inside markdown → sanitized; plain_text content untouched
+  - **17**: heuristic card path (forced via `format='card'`) with `<at>` in text → no `<at user_id` survives anywhere in the sent JSON
+
+### Operator notes
+- **No behavior change for legitimate text content.** Cards with markdown bodies that don't contain `<at>` tags pass through unchanged. The sanitizer only strips Feishu @-mention syntax.
+- **`plain_text` element content is intentionally NOT sanitized.** Feishu renders `<at>` as literal angle brackets in plain_text. Some legitimate use cases display angle-bracketed text in plain_text headers; preserving that is correct.
+- **Operator-built cards (e.g. from `scripts/lark-cli`) also get sanitized.** If you have an operator-trusted card that legitimately needs `<at>` rendering as a mention, you'll need to construct the mention via Feishu's structured mention API instead of inline `<at>` tags — same as the existing text-path constraint.
+
+---
+
 ## [1.0.54] - 2026-05-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.54",
+  "version": "1.0.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.54",
+      "version": "1.0.55",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.54",
+  "version": "1.0.55",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/at-tag-sanitization-smoke.ts
+++ b/scripts/at-tag-sanitization-smoke.ts
@@ -15,7 +15,7 @@
  * `<atom>` etc. mistakenly matched).
  */
 
-import { sanitizeOutboundText } from '../src/tools.js';
+import { sanitizeOutboundText, sanitizeCardJson } from '../src/tools.js';
 
 function fail(msg: string): never {
   console.error(`FAIL: ${msg}`);
@@ -250,6 +250,142 @@ let testNum = 0;
   if (elapsed > 500) fail(`sanitizeOutboundText took ${elapsed}ms on 1000 unclosed tags (DoS risk)`);
   // With no closers nothing matches paired/self-closing; output unchanged.
   if (out !== torture) fail(`unexpected modification of 1000-unclosed input`);
+}
+
+// ── #105 — sanitizeCardJson: walk Schema 2.0 card tree + strip <at> ──
+
+// 19. Markdown element with <at> → content stripped
+{
+  testNum++;
+  const card: any = {
+    schema: '2.0',
+    body: {
+      elements: [
+        { tag: 'markdown', content: 'hello <at user_id="all">all</at> please' },
+      ],
+    },
+  };
+  sanitizeCardJson(card);
+  if (card.body.elements[0].content !== 'hello all please') {
+    fail(`19: markdown content not sanitized, got: ${JSON.stringify(card.body.elements[0].content)}`);
+  }
+}
+
+// 20. lark_md (legacy alias) treated identically
+{
+  testNum++;
+  const card: any = {
+    body: { elements: [{ tag: 'lark_md', content: '<at user_id="ou_x">K</at>' }] },
+  };
+  sanitizeCardJson(card);
+  if (card.body.elements[0].content !== 'K') {
+    fail(`20: lark_md content not sanitized, got: ${JSON.stringify(card.body.elements[0].content)}`);
+  }
+}
+
+// 21. plain_text element NOT touched (Feishu doesn't render <at> there)
+{
+  testNum++;
+  const card: any = {
+    body: { elements: [{ tag: 'plain_text', content: 'header with <at user_id="all">literal</at>' }] },
+  };
+  sanitizeCardJson(card);
+  // plain_text content stays untouched — Feishu renders the literal angle brackets
+  if (card.body.elements[0].content !== 'header with <at user_id="all">literal</at>') {
+    fail(`21: plain_text content must NOT be sanitized, got: ${JSON.stringify(card.body.elements[0].content)}`);
+  }
+}
+
+// 22. Nested column_set with markdown inside columns
+{
+  testNum++;
+  const card: any = {
+    body: {
+      elements: [
+        {
+          tag: 'column_set',
+          columns: [
+            { elements: [{ tag: 'markdown', content: 'left <at user_id="all">L</at>' }] },
+            { elements: [{ tag: 'plain_text', content: 'right <at>X</at>' }] },
+          ],
+        },
+      ],
+    },
+  };
+  sanitizeCardJson(card);
+  const leftMd = card.body.elements[0].columns[0].elements[0];
+  const rightPt = card.body.elements[0].columns[1].elements[0];
+  if (leftMd.content !== 'left L') {
+    fail(`22: nested markdown not sanitized, got: ${JSON.stringify(leftMd.content)}`);
+  }
+  if (rightPt.content !== 'right <at>X</at>') {
+    fail(`22: nested plain_text incorrectly modified, got: ${JSON.stringify(rightPt.content)}`);
+  }
+}
+
+// 23. Defensive: tolerates unknown structure without throwing
+{
+  testNum++;
+  const weird: any = {
+    schema: 'future-shape',
+    unknown_field: { tag: 'unknown', content: '<at user_id="all">X</at>' },
+    body: { elements: 'not-an-array-but-string' },
+    other: null,
+  };
+  sanitizeCardJson(weird);
+  // unknown_field has tag='unknown', not markdown/lark_md → content unchanged
+  if (weird.unknown_field.content !== '<at user_id="all">X</at>') {
+    fail(`23: unknown tag should not be sanitized`);
+  }
+  // No throw, weird shape tolerated
+}
+
+// 24. Empty / null / non-object inputs degrade gracefully
+{
+  testNum++;
+  if (sanitizeCardJson(null) !== null) fail(`24: null input`);
+  if (sanitizeCardJson(undefined) !== undefined) fail(`24: undefined input`);
+  if (sanitizeCardJson('string') !== 'string') fail(`24: string input`);
+  if (sanitizeCardJson(42) !== 42) fail(`24: number input`);
+  // Array of elements at top level
+  const arr: any[] = [{ tag: 'markdown', content: '<at user_id="all">x</at>' }];
+  sanitizeCardJson(arr);
+  if (arr[0].content !== 'x') fail(`24: array top-level not handled`);
+}
+
+// 25. Self-closing <at/> inside markdown content
+{
+  testNum++;
+  const card: any = {
+    body: { elements: [{ tag: 'markdown', content: 'ping <at user_id="ou_x"/> later' }] },
+  };
+  sanitizeCardJson(card);
+  if (card.body.elements[0].content !== 'ping  later') {
+    fail(`25: self-closing inside markdown not sanitized, got: ${JSON.stringify(card.body.elements[0].content)}`);
+  }
+}
+
+// 26. Multi-element body: only markdown elements sanitized
+{
+  testNum++;
+  const card: any = {
+    body: {
+      elements: [
+        { tag: 'div', text: { tag: 'plain_text', content: 'header text with <at>X</at>' } },
+        { tag: 'markdown', content: 'body with <at user_id="all">all</at>' },
+        { tag: 'hr' },
+      ],
+    },
+  };
+  sanitizeCardJson(card);
+  // plain_text under div.text: stays
+  if (card.body.elements[0].text.content !== 'header text with <at>X</at>') {
+    fail(`26: div.text.plain_text incorrectly sanitized`);
+  }
+  // markdown: sanitized
+  if (card.body.elements[1].content !== 'body with all') {
+    fail(`26: markdown not sanitized, got: ${JSON.stringify(card.body.elements[1].content)}`);
+  }
 }
 
 console.log(`at-tag sanitization smoke: ${testNum}/${testNum} PASS`);

--- a/scripts/reply-card-smoke.ts
+++ b/scripts/reply-card-smoke.ts
@@ -747,6 +747,31 @@ async function run() {
     }
   }
 
+  // ── Test 18: #105 R1-followup — footer path also sanitized ──
+  // buildCards embeds `footer` in its OWN tag:'markdown' element. Pre-
+  // followup, only the body `text` was sanitized — `footer` was an
+  // identical-shape vector that bypassed the fix entirely. R1 caught
+  // this; in-PR fix sanitizes `footer` before passing into buildCards.
+  {
+    apiCalls.length = 0;
+    await replyHandler({
+      chat_id: 'chat_footer_at',
+      text: 'safe body text',
+      footer: 'note: <at user_id="all">all</at> please review',
+      format: 'card',  // force card path
+    });
+    const sent = apiCalls.find((c) => c.method === 'message.create');
+    if (!sent) fail('Test 18: message.create not called');
+    const allContent = JSON.stringify(JSON.parse(sent!.args.data.content));
+    if (allContent.includes('<at user_id')) {
+      fail(`Test 18: footer <at> not sanitized; full JSON: ${allContent.slice(0, 200)}`);
+    }
+    // Legit footer label "all" preserved
+    if (!allContent.includes('note: all please review')) {
+      fail(`Test 18: footer legit content lost during sanitization`);
+    }
+  }
+
   console.log('PASS');
 }
 

--- a/scripts/reply-card-smoke.ts
+++ b/scripts/reply-card-smoke.ts
@@ -684,6 +684,69 @@ async function run() {
     if (seenIds.size !== 5) fail(`Test 15: duplicate or missing delete targets: ${[...seenIds].join(',')}`);
   }
 
+  // ── Test 16: #105 — raw-card path sanitizes <at> inside markdown elements ──
+  // The card param is a raw Schema 2.0 JSON string. Pre-fix, an adversarial
+  // Claude could embed `<at user_id="all">all</at>` inside a `markdown`
+  // element and it would render as a real @-all on Feishu.
+  {
+    apiCalls.length = 0;
+    const attackCard = JSON.stringify({
+      schema: '2.0',
+      body: {
+        elements: [
+          { tag: 'markdown', content: 'hello <at user_id="all">all</at> please' },
+          { tag: 'plain_text', content: 'footer <at>X</at>' },  // untouched
+        ],
+      },
+    });
+    await replyHandler({
+      chat_id: 'chat_card_at',
+      text: '',
+      card: attackCard,
+    });
+    const sent = apiCalls.find((c) => c.method === 'message.create');
+    if (!sent) fail('Test 16: message.create not called');
+    const parsedSent = JSON.parse(sent!.args.data.content);
+    const mdEl = parsedSent.body.elements[0];
+    const ptEl = parsedSent.body.elements[1];
+    // markdown content sanitized
+    if (mdEl.content !== 'hello all please') {
+      fail(`Test 16: markdown content not sanitized, got: ${JSON.stringify(mdEl.content)}`);
+    }
+    // plain_text content NOT touched
+    if (ptEl.content !== 'footer <at>X</at>') {
+      fail(`Test 16: plain_text content incorrectly modified, got: ${JSON.stringify(ptEl.content)}`);
+    }
+  }
+
+  // ── Test 17: #105 — heuristic card path (text → buildCards) sanitizes ──
+  // buildCards wraps content in `tag: 'markdown'` elements which DO render
+  // <at>. Pre-fix the text path also auto-detected card mode for long /
+  // markdown-rich content, exposing the same vector.
+  {
+    apiCalls.length = 0;
+    // Use long text to trigger card heuristic (>500 chars or markdown-rich)
+    const attackText = '# Heading\n\nhello <at user_id="all">all</at> please review the report.\n\n' +
+      'Long body to trigger card auto-detection. '.repeat(20);
+    await replyHandler({
+      chat_id: 'chat_heuristic_card',
+      text: attackText,
+      format: 'card',  // force card path to avoid auto-detect dependency
+    });
+    const sent = apiCalls.find((c) => c.method === 'message.create');
+    if (!sent) fail('Test 17: message.create not called');
+    const parsedSent = JSON.parse(sent!.args.data.content);
+    // Walk all elements for any markdown content; verify NO <at user_id> survives
+    const allContent = JSON.stringify(parsedSent);
+    if (allContent.includes('<at user_id')) {
+      fail(`Test 17: heuristic card path did not sanitize <at>; full JSON: ${allContent.slice(0, 200)}`);
+    }
+    // The legit text "hello all please" should still be present (sanitizer preserves the label)
+    if (!allContent.includes('hello all please')) {
+      fail(`Test 17: legitimate label content lost during sanitization`);
+    }
+  }
+
   console.log('PASS');
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.54' },
+    { name: 'claude-lark-plugin', version: '1.0.55' },
     {
       capabilities: {
         logging: {},

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -44,8 +44,18 @@ import { writeSdkResource, WriteSdkResourceTooLargeError } from './sdk-resource.
  * This is the canonical sanitizer applied to ALL outbound bot text on
  * Feishu's `msg_type=text` path: tool `reply`, tool `edit_message` (text
  * variant), scheduler stale-skip notice, scheduler message-job execution.
- * Card paths are NOT sanitized — Feishu's Schema 2.0 card renderer does
- * NOT interpret `<at>` as a mention, so the vector doesn't exist there.
+ *
+ * Card paths: pre-#105, this docstring claimed cards were safe because
+ * Schema 2.0 plain-element cards (`div` / `text` / `plain_text`) don't
+ * render `<at>`. That claim was HALF-TRUE — Schema 2.0 `markdown` /
+ * `lark_md` element blocks DO interpret `<at>` as a Feishu mention.
+ * `buildCards` produces such elements (every chunked rendering uses
+ * `tag: 'markdown'`), and the raw-card path lets Claude submit
+ * arbitrary card JSON which might include them. Post-#105:
+ *   - `buildCards` callers sanitize `text` before passing in.
+ *   - The raw-card path runs `sanitizeCardJson` (below) which walks
+ *     the parsed tree and sanitizes any `markdown` / `lark_md`
+ *     element's `content`.
  *
  * Exported for unit testing.
  */
@@ -84,6 +94,53 @@ export function sanitizeOutboundText(text: string): string {
   // self-closing+paired input, or a malformed half-tag) is purely
   // cosmetic noise — keep the output clean.
   return out.replace(/<\/at>/gi, '');
+}
+
+/**
+ * #105 fix: walk a parsed Feishu Schema 2.0 card object and sanitize
+ * `<at>` tags out of every `markdown` / `lark_md` element's `content`
+ * field. Other element types (`plain_text`, `div`, `column_set`, etc.)
+ * render `<at>` as literal text per Feishu's docs and don't need the
+ * scrub — but `markdown` / `lark_md` go through the card-markdown
+ * renderer which DOES interpret `<at>` as a mention.
+ *
+ * The walker is deeply recursive and resilient: it tolerates unknown
+ * structure (operator-built / future-format cards), only mutating
+ * fields it recognizes. Mutates in place AND returns the same object
+ * (caller convenience).
+ *
+ * Recognized element shapes (Feishu Schema 2.0):
+ *   - `{ tag: 'markdown', content: '...' }`  — main content block
+ *   - `{ tag: 'lark_md', content: '...' }`   — legacy alias
+ *   - `{ tag: 'note', elements: [...] }`     — wraps inner elements
+ *   - `{ tag: 'column_set', columns: [...] }` → recurses into each column's elements
+ *   - any object with `body: { elements: [...] }` (top-level card)
+ *   - any object with `elements: [...]` (column, note, etc.)
+ *
+ * Exported for unit testing.
+ */
+export function sanitizeCardJson(obj: unknown): unknown {
+  if (obj === null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) {
+    for (const item of obj) sanitizeCardJson(item);
+    return obj;
+  }
+  const o = obj as Record<string, unknown>;
+  // Markdown-rendering tags: sanitize their content string.
+  if ((o.tag === 'markdown' || o.tag === 'lark_md') && typeof o.content === 'string') {
+    o.content = sanitizeOutboundText(o.content);
+  }
+  // Recurse into common container fields. Walking by key name is
+  // resilient to unknown structures — Feishu can add new container
+  // shapes and we'll still drill into anything that looks like a
+  // child collection.
+  for (const key of Object.keys(o)) {
+    const v = o[key];
+    if (v !== null && typeof v === 'object') {
+      sanitizeCardJson(v);
+    }
+  }
+  return obj;
 }
 
 /**
@@ -660,6 +717,13 @@ export function registerTools(
             isError: true,
           };
         }
+        // #105 fix: sanitize <at> inside any markdown/lark_md content
+        // elements. Schema 2.0 plain elements (div / text / plain_text)
+        // don't render <at>, but markdown/lark_md elements DO — and an
+        // adversarial Claude can construct valid Schema 2.0 JSON with
+        // a markdown element containing <at user_id="all">. Walks the
+        // parsed tree in place and applies the existing sanitizer.
+        sanitizeCardJson(cardObj);
         const content = JSON.stringify(cardObj);
         try {
           // #112: retry-wrapped — rate-limit / 5xx auto-retry, permanent
@@ -710,7 +774,12 @@ export function registerTools(
       let sentCount = 0;
 
       if (useCard) {
-        const cards = buildCards(text, { footer });
+        // #105 fix: sanitize text BEFORE buildCards. buildCards wraps
+        // content in `tag: 'markdown'` Schema 2.0 elements, which DO
+        // render <at> as a Feishu mention. Pre-fix the heuristic card
+        // path (text auto-detected as markdown-rich or long) had the
+        // same exposure as the raw-card path.
+        const cards = buildCards(sanitizeOutboundText(text), { footer });
         sentCount = cards.length;
         for (let i = 0; i < cards.length; i++) {
           const content = JSON.stringify(cards[i]);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -779,7 +779,15 @@ export function registerTools(
         // render <at> as a Feishu mention. Pre-fix the heuristic card
         // path (text auto-detected as markdown-rich or long) had the
         // same exposure as the raw-card path.
-        const cards = buildCards(sanitizeOutboundText(text), { footer });
+        //
+        // R1-followup: also sanitize `footer`. buildCards embeds the
+        // footer in its own `{tag:'markdown'}` element (see
+        // feishu-card.ts L52-58) — same identical-shape vector as
+        // the body text. Pre-followup an adversarial Claude could
+        // smuggle `<at user_id="all">` via `footer` and bypass the
+        // body-text sanitizer entirely.
+        const safeFooter = footer ? sanitizeOutboundText(footer) : footer;
+        const cards = buildCards(sanitizeOutboundText(text), { footer: safeFooter });
         sentCount = cards.length;
         for (let i = 0; i < cards.length; i++) {
           const content = JSON.stringify(cards[i]);


### PR DESCRIPTION
## Summary

Closes #105. R2 residual from #96 / v1.0.16.

Pre-fix docstring on `sanitizeOutboundText` claimed cards were safe because Schema 2.0 plain elements don't render `<at>`. HALF-TRUE — Schema 2.0 `markdown` and `lark_md` elements DO. Two exposed paths:

1. **Raw-card path** (`reply` with `card` param): adversarial Claude submits Schema 2.0 JSON with `{tag:'markdown', content:'<at user_id="all">all</at>'}` → Feishu renders @-all in the card.
2. **Heuristic card path** (text auto-detected as card via length / markdown features): `buildCards` wraps `text` in `tag:'markdown'` elements; pre-fix `text` was passed un-sanitized.

## Implementation

- New `sanitizeCardJson(obj)` walks a parsed Feishu card tree in place, applies `sanitizeOutboundText` to `content` of any `{tag:'markdown'|'lark_md',content}` element. Other tags are recursed into but untouched.
- Raw-card path: `JSON.parse → sanitizeCardJson → JSON.stringify`.
- Heuristic path: `buildCards(sanitizeOutboundText(text), ...)`.
- Corrected the misleading `sanitizeOutboundText` docstring.

## Test plan

- [x] `npm run typecheck` clean
- [x] `bash scripts/test.sh` — full gate
- [x] `at-tag-sanitization-smoke.ts`: 18 → 26 (+8 direct `sanitizeCardJson` cases incl. nested column_set, defensive shapes, multi-element)
- [x] `reply-card-smoke.ts`: 15 → 17 (+2 end-to-end via reply tool — raw + heuristic paths)

## Operator impact

No behavior change for legitimate text content. `plain_text` element content is intentionally NOT sanitized (Feishu doesn't render `<at>` there). Operator-built cards that legitimately need `<at>` mentions must use Feishu's structured mention API instead of inline tags — same constraint as the existing text-path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)