### PR TITLE
chore(distiller): audit-log Stage 2 dispatches (v1.0.58, closes #176)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "lark",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "source": "./",
       "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lark",
   "description": "Feishu/Lark channel plugin for Claude Code — receive messages via WebSocket, reply with text/images/files, manage cross-session memory",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "author": {
     "name": "IS908"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.58] - 2026-05-26
+
+### Added
+- **Stage 2 dispatch audit-log trail** (#176, closes R2 followup of #113/#175). Pre-fix `triggerProfileDistillation` only logged to stderr (`[distill-stage2] dispatching profile distillation for user X`). For an operator who enables `LARK_PROFILE_DISTILL_ENABLED=true` against a 50-user/10-chat deployment (~50 extra Claude turns daily at default 24h cooldown), counting actual dispatches required grepping stderr/debug.log — every other sensitive-tool boundary in the plugin already writes to `~/.claude/channels/lark/audit.log`. Post-fix: each outcome path (`dispatched`, `cooldown`, `no-episodes`, `error`) writes one line via the existing `audit()` boundary. The `tool` field is `profile-distill-dispatch` (single grep target) and `args.reason` distinguishes real dispatches from skips. Cost: 4 calls per Stage 2 pass at worst, each best-effort and non-blocking — identical pattern to `src/tools.ts` boundary writes.
+
+### Implementation
+- `src/memory/distiller.ts`: import `audit` from `../audit-log.js`; extend `ProfileDistillDeps` with optional `audit?: typeof defaultAudit` for unit-test injection (defaults to the global writer). Add 4 audit call sites — one per outcome — inside `triggerProfileDistillation`. All use `void audit(...)` (best-effort fire-and-forget) so a logging hiccup never affects dispatch behavior.
+- `scripts/profile-distill-stage2-smoke.ts`: add Part D (4 tests, 10→14 total) — assert audit fires on dispatch (outcome='ok', reason='dispatched', includes chat_id+episode_count+distill_key), cooldown skip (reason='cooldown', includes remain_hours), no-episodes skip (reason='no-episodes', includes episode_count+min_required), and per-user error (outcome='error', reason='error', includes truncated error_message).
+
 ## [1.0.57] - 2026-05-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-lark-plugin",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "license": "Apache-2.0",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-lark-plugin",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "Claude Code channel plugin for Feishu/Lark — chat with Claude through Feishu with local-file memory and scheduled jobs",
   "type": "module",
   "main": "src/index.ts",

--- a/scripts/profile-distill-stage2-smoke.ts
+++ b/scripts/profile-distill-stage2-smoke.ts
@@ -20,6 +20,7 @@
 
 import { triggerProfileDistillation } from '../src/memory/distiller.js';
 import type { ProfileDistillDeps } from '../src/memory/distiller.js';
+import type { AuditOutcome } from '../src/audit-log.js';
 
 function fail(msg: string): never {
   console.error(`FAIL: ${msg}`);
@@ -30,6 +31,12 @@ let passed = 0;
 const HOUR_MS = 60 * 60 * 1000;
 
 // Test scaffolding: minimal mock deps with assertion hooks.
+interface AuditCall {
+  tool: string;
+  caller: string | null;
+  args: Record<string, unknown>;
+  outcome: AuditOutcome;
+}
 interface MockHooks {
   injections: Array<{ text: string; distillKey: string }>;
   callerBindings: Array<{ chatId: string; threadId: string; callerId: string }>;
@@ -41,6 +48,8 @@ interface MockHooks {
   l2RulesError?: Error;
   // Per-userId override to inject getProfile errors
   profileErrors?: Record<string, Error>;
+  // #176: captured audit-log calls
+  audits: AuditCall[];
 }
 
 function makeDeps(hooks: MockHooks, nowFn?: () => number): ProfileDistillDeps {
@@ -73,6 +82,9 @@ function makeDeps(hooks: MockHooks, nowFn?: () => number): ProfileDistillDeps {
       return hooks.l2Rules;
     },
     nowFn,
+    audit: async (tool, caller, args, outcome) => {
+      hooks.audits.push({ tool, caller, args, outcome });
+    },
   };
 }
 
@@ -84,6 +96,7 @@ function freshHooks(overrides: Partial<MockHooks> = {}): MockHooks {
     profiles: {},
     isPrivate: false,
     l2Rules: '',
+    audits: [],
     ...overrides,
   };
 }
@@ -321,6 +334,100 @@ function freshHooks(overrides: Partial<MockHooks> = {}): MockHooks {
   // The prompt's L2 section shows "(none set)" when empty.
   if (!hooks.injections[0].text.includes('(none set)')) {
     fail(`9: prompt should show '(none set)' for empty l2Rules after error fallback`);
+  }
+  passed++;
+}
+
+// ── Part D: audit-log (#176, v1.0.58) ──
+
+// 10. Audit fires on dispatch with shape {tool, caller, outcome='ok',
+//     args.reason='dispatched', chat_id, episode_count, distill_key}.
+{
+  const hooks = freshHooks({ episodeCounts: { 'oc_audit_disp': 10 } });
+  await triggerProfileDistillation(
+    'oc_audit_disp',
+    [{ role: 'user', senderId: 'ou_audit1' }],
+    makeDeps(hooks),
+    { cooldownMs: 24 * HOUR_MS, minEpisodes: 5, cooldownState: new Map() },
+  );
+  if (hooks.audits.length !== 1) fail(`10: expected 1 audit call on dispatch, got ${hooks.audits.length}`);
+  const a = hooks.audits[0];
+  if (a.tool !== 'profile-distill-dispatch') fail(`10: tool mismatch, got ${a.tool}`);
+  if (a.caller !== 'ou_audit1') fail(`10: caller should be userId, got ${a.caller}`);
+  if (a.outcome !== 'ok') fail(`10: outcome=ok on dispatch, got ${a.outcome}`);
+  if (a.args.reason !== 'dispatched') fail(`10: reason=dispatched, got ${a.args.reason}`);
+  if (a.args.chat_id !== 'oc_audit_disp') fail(`10: chat_id mismatch`);
+  if (a.args.episode_count !== 10) fail(`10: episode_count should be 10, got ${a.args.episode_count}`);
+  if (typeof a.args.distill_key !== 'string' || !String(a.args.distill_key).startsWith('distill-ou_audit1-')) {
+    fail(`10: distill_key should be distill-<user>-<ts>, got ${a.args.distill_key}`);
+  }
+  passed++;
+}
+
+// 11. Audit fires on cooldown skip with reason='cooldown' and outcome='ok'.
+{
+  const hooks = freshHooks({ episodeCounts: { 'oc_audit_cd': 10 } });
+  const cooldownState = new Map<string, number>();
+  let now = 1_000_000;
+  await triggerProfileDistillation(
+    'oc_audit_cd',
+    [{ role: 'user', senderId: 'ou_audit2' }],
+    makeDeps(hooks, () => now),
+    { cooldownMs: 24 * HOUR_MS, minEpisodes: 5, cooldownState },
+  );
+  // Re-fire inside cooldown window
+  now += 1 * HOUR_MS;
+  await triggerProfileDistillation(
+    'oc_audit_cd',
+    [{ role: 'user', senderId: 'ou_audit2' }],
+    makeDeps(hooks, () => now),
+    { cooldownMs: 24 * HOUR_MS, minEpisodes: 5, cooldownState },
+  );
+  // Two audits total: the first dispatch, then the cooldown skip.
+  if (hooks.audits.length !== 2) fail(`11: expected 2 audits (dispatch + cooldown), got ${hooks.audits.length}`);
+  const cd = hooks.audits[1];
+  if (cd.args.reason !== 'cooldown') fail(`11: 2nd audit reason should be 'cooldown', got ${cd.args.reason}`);
+  if (cd.outcome !== 'ok') fail(`11: cooldown skip is outcome=ok (gate worked), got ${cd.outcome}`);
+  if (typeof cd.args.remain_hours !== 'number') fail(`11: remain_hours should be numeric`);
+  passed++;
+}
+
+// 12. Audit fires on no-episodes skip with reason='no-episodes'.
+{
+  const hooks = freshHooks({ episodeCounts: { 'oc_audit_ne': 3 } });
+  await triggerProfileDistillation(
+    'oc_audit_ne',
+    [{ role: 'user', senderId: 'ou_audit3' }],
+    makeDeps(hooks),
+    { cooldownMs: 24 * HOUR_MS, minEpisodes: 5, cooldownState: new Map() },
+  );
+  if (hooks.audits.length !== 1) fail(`12: expected 1 audit on no-episodes skip, got ${hooks.audits.length}`);
+  const a = hooks.audits[0];
+  if (a.args.reason !== 'no-episodes') fail(`12: reason should be 'no-episodes', got ${a.args.reason}`);
+  if (a.outcome !== 'ok') fail(`12: no-episodes skip is outcome=ok, got ${a.outcome}`);
+  if (a.args.episode_count !== 3) fail(`12: episode_count should reflect actual count, got ${a.args.episode_count}`);
+  if (a.args.min_required !== 5) fail(`12: min_required should be 5, got ${a.args.min_required}`);
+  passed++;
+}
+
+// 13. Audit fires on per-user error with outcome='error'.
+{
+  const hooks = freshHooks({
+    episodeCounts: { 'oc_audit_err': 10 },
+    profileErrors: { 'ou_audit4': new Error('mock profile read failure') },
+  });
+  await triggerProfileDistillation(
+    'oc_audit_err',
+    [{ role: 'user', senderId: 'ou_audit4' }],
+    makeDeps(hooks),
+    { cooldownMs: 24 * HOUR_MS, minEpisodes: 5, cooldownState: new Map() },
+  );
+  if (hooks.audits.length !== 1) fail(`13: expected 1 audit on error, got ${hooks.audits.length}`);
+  const a = hooks.audits[0];
+  if (a.outcome !== 'error') fail(`13: outcome should be 'error', got ${a.outcome}`);
+  if (a.args.reason !== 'error') fail(`13: reason should be 'error', got ${a.args.reason}`);
+  if (typeof a.args.error_message !== 'string' || !String(a.args.error_message).includes('mock profile read failure')) {
+    fail(`13: error_message should include underlying error text, got ${a.args.error_message}`);
   }
   passed++;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ async function main() {
 
   // 2. Create MCP server
   const server = new McpServer(
-    { name: 'claude-lark-plugin', version: '1.0.57' },
+    { name: 'claude-lark-plugin', version: '1.0.58' },
     {
       capabilities: {
         logging: {},

--- a/src/memory/distiller.ts
+++ b/src/memory/distiller.ts
@@ -1,6 +1,7 @@
 import type { BufferedMessage } from './buffer.js';
 import { flushPrompt, profileDistillationPrompt, wrapEnrichmentSection } from '../prompts.js';
 import { applyL1, loadL2Rules } from '../privacy-rules.js';
+import { audit as defaultAudit } from '../audit-log.js';
 
 /**
  * Distillation Stage 1: Buffer → Episode.
@@ -164,6 +165,21 @@ export interface ProfileDistillDeps {
   loadL2Rules?: () => Promise<string>;
   /** Optional override for the "now" timestamp — used by tests. */
   nowFn?: () => number;
+  /**
+   * Optional override for the audit-log writer. Defaults to the global
+   * `audit()` from `src/audit-log.ts`. Injectable so unit tests can
+   * assert that Stage 2 dispatches (and skip outcomes) are recorded
+   * without touching the operator's real `~/.claude/channels/lark/audit.log`.
+   *
+   * #176 fix (v1.0.58): pre-fix Stage 2 only logged to stderr — operators
+   * who enabled `LARK_PROFILE_DISTILL_ENABLED=true` had no audit-log
+   * trail for the autonomous Claude turns. Every dispatch, cooldown,
+   * and no-episodes skip now writes one line (tool='profile-distill-
+   * dispatch', outcome='ok' regardless of subroute — `reason` field
+   * distinguishes them in args). Per-user `error` outcomes write with
+   * outcome='error'. Pattern mirrors `src/tools.ts` boundary writes.
+   */
+  audit?: typeof defaultAudit;
 }
 
 export interface ProfileDistillOpts {
@@ -196,6 +212,7 @@ export async function triggerProfileDistillation(
   const now = (deps.nowFn ?? Date.now)();
   const chatType: 'p2p' | 'group' = deps.isPrivateChat(chatId) ? 'p2p' : 'group';
   const maxEpisodes = opts.maxEpisodes ?? 10;
+  const audit = deps.audit ?? defaultAudit;
 
   // L2 rules: global per-operator, shared across users in this pass.
   let l2Rules = '';
@@ -213,6 +230,14 @@ export async function triggerProfileDistillation(
         const remainHrs = ((opts.cooldownMs - (now - lastRun)) / 3_600_000).toFixed(1);
         console.error(`[distill-stage2] user ${userId} in cooldown (${remainHrs}h remaining); skipping`);
         outcomes[userId] = 'cooldown';
+        // #176: skip is still operator-visible activity. Use outcome='ok'
+        // because the gate functioned correctly (not an error); the
+        // `reason` arg distinguishes it from a real dispatch.
+        void audit('profile-distill-dispatch', userId, {
+          chat_id: chatId,
+          reason: 'cooldown',
+          remain_hours: Number(remainHrs),
+        }, 'ok');
         continue;
       }
       // 2. Min-episodes gate
@@ -220,6 +245,12 @@ export async function triggerProfileDistillation(
       if (episodes.length < opts.minEpisodes) {
         console.error(`[distill-stage2] user ${userId} chat ${chatId}: only ${episodes.length}/${opts.minEpisodes} episodes; skipping`);
         outcomes[userId] = 'no-episodes';
+        void audit('profile-distill-dispatch', userId, {
+          chat_id: chatId,
+          reason: 'no-episodes',
+          episode_count: episodes.length,
+          min_required: opts.minEpisodes,
+        }, 'ok');
         continue;
       }
       // 3. Gather inputs
@@ -257,9 +288,24 @@ export async function triggerProfileDistillation(
       //    failed Claude turns won't retry-storm into the next flush).
       opts.cooldownState.set(userId, now);
       outcomes[userId] = 'dispatched';
+      // #176: real dispatch audit-log entry. Operators grep
+      // `tool=profile-distill-dispatch outcome=ok` and exclude
+      // reason!=undefined rows to count actual Claude turns spent.
+      void audit('profile-distill-dispatch', userId, {
+        chat_id: chatId,
+        reason: 'dispatched',
+        episode_count: recentEpisodes.length,
+        distill_key: distillKey,
+        chat_type: chatType,
+      }, 'ok');
     } catch (err: any) {
       console.error(`[distill-stage2] user ${userId} failed: ${err?.message ?? err}`);
       outcomes[userId] = 'error';
+      void audit('profile-distill-dispatch', userId, {
+        chat_id: chatId,
+        reason: 'error',
+        error_message: String(err?.message ?? err).slice(0, 120),
+      }, 'error');
     }
   }
 


### PR DESCRIPTION
## Summary
- Add `audit()` calls to every outcome path inside `triggerProfileDistillation` (dispatched / cooldown / no-episodes / error). Pre-fix the autonomous Claude turns from #113 (PR #175) only logged to stderr — operators enabling `LARK_PROFILE_DISTILL_ENABLED=true` had no boundary in `~/.claude/channels/lark/audit.log` (every other sensitive-tool boundary in the plugin already writes there).
- `ProfileDistillDeps` gains an optional `audit?: typeof audit` for test injection (defaults to the global writer). All call sites use `void audit(...)` — best-effort fire-and-forget, never blocks dispatch.
- 4 new smoke tests (10 → 14 PASS) — one per outcome path.

## Per-outcome audit shape

| outcome | `outcome` | `args.reason` | extra args |
|---|---|---|---|
| dispatched | `ok` | `dispatched` | `chat_id`, `episode_count`, `distill_key`, `chat_type` |
| cooldown skip | `ok` | `cooldown` | `chat_id`, `remain_hours` |
| no-episodes skip | `ok` | `no-episodes` | `chat_id`, `episode_count`, `min_required` |
| per-user error | `error` | `error` | `chat_id`, `error_message` (truncated) |

Operators count actual Claude turns with `grep 'profile-distill-dispatch.*reason\":\"dispatched\"' audit.log`.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 91/91 hook tests + 14/14 Stage 2 smoke PASS
- [ ] Squash-merge, tag v1.0.58, GH release, marketplace clone sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)