### PR TITLE
feat(retry): extract PERMANENT_FEISHU_CODES set, add 99991668 (closes #202)

### DIFF
--- a/src/feishu-retry.ts
+++ b/src/feishu-retry.ts
@@ -45,6 +45,25 @@ export const PERMANENT_TARGET_CODES = new Set<number>([
   190005,
 ]);
 
+/**
+ * Feishu API error codes that are PERMANENT-by-classification: identical
+ * request → identical rejection, so a retry can only waste the budget
+ * (~7s hot-path wall-clock for 3 attempts). Single source of truth for
+ * `isRetryableError`'s fail-fast check; mirrors the equivalent set in
+ * `IS908/codex-lark-plugin` so the two channel plugins agree on what
+ * "non-retryable" means (#202).
+ *
+ * - 230001   — parameter error (request shape rejected; retry can't fix)
+ * - 99991668 — invalid file_key / resource not found (file gone or never
+ *              existed; download_attachment etc. burned 3 retries pre-fix)
+ * - 99991672 — permission denied (auth/scope, not transient)
+ */
+const PERMANENT_FEISHU_CODES = new Set<number>([
+  230001,
+  99991668,
+  99991672,
+]);
+
 /** Extract a numeric Feishu API code from a thrown error, or null. */
 export function getFeishuApiCode(err: any): number | null {
   const code = err?.response?.data?.code ?? err?.data?.code;
@@ -63,7 +82,8 @@ export function getFeishuApiMsg(err: any): string {
  *
  *   - Network errors (ENOTFOUND etc.) → retry
  *   - HTTP 429/5xx → retry
- *   - Feishu 99991672 (perm denied) / 230001 (param error) → NO retry
+ *   - Feishu PERMANENT_FEISHU_CODES (230001 param / 99991668 invalid
+ *     file_key / 99991672 perm denied) → NO retry (#202)
  *   - Feishu 99990000–99999999 generic 9999-class → retry (covers
  *     rate-limit 99991663 / 99991400 / etc.)
  *   - Message containing 'timeout' / 'enotfound' / 'econnreset' → retry
@@ -85,8 +105,8 @@ export function isRetryableError(err: any): boolean {
   // it differently from a numeric typecheck — tighten regardless.)
   const apiCode = err?.response?.data?.code ?? err?.data?.code;
   if (apiCode != null) {
-    // Known non-retryable Feishu codes
-    if (apiCode === 99991672 || apiCode === 230001) return false;
+    // Known non-retryable Feishu codes — see PERMANENT_FEISHU_CODES doc (#202)
+    if (PERMANENT_FEISHU_CODES.has(apiCode)) return false;
     // Other Feishu codes starting with 9999 are usually transient
     if (apiCode >= 99990000 && apiCode < 100000000) return true;
   }


### PR DESCRIPTION
## Summary
- Closes #202. Lifts the inline `apiCode === 99991672 || apiCode === 230001` check in `isRetryableError` into a documented `PERMANENT_FEISHU_CODES` set, and adds **99991668** (invalid file_key / resource not found) — gap relative to the sister `IS908/codex-lark-plugin` repo's equivalent set.
- Behavior change is narrow: pre-fix, a 99991668 from a doomed file/download path burned the full 3-attempt hot-path budget (500ms + 1500ms + 5000ms ≈ 7s of wasted real-time wait) before surfacing. Now it fails fast on the first response. 230001 and 99991672 are behavior-identical, just refactored into the named set.
- `PERMANENT_TARGET_CODES` (already factored out for #106's target-eviction policy) is intentionally left untouched — different semantic purpose. The two sets overlap on 99991672 by design.

## Justification per code (set membership)
- **230001** — parameter error. Identical request shape → identical rejection.
- **99991668** — invalid file_key / resource not found. File gone or never visible to bot; retry repeats the same lookup against the same missing row. **New.**
- **99991672** — permission denied. Auth/scope, not transient.

## Test plan
- [x] `npm run typecheck` clean
- [ ] No existing tests touch `feishu-retry.ts` classification directly; per CLAUDE.md "NO new tests unless the file already has tests" the change rides on typecheck + downstream smoke. Operators on the next release should watch `debug.log` for `[feishu-retry]` lines disappearing on 99991668 (previously 3 retry breadcrumbs per failure, now 0).

## Reference
Codex equivalent: https://github.com/IS908/codex-lark-plugin/blob/main/src/feishu-retry.ts — `PERMANENT_FEISHU_CODES` set with the same three codes, same fail-fast intent.